### PR TITLE
feat(activex): support advanced session settings

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -466,7 +466,7 @@ subtype, and functional-key count, secured `StartProgram`/`WorkDir`, both public
 `StartProgram` and `WorkDir` retain their caller-owned BSTR values and configure IronRDP's next
 Client Info PDU alternate shell and working directory. The keyboard fields configure the next GCC
 Client Core Data block.
-`LoadBalanceInfo` accepts an ASCII routing token of at most 256 bytes and carries it in the next X.224 Connection Request.
+`LoadBalanceInfo` accepts an ASCII routing token of at most 238 bytes and carries it in the next X.224 Connection Request.
 `ConnectToServerConsole` and `ConnectToAdministerServer` are aliases that request session ID zero through GCC Client Cluster Data.
 `AudioQualityMode` values `0`, `1`, and `2` select dynamic, medium, and high RDPSND quality.
 Audio mode `0` enables the Windows-native RDPSND playback backend (CPAL) and

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -280,12 +280,12 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | --- | --- |
 | Legacy RDP 6.1 through 11 host selection | The six published `MsRdpClient*NotSafeForScripting` class identifiers are accepted by `DllGetClassObject` and preserve their requested `IPersist` class identity. They are explicit backend aliases, not global COM registrations. |
 | WinForms `AxHost` lifecycle | Windowed OLE activation, focus, sizing, the inherited `IMsRdpClient` through `IMsRdpClient10` raw interfaces, and the RDM virtual channels `RDMJump`, `RDMLog`, and `RDMCmd` are supported. |
-| Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio, clipboard, CredSSP, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
+| Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio and quality policy, clipboard, CredSSP, administrative session, load-balance routing token, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, writable confirm-close, and worker-backed warning and auto-reconnect events are delivered on the creating apartment. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 | Smartcard redirection | `IMsRdpClientAdvancedSettings::RedirectSmartCards` enables WinSCard RDPDR smartcard redirection (smartcard-only sessions are valid without redirected drives). |
 
-The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling, authentication policy, device/printer/port redirection, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
+The audit also identified settings that have no IronRDP ActiveX backend: input throttling, keepalive and idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, security-layer negotiation, and Microsoft workspace extensions.
 Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
@@ -459,12 +459,17 @@ has already been released. The currently mapped members are `SmartSizing`, `Enab
 `KeyboardHookMode`, keyboard type,
 subtype, and functional-key count, secured `StartProgram`/`WorkDir`, both public
 `AudioRedirectionMode` slots, both public `AudioCaptureRedirectionMode` slots,
+`AudioQualityMode`, `LoadBalanceInfo`, `ConnectToServerConsole`/`ConnectToAdministerServer`,
 `GrabFocusOnConnect`, `Compress`, `RDPPort`,
 `AuthenticationLevel`, and `PublicMode`,
 `RedirectClipboard`, `PerformanceFlags`, and RD Gateway transport selection.
 `StartProgram` and `WorkDir` retain their caller-owned BSTR values and configure IronRDP's next
 Client Info PDU alternate shell and working directory. The keyboard fields configure the next GCC
-Client Core Data block. Audio mode `0` enables the Windows-native RDPSND playback backend (CPAL) and
+Client Core Data block.
+`LoadBalanceInfo` accepts an ASCII routing token of at most 256 bytes and carries it in the next X.224 Connection Request.
+`ConnectToServerConsole` and `ConnectToAdministerServer` are aliases that request session ID zero through GCC Client Cluster Data.
+`AudioQualityMode` values `0`, `1`, and `2` select dynamic, medium, and high RDPSND quality.
+Audio mode `0` enables the Windows-native RDPSND playback backend (CPAL) and
 advertises the `rdpsnd` static channel for server-to-client wave data; modes
 `1` (play on server) and `2` (disabled) both clear local playback and set
 `INFO_NOAUDIOPLAYBACK` (a no-op RDPSND channel may still attach when RDPDR is

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -285,8 +285,9 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 | Smartcard redirection | `IMsRdpClientAdvancedSettings::RedirectSmartCards` enables WinSCard RDPDR smartcard redirection (smartcard-only sessions are valid without redirected drives). |
 
-The audit also identified settings that have no IronRDP ActiveX backend: input throttling, keepalive and idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, security-layer negotiation, and Microsoft workspace extensions.
-Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
+The audit also identified unsupported `AdvancedSettings` members: plug-in DLL loading, input throttling, keepalive and idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, and security-layer negotiation.
+Their audited vtable slots use published ABI signatures, initialize getter outputs, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
+`IMsRdpClientNonScriptable8::StartWorkspaceExtension` independently returns `E_NOTIMPL` because IronRDP does not implement Microsoft workspace extensions.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
 published `IMsTscAxEvents` IID `{336D5562-EFA8-482E-8CB3-C5C0FC7A7DB6}`. Lifecycle events are delivered
@@ -466,9 +467,11 @@ subtype, and functional-key count, secured `StartProgram`/`WorkDir`, both public
 `StartProgram` and `WorkDir` retain their caller-owned BSTR values and configure IronRDP's next
 Client Info PDU alternate shell and working directory. The keyboard fields configure the next GCC
 Client Core Data block.
-`LoadBalanceInfo` accepts an ASCII routing token of at most 238 bytes and carries it in the next X.224 Connection Request.
+`LoadBalanceInfo` carries a nonempty routing token in the next X.224 Connection Request.
+The token must contain 1–238 printable ASCII bytes, excluding an optional trailing CRLF; an empty value clears it.
 `ConnectToServerConsole` and `ConnectToAdministerServer` are aliases that request session ID zero through GCC Client Cluster Data.
-`AudioQualityMode` values `0`, `1`, and `2` select dynamic, medium, and high RDPSND quality.
+`AudioQualityMode` values `0`, `1`, and `2` select dynamic, medium, and high RDPSND quality; `0` is the default.
+The control sends this policy only when the server advertises RDPSND version 6 or newer.
 Audio mode `0` enables the Windows-native RDPSND playback backend (CPAL) and
 advertises the `rdpsnd` static channel for server-to-client wave data; modes
 `1` (play on server) and `2` (disabled) both clear local playback and set

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2102,11 +2102,13 @@ const MAX_LOAD_BALANCE_INFO_BYTES: usize = ironrdp_pdu::nego::MAX_ROUTING_TOKEN_
 
 unsafe extern "system" fn advanced_put_load_balance_info(this: *mut c_void, value: Bstr) -> HRESULT {
     let value = match string_from_bstr(value) {
-        Ok(value) if value.is_ascii() => value,
-        Ok(_) | Err(_) => return E_INVALIDARG,
+        Ok(value) => value,
+        Err(_) => return E_INVALIDARG,
     };
     let normalized = value.strip_suffix("\r\n").unwrap_or(&value);
-    if normalized.len() > MAX_LOAD_BALANCE_INFO_BYTES || normalized.contains(['\r', '\n']) {
+    if normalized.len() > MAX_LOAD_BALANCE_INFO_BYTES
+        || !normalized.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte))
+    {
         return E_INVALIDARG;
     }
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
@@ -2114,7 +2116,7 @@ unsafe extern "system" fn advanced_put_load_balance_info(this: *mut c_void, valu
     if settings.connection_settings_sealed {
         return E_FAIL;
     }
-    settings.load_balance_info = value;
+    settings.load_balance_info = if normalized.is_empty() { String::new() } else { value };
     S_OK
 }
 
@@ -16493,10 +16495,35 @@ mod tests {
             unsafe { advanced_put_load_balance_info(this, invalid_load_balance_info.as_ptr()) },
             E_INVALIDARG
         );
+        let control_character_load_balance_info = BSTR::from("tsv://invalid\t");
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, control_character_load_balance_info.as_ptr()) },
+            E_INVALIDARG
+        );
         let terminated_load_balance_info = BSTR::from("tsv://terminated\r\n");
         assert_eq!(
             unsafe { advanced_put_load_balance_info(this, terminated_load_balance_info.as_ptr()) },
             S_OK
+        );
+        let mut returned_terminated_load_balance_info = ptr::null();
+        assert_eq!(
+            unsafe { advanced_get_load_balance_info(this, &mut returned_terminated_load_balance_info) },
+            S_OK
+        );
+        let returned_terminated_load_balance_info = unsafe { BSTR::from_raw(returned_terminated_load_balance_info) };
+        assert_eq!(
+            String::try_from(&returned_terminated_load_balance_info).expect("valid terminated load-balance BSTR"),
+            "tsv://terminated\r\n"
+        );
+        let maximum_load_balance_info = BSTR::from("x".repeat(MAX_LOAD_BALANCE_INFO_BYTES));
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, maximum_load_balance_info.as_ptr()) },
+            S_OK
+        );
+        let oversized_load_balance_info = BSTR::from("x".repeat(MAX_LOAD_BALANCE_INFO_BYTES + 1));
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, oversized_load_balance_info.as_ptr()) },
+            E_INVALIDARG
         );
 
         let mut administrative_session = VARIANT_TRUE.0;
@@ -16530,7 +16557,10 @@ mod tests {
         assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 3) }, E_INVALIDARG);
 
         let snapshot = active_x_property_snapshot(&Settings::default(), &settings.borrow());
-        assert_eq!(snapshot.get::<&str>("loadbalanceinfo"), Some("tsv://terminated"));
+        assert_eq!(
+            snapshot.get::<&str>("loadbalanceinfo").map(str::len),
+            Some(MAX_LOAD_BALANCE_INFO_BYTES)
+        );
         assert_eq!(snapshot.get::<bool>("administrative session"), Some(true));
         assert_eq!(snapshot.get::<u32>("audioqualitymode"), Some(2));
 

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -12,7 +12,9 @@ use std::sync::{Arc, Condvar, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
 
 use ironrdp_cfg::{AudioMode, GatewayCredentialsSource, GatewayUsageMethod};
-use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, RDCleanPathConfig, Transport, TransportKind};
+use ironrdp_client::config::{
+    AudioQualityMode, ClipboardType, ConfigBuilder, Destination, RDCleanPathConfig, Transport, TransportKind,
+};
 use ironrdp_client::rail::RailInputEvent;
 use ironrdp_client::rdp::{
     AutoReconnectDecision, CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent,
@@ -1208,6 +1210,9 @@ struct CompatibilitySettings {
     grab_focus_on_connect: bool,
     enable_credssp: Option<bool>,
     compression: Option<bool>,
+    load_balance_info: String,
+    administrative_session: bool,
+    audio_quality_mode: AudioQualityMode,
     rdp_port: Option<u16>,
     enable_mouse: bool,
     enable_windows_key: bool,
@@ -1284,6 +1289,9 @@ impl Default for CompatibilitySettings {
             grab_focus_on_connect: false,
             enable_credssp: None,
             compression: None,
+            load_balance_info: String::new(),
+            administrative_session: false,
+            audio_quality_mode: AudioQualityMode::Dynamic,
             rdp_port: None,
             enable_mouse: true,
             enable_windows_key: true,
@@ -2066,43 +2074,110 @@ advanced_put_not_implemented!(
     (7, advanced_put_plugin_dlls, Bstr),
     (69, advanced_put_min_input_send_interval, i32),
     (75, advanced_put_keep_alive_interval, i32),
-    (91, advanced_put_connect_to_server_console, i16),
     (93, advanced_put_bitmap_persistence, i32),
     (95, advanced_put_minutes_to_idle_timeout, i32),
-    (112, advanced_put_load_balance_info, Bstr),
     (116, advanced_put_redirect_printers, i16),
     (118, advanced_put_redirect_ports, i16),
     (150, advanced_put_redirect_devices, i16),
     (161, advanced_put_pcb, Bstr),
-    (169, advanced_put_connect_to_administer_server, i16),
     (173, advanced_put_video_playback_mode, u32),
     (175, advanced_put_enable_super_pan, i16),
     (179, advanced_put_negotiate_security_layer, i16),
-    (181, advanced_put_audio_quality_mode, u32),
 );
 
 advanced_get_not_implemented!(
     (70, advanced_get_min_input_send_interval, i32),
     (76, advanced_get_keep_alive_interval, i32),
-    (92, advanced_get_connect_to_server_console, i16),
     (94, advanced_get_bitmap_persistence, i32),
     (96, advanced_get_minutes_to_idle_timeout, i32),
     (117, advanced_get_redirect_printers, i16),
     (119, advanced_get_redirect_ports, i16),
     (151, advanced_get_redirect_devices, i16),
-    (170, advanced_get_connect_to_administer_server, i16),
     (174, advanced_get_video_playback_mode, u32),
     (176, advanced_get_enable_super_pan, i16),
     (180, advanced_get_negotiate_security_layer, i16),
-    (182, advanced_get_audio_quality_mode, u32),
 );
 
-unsafe extern "system" fn advanced_get_load_balance_info(_this: *mut c_void, value: BstrOut) -> HRESULT {
-    if let Err(error) = write_out(value, ptr::null()) {
-        return error.code();
+const MAX_LOAD_BALANCE_INFO_BYTES: usize = 256;
+
+unsafe extern "system" fn advanced_put_load_balance_info(this: *mut c_void, value: Bstr) -> HRESULT {
+    let value = match string_from_bstr(value) {
+        Ok(value) if value.len() <= MAX_LOAD_BALANCE_INFO_BYTES && value.is_ascii() => value,
+        Ok(_) | Err(_) => return E_INVALIDARG,
+    };
+    let value = value.strip_suffix("\r\n").unwrap_or(&value);
+    if value.contains(['\r', '\n']) {
+        return E_INVALIDARG;
     }
-    trace_host_call("E_NOTIMPL:AdvancedSettings::slot_113");
-    E_NOTIMPL
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.load_balance_info = value.to_owned();
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_load_balance_info(this: *mut c_void, value: BstrOut) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_bstr(value, &object.settings.borrow().load_balance_info).map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_connect_to_server_console(this: *mut c_void, value: i16) -> HRESULT {
+    unsafe { advanced_put_connect_to_administer_server(this, value) }
+}
+
+unsafe extern "system" fn advanced_get_connect_to_server_console(this: *mut c_void, value: *mut i16) -> HRESULT {
+    unsafe { advanced_get_connect_to_administer_server(this, value) }
+}
+
+unsafe extern "system" fn advanced_put_connect_to_administer_server(this: *mut c_void, value: i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.administrative_session = value != VARIANT_FALSE.0;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_connect_to_administer_server(this: *mut c_void, value: *mut i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(
+        value,
+        if object.settings.borrow().administrative_session {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        },
+    )
+    .map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_audio_quality_mode(this: *mut c_void, value: u32) -> HRESULT {
+    let value = match value {
+        0 => AudioQualityMode::Dynamic,
+        1 => AudioQualityMode::Medium,
+        2 => AudioQualityMode::High,
+        _ => return E_INVALIDARG,
+    };
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.audio_quality_mode = value;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_audio_quality_mode(this: *mut c_void, out: *mut u32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let value = match object.settings.borrow().audio_quality_mode {
+        AudioQualityMode::Dynamic => 0,
+        AudioQualityMode::Medium => 1,
+        AudioQualityMode::High => 2,
+    };
+    write_out(out, value).map_or_else(|error| error.code(), |_| S_OK)
 }
 
 unsafe extern "system" fn advanced_get_authentication_type(_this: *mut c_void, value: *mut u32) -> HRESULT {
@@ -6215,6 +6290,18 @@ fn active_x_property_snapshot(settings: &Settings, compatibility: &Compatibility
     if let Some(value) = compatibility.desktop_scale_factor {
         properties.insert("desktopscalefactor", value);
     }
+    if !compatibility.load_balance_info.is_empty() {
+        properties.insert("loadbalanceinfo", compatibility.load_balance_info.clone());
+    }
+    properties.insert("administrative session", compatibility.administrative_session);
+    properties.insert(
+        "audioqualitymode",
+        match compatibility.audio_quality_mode {
+            AudioQualityMode::Dynamic => 0,
+            AudioQualityMode::Medium => 1,
+            AudioQualityMode::High => 2,
+        },
+    );
     properties.insert("redirectclipboard", compatibility.redirect_clipboard);
     properties.insert("redirectwebauthn", compatibility.redirect_webauthn);
     properties.insert("ironrdp_smartcard", compatibility.redirect_smart_cards);
@@ -8713,6 +8800,13 @@ impl Control {
             } else {
                 VARIANT_FALSE.0
             };
+            compatibility.load_balance_info = config
+                .properties()
+                .get::<&str>("loadbalanceinfo")
+                .unwrap_or_default()
+                .to_owned();
+            compatibility.administrative_session = config.administrative_session();
+            compatibility.audio_quality_mode = config.audio_quality_mode();
             compatibility.secured_start_program = connector.alternate_shell.clone();
             compatibility.secured_work_dir = connector.work_dir.clone();
             compatibility.authentication_level_set =
@@ -9019,6 +9113,9 @@ impl Control {
         let autologon = compatibility.autologon;
         let desktop_scale_factor = compatibility.desktop_scale_factor;
         let compression_level = compatibility.compression_level;
+        let load_balance_info = compatibility.load_balance_info.clone();
+        let administrative_session = compatibility.administrative_session;
+        let audio_quality_mode = compatibility.audio_quality_mode;
         let client_build = compatibility.client_build;
         let client_dir = compatibility.client_dir.clone();
         let ime_file_name = compatibility.ime_file_name.clone();
@@ -9158,6 +9255,9 @@ impl Control {
             .with_connection_type(connection_type)
             .with_audio_mode(audio_redirection_mode)
             .with_audio_capture(audio_capture_enabled)
+            .with_audio_quality_mode(audio_quality_mode)
+            .with_load_balance_info(load_balance_info)
+            .with_administrative_session(administrative_session)
             .with_certificate_validation(certificate_validation)
             // The GDI presenter has no hardware-cursor overlay, so cursor updates must be
             // composited into the decoded framebuffer before it receives image events.
@@ -16283,6 +16383,16 @@ mod tests {
             advanced_put_clear_text_password as *const () as usize
         );
         assert_eq!(
+            vtable.slots[91],
+            advanced_put_connect_to_server_console as *const () as usize
+        );
+        assert_eq!(vtable.slots[112], advanced_put_load_balance_info as *const () as usize);
+        assert_eq!(
+            vtable.slots[169],
+            advanced_put_connect_to_administer_server as *const () as usize
+        );
+        assert_eq!(vtable.slots[181], advanced_put_audio_quality_mode as *const () as usize);
+        assert_eq!(
             vtable.slots[168],
             advanced_get_authentication_type as *const () as usize
         );
@@ -16331,12 +16441,12 @@ mod tests {
     }
 
     #[test]
-    fn rdm_unmapped_advanced_settings_slots_use_typed_failures() {
+    fn advanced_settings_support_routing_admin_and_audio_quality_without_masking_stubs() {
         let settings = Rc::new(RefCell::new(CompatibilitySettings::default()));
         let mut object = CompatibilitySettingsObject {
             vtable: advanced_vtable(),
             references: AtomicU32::new(1),
-            settings,
+            settings: Rc::clone(&settings),
             native_mstsc_credential_bridge: None,
             server_object: false,
         };
@@ -16366,14 +16476,63 @@ mod tests {
         let load_balance_info = BSTR::from("tsv://example");
         assert_eq!(
             unsafe { advanced_put_load_balance_info(this, load_balance_info.as_ptr()) },
-            E_NOTIMPL
+            S_OK
         );
-        let mut load_balance_info = ptr::dangling::<u16>();
+        let mut load_balance_info = ptr::null();
         assert_eq!(
             unsafe { advanced_get_load_balance_info(this, &mut load_balance_info) },
-            E_NOTIMPL
+            S_OK
         );
-        assert!(load_balance_info.is_null());
+        let load_balance_info = unsafe { BSTR::from_raw(load_balance_info) };
+        assert_eq!(
+            String::try_from(&load_balance_info).expect("valid load-balance BSTR"),
+            "tsv://example"
+        );
+        let invalid_load_balance_info = BSTR::from("line1\r\nline2");
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, invalid_load_balance_info.as_ptr()) },
+            E_INVALIDARG
+        );
+        let terminated_load_balance_info = BSTR::from("tsv://terminated\r\n");
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, terminated_load_balance_info.as_ptr()) },
+            S_OK
+        );
+
+        let mut administrative_session = VARIANT_TRUE.0;
+        assert_eq!(
+            unsafe { advanced_get_connect_to_server_console(this, &mut administrative_session) },
+            S_OK
+        );
+        assert_eq!(administrative_session, VARIANT_FALSE.0);
+        assert_eq!(
+            unsafe { advanced_put_connect_to_server_console(this, VARIANT_TRUE.0) },
+            S_OK
+        );
+        assert_eq!(
+            unsafe { advanced_get_connect_to_administer_server(this, &mut administrative_session) },
+            S_OK
+        );
+        assert_eq!(administrative_session, VARIANT_TRUE.0);
+
+        let mut audio_quality_mode = u32::MAX;
+        assert_eq!(
+            unsafe { advanced_get_audio_quality_mode(this, &mut audio_quality_mode) },
+            S_OK
+        );
+        assert_eq!(audio_quality_mode, 0);
+        assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 2) }, S_OK);
+        assert_eq!(
+            unsafe { advanced_get_audio_quality_mode(this, &mut audio_quality_mode) },
+            S_OK
+        );
+        assert_eq!(audio_quality_mode, 2);
+        assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 3) }, E_INVALIDARG);
+
+        let snapshot = active_x_property_snapshot(&Settings::default(), &settings.borrow());
+        assert_eq!(snapshot.get::<&str>("loadbalanceinfo"), Some("tsv://terminated"));
+        assert_eq!(snapshot.get::<bool>("administrative session"), Some(true));
+        assert_eq!(snapshot.get::<u32>("audioqualitymode"), Some(2));
 
         let mut authentication_level = u32::MAX;
         assert_eq!(
@@ -16395,6 +16554,17 @@ mod tests {
             E_NOTIMPL
         );
         assert_eq!(keep_alive_interval, 0);
+
+        object.settings.borrow_mut().connection_settings_sealed = true;
+        assert_eq!(
+            unsafe { advanced_put_connect_to_administer_server(this, VARIANT_FALSE.0) },
+            E_FAIL
+        );
+        assert_eq!(
+            unsafe { advanced_put_load_balance_info(this, load_balance_info.as_ptr()) },
+            E_FAIL
+        );
+        assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 1) }, E_FAIL);
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2098,15 +2098,15 @@ advanced_get_not_implemented!(
     (180, advanced_get_negotiate_security_layer, i16),
 );
 
-const MAX_LOAD_BALANCE_INFO_BYTES: usize = 256;
+const MAX_LOAD_BALANCE_INFO_BYTES: usize = ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH;
 
 unsafe extern "system" fn advanced_put_load_balance_info(this: *mut c_void, value: Bstr) -> HRESULT {
     let value = match string_from_bstr(value) {
-        Ok(value) if value.len() <= MAX_LOAD_BALANCE_INFO_BYTES && value.is_ascii() => value,
+        Ok(value) if value.is_ascii() => value,
         Ok(_) | Err(_) => return E_INVALIDARG,
     };
-    let value = value.strip_suffix("\r\n").unwrap_or(&value);
-    if value.contains(['\r', '\n']) {
+    let normalized = value.strip_suffix("\r\n").unwrap_or(&value);
+    if normalized.len() > MAX_LOAD_BALANCE_INFO_BYTES || normalized.contains(['\r', '\n']) {
         return E_INVALIDARG;
     }
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
@@ -2114,7 +2114,7 @@ unsafe extern "system" fn advanced_put_load_balance_info(this: *mut c_void, valu
     if settings.connection_settings_sealed {
         return E_FAIL;
     }
-    settings.load_balance_info = value.to_owned();
+    settings.load_balance_info = value;
     S_OK
 }
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -103,6 +103,7 @@ pub struct Config {
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
     pub(crate) administrative_session: bool,
+    pub(crate) load_balance_info: Option<String>,
     #[cfg(any(feature = "sound", feature = "rdpdr"))]
     pub(crate) audio_quality_mode: AudioQualityMode,
     pub(crate) rail_client_status_flags: Option<u32>,
@@ -193,6 +194,11 @@ impl Config {
         self.administrative_session
     }
 
+    /// Opaque load-balancing data sent in the initial X.224 Connection Request.
+    pub fn load_balance_info(&self) -> Option<&str> {
+        self.load_balance_info.as_deref()
+    }
+
     /// RDPSND quality policy sent during audio format negotiation.
     #[cfg(any(feature = "sound", feature = "rdpdr"))]
     pub fn audio_quality_mode(&self) -> AudioQualityMode {
@@ -243,6 +249,7 @@ impl fmt::Debug for Config {
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
         s.field("administrative_session", &self.administrative_session);
+        s.field("load_balance_info", &self.load_balance_info);
         #[cfg(any(feature = "sound", feature = "rdpdr"))]
         s.field("audio_quality_mode", &self.audio_quality_mode);
         s.field("rail_client_status_flags", &self.rail_client_status_flags);
@@ -712,7 +719,7 @@ pub struct ConfigBuilder {
     enable_audio_capture: Option<bool>,
     compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
     compression_enabled: Option<bool>,
-    request_data: Option<ironrdp_pdu::nego::NegoRequestData>,
+    load_balance_info: Option<String>,
     administrative_session: bool,
     alternate_shell: Option<String>,
     work_dir: Option<String>,
@@ -964,13 +971,11 @@ impl ConfigBuilder {
         let value = value.into();
         let normalized = value.strip_suffix("\r\n").unwrap_or(&value);
         if normalized.is_empty() {
-            self.request_data = None;
+            self.load_balance_info = None;
             self.properties.remove("loadbalanceinfo");
         } else {
             self.properties.insert("loadbalanceinfo", value.clone());
-            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
-                normalized.to_owned(),
-            ));
+            self.load_balance_info = Some(normalized.to_owned());
         }
         self
     }
@@ -1527,11 +1532,14 @@ impl ConfigBuilder {
         use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
         use ironrdp_pdu::rdp::client_info::TimezoneInfo;
 
-        if let Some(ironrdp_pdu::nego::NegoRequestData::OpaqueRoutingToken(token)) = &self.request_data {
+        if let Some(load_balance_info) = &self.load_balance_info {
             anyhow::ensure!(
-                token.0.len() <= ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH
-                    && !token.0.is_empty()
-                    && token.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte)),
+                load_balance_info.len() <= ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH
+                    && !load_balance_info.is_empty()
+                    && load_balance_info
+                        .as_bytes()
+                        .iter()
+                        .all(|byte| (0x20..=0x7E).contains(byte)),
                 "invalid load-balance routing token"
             );
         }
@@ -1771,7 +1779,7 @@ impl ConfigBuilder {
             autologon: self.autologon.unwrap_or(false),
             enable_audio_playback: self.enable_audio_playback.unwrap_or(true),
             enable_audio_capture: self.enable_audio_capture.unwrap_or(false),
-            request_data: self.request_data,
+            request_data: None,
             pointer_software_rendering: self.pointer_software_rendering.unwrap_or(false),
             multitransport_flags: None,
             compression_type,
@@ -1816,6 +1824,7 @@ impl ConfigBuilder {
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,
             administrative_session: self.administrative_session,
+            load_balance_info: self.load_balance_info,
             #[cfg(any(feature = "sound", feature = "rdpdr"))]
             audio_quality_mode: self.audio_quality_mode.unwrap_or_default(),
             rail_client_status_flags: self.rail_client_status_flags,
@@ -1888,12 +1897,10 @@ impl ConfigBuilder {
         }
         if let Some(load_balance_info) = ps.get::<&str>("loadbalanceinfo") {
             let normalized = load_balance_info.strip_suffix("\r\n").unwrap_or(load_balance_info);
-            self.request_data = if normalized.is_empty() {
+            self.load_balance_info = if normalized.is_empty() {
                 None
             } else {
-                Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
-                    normalized.to_owned(),
-                ))
+                Some(normalized.to_owned())
             };
         }
         if let Some(scale) = ps.desktop_scale_factor().ok().flatten() {
@@ -2206,7 +2213,7 @@ mod tests {
             .with_load_balance_info("\r\n")
             .build()
             .expect("terminator-only load-balance info clears the token");
-        assert!(cleared.connector().request_data.is_none());
+        assert!(cleared.load_balance_info().is_none());
     }
 
     #[cfg(any(feature = "sound", feature = "rdpdr"))]

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -964,7 +964,9 @@ impl ConfigBuilder {
             self.properties.remove("loadbalanceinfo");
         } else {
             self.properties.insert("loadbalanceinfo", value.clone());
-            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(value));
+            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
+                value.strip_suffix("\r\n").unwrap_or(&value).to_owned(),
+            ));
         }
         self
     }
@@ -1521,9 +1523,9 @@ impl ConfigBuilder {
         use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
         use ironrdp_pdu::rdp::client_info::TimezoneInfo;
 
-        if let Some(ironrdp_pdu::nego::NegoRequestData::RoutingToken(token)) = &self.request_data {
+        if let Some(ironrdp_pdu::nego::NegoRequestData::OpaqueRoutingToken(token)) = &self.request_data {
             anyhow::ensure!(
-                token.0.len() <= 256
+                token.0.len() <= ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH
                     && !token.0.is_empty()
                     && token.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte)),
                 "invalid load-balance routing token"
@@ -1882,7 +1884,10 @@ impl ConfigBuilder {
         }
         if let Some(load_balance_info) = ps.get::<&str>("loadbalanceinfo") {
             self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
-                load_balance_info.to_owned(),
+                load_balance_info
+                    .strip_suffix("\r\n")
+                    .unwrap_or(load_balance_info)
+                    .to_owned(),
             ));
         }
         if let Some(scale) = ps.desktop_scale_factor().ok().flatten() {
@@ -1955,7 +1960,7 @@ impl ConfigBuilder {
             _ => {}
         }
         #[cfg(any(feature = "sound", feature = "rdpdr"))]
-        if let Some(audio_quality_mode) = ps.get::<u32>("audioqualitymode") {
+        if let Some(audio_quality_mode) = ps.get::<i64>("audioqualitymode") {
             self.audio_quality_mode = Some(match audio_quality_mode {
                 0 => AudioQualityMode::Dynamic,
                 1 => AudioQualityMode::Medium,

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -48,6 +48,35 @@ impl fmt::Debug for ExtensionRegistry {
 
 // ── Public configuration types ────────────────────────────────────────────────
 
+/// RDPSND quality policy sent to servers that support audio protocol version 6 or newer.
+#[cfg(any(feature = "sound", feature = "rdpdr"))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AudioQualityMode {
+    Dynamic,
+    Medium,
+    #[default]
+    High,
+}
+
+#[cfg(any(feature = "sound", feature = "rdpdr"))]
+impl AudioQualityMode {
+    pub(crate) fn into_rdpsnd(self) -> ironrdp_rdpsnd::pdu::QualityMode {
+        match self {
+            Self::Dynamic => ironrdp_rdpsnd::pdu::QualityMode::Dynamic,
+            Self::Medium => ironrdp_rdpsnd::pdu::QualityMode::Medium,
+            Self::High => ironrdp_rdpsnd::pdu::QualityMode::High,
+        }
+    }
+
+    fn as_u32(self) -> u32 {
+        match self {
+            Self::Dynamic => 0,
+            Self::Medium => 1,
+            Self::High => 2,
+        }
+    }
+}
+
 /// Fully resolved client configuration.
 ///
 /// This is the typed surface consumed by [`crate::rdp::RdpClient`]. Build it with
@@ -73,6 +102,9 @@ pub struct Config {
     pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
+    pub(crate) administrative_session: bool,
+    #[cfg(any(feature = "sound", feature = "rdpdr"))]
+    pub(crate) audio_quality_mode: AudioQualityMode,
     pub(crate) rail_client_status_flags: Option<u32>,
     /// Initial RemoteApp launch queued after the RAIL handshake.
     pub(crate) rail_initial_execute: Option<ExecutePdu>,
@@ -156,6 +188,17 @@ impl Config {
         &self.channels
     }
 
+    /// Whether GCC requests the server's administrative session.
+    pub fn administrative_session(&self) -> bool {
+        self.administrative_session
+    }
+
+    /// RDPSND quality policy sent during audio format negotiation.
+    #[cfg(any(feature = "sound", feature = "rdpdr"))]
+    pub fn audio_quality_mode(&self) -> AudioQualityMode {
+        self.audio_quality_mode
+    }
+
     /// DVC named-pipe proxy mappings.
     #[cfg(feature = "dvc-pipe-proxy")]
     pub fn dvc_pipe_proxies(&self) -> &[DvcProxyInfo] {
@@ -199,6 +242,9 @@ impl fmt::Debug for Config {
         s.field("kerberos_config", &self.kerberos_config);
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
+        s.field("administrative_session", &self.administrative_session);
+        #[cfg(any(feature = "sound", feature = "rdpdr"))]
+        s.field("audio_quality_mode", &self.audio_quality_mode);
         s.field("rail_client_status_flags", &self.rail_client_status_flags);
         #[cfg(feature = "dvc-pipe-proxy")]
         s.field("dvc_pipe_proxies", &self.dvc_pipe_proxies);
@@ -666,6 +712,8 @@ pub struct ConfigBuilder {
     enable_audio_capture: Option<bool>,
     compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
     compression_enabled: Option<bool>,
+    request_data: Option<ironrdp_pdu::nego::NegoRequestData>,
+    administrative_session: bool,
     alternate_shell: Option<String>,
     work_dir: Option<String>,
     remote_application_mode: Option<bool>,
@@ -682,6 +730,8 @@ pub struct ConfigBuilder {
     kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     fake_events_interval: Option<Duration>,
     channels: ChannelConfig,
+    #[cfg(any(feature = "sound", feature = "rdpdr"))]
+    audio_quality_mode: Option<AudioQualityMode>,
     #[cfg(feature = "dvc-pipe-proxy")]
     dvc_pipe_proxies: Vec<DvcProxyInfo>,
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
@@ -902,6 +952,28 @@ impl ConfigBuilder {
     pub fn with_autologon(mut self, enabled: bool) -> Self {
         self.autologon = Some(enabled);
         self.properties.set_autologon(enabled);
+        self
+    }
+
+    /// Set the opaque load-balance routing token carried by the X.224 Connection Request PDU.
+    #[must_use]
+    pub fn with_load_balance_info(mut self, value: impl Into<String>) -> Self {
+        let value = value.into();
+        if value.is_empty() {
+            self.request_data = None;
+            self.properties.remove("loadbalanceinfo");
+        } else {
+            self.properties.insert("loadbalanceinfo", value.clone());
+            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(value));
+        }
+        self
+    }
+
+    /// Request the server's administrative session through GCC Client Cluster Data.
+    #[must_use]
+    pub fn with_administrative_session(mut self, enabled: bool) -> Self {
+        self.administrative_session = enabled;
+        self.properties.insert("administrative session", enabled);
         self
     }
 
@@ -1225,6 +1297,15 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set the RDPSND quality policy sent to servers supporting audio protocol version 6 or newer.
+    #[cfg(any(feature = "sound", feature = "rdpdr"))]
+    #[must_use]
+    pub fn with_audio_quality_mode(mut self, mode: AudioQualityMode) -> Self {
+        self.audio_quality_mode = Some(mode);
+        self.properties.insert("audioqualitymode", mode.as_u32());
+        self
+    }
+
     /// Set the CLIPRDR (clipboard) redirection mode.
     #[cfg(feature = "clipboard")]
     #[must_use]
@@ -1439,6 +1520,15 @@ impl ConfigBuilder {
     pub fn build(mut self) -> anyhow::Result<Config> {
         use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
         use ironrdp_pdu::rdp::client_info::TimezoneInfo;
+
+        if let Some(ironrdp_pdu::nego::NegoRequestData::RoutingToken(token)) = &self.request_data {
+            anyhow::ensure!(
+                token.0.len() <= 256
+                    && !token.0.is_empty()
+                    && token.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte)),
+                "invalid load-balance routing token"
+            );
+        }
 
         #[cfg(feature = "gateway")]
         if matches!(self.transport, TransportKind::Gateway { .. }) {
@@ -1675,7 +1765,7 @@ impl ConfigBuilder {
             autologon: self.autologon.unwrap_or(false),
             enable_audio_playback: self.enable_audio_playback.unwrap_or(true),
             enable_audio_capture: self.enable_audio_capture.unwrap_or(false),
-            request_data: None,
+            request_data: self.request_data,
             pointer_software_rendering: self.pointer_software_rendering.unwrap_or(false),
             multitransport_flags: None,
             compression_type,
@@ -1719,6 +1809,9 @@ impl ConfigBuilder {
             kerberos_config,
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,
+            administrative_session: self.administrative_session,
+            #[cfg(any(feature = "sound", feature = "rdpdr"))]
+            audio_quality_mode: self.audio_quality_mode.unwrap_or_default(),
             rail_client_status_flags: self.rail_client_status_flags,
             rail_initial_execute,
             #[cfg(feature = "dvc-pipe-proxy")]
@@ -1783,6 +1876,14 @@ impl ConfigBuilder {
         }
         if let Some(autologon) = ps.autologon() {
             self.autologon = Some(autologon);
+        }
+        if let Some(administrative_session) = ps.get::<bool>("administrative session") {
+            self.administrative_session = administrative_session;
+        }
+        if let Some(load_balance_info) = ps.get::<&str>("loadbalanceinfo") {
+            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
+                load_balance_info.to_owned(),
+            ));
         }
         if let Some(scale) = ps.desktop_scale_factor().ok().flatten() {
             self.desktop_scale_factor = Some(scale);
@@ -1852,6 +1953,15 @@ impl ConfigBuilder {
             Ok(Some(AudioCaptureMode::CaptureFromClient)) => self.enable_audio_capture = Some(true),
             Ok(Some(AudioCaptureMode::Disabled)) => self.enable_audio_capture = Some(false),
             _ => {}
+        }
+        #[cfg(any(feature = "sound", feature = "rdpdr"))]
+        if let Some(audio_quality_mode) = ps.get::<u32>("audioqualitymode") {
+            self.audio_quality_mode = Some(match audio_quality_mode {
+                0 => AudioQualityMode::Dynamic,
+                1 => AudioQualityMode::Medium,
+                2 => AudioQualityMode::High,
+                _ => anyhow::bail!("invalid 'audioqualitymode': {audio_quality_mode}"),
+            });
         }
 
         // Transport: NamedPipe > RDCleanPath > Gateway > Direct.

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -2213,7 +2213,7 @@ mod tests {
     #[test]
     fn property_set_rejects_out_of_range_audio_quality() {
         let mut properties = ironrdp_propertyset::PropertySet::new();
-        properties.insert("audioqualitymode", -1_i64);
+        properties.insert("audioqualitymode", -1i64);
         assert!(ConfigBuilder::from_property_set(&properties).is_err());
     }
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -955,17 +955,21 @@ impl ConfigBuilder {
         self
     }
 
-    /// Set the opaque load-balance routing token carried by the X.224 Connection Request PDU.
+    /// Set or clear the opaque load-balance routing token carried by the X.224 Connection Request PDU.
+    ///
+    /// A nonempty token must contain 1–238 printable ASCII bytes, excluding an optional trailing CRLF.
+    /// An empty value clears the token, and [`Self::build`] rejects other values.
     #[must_use]
     pub fn with_load_balance_info(mut self, value: impl Into<String>) -> Self {
         let value = value.into();
-        if value.is_empty() {
+        let normalized = value.strip_suffix("\r\n").unwrap_or(&value);
+        if normalized.is_empty() {
             self.request_data = None;
             self.properties.remove("loadbalanceinfo");
         } else {
             self.properties.insert("loadbalanceinfo", value.clone());
             self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
-                value.strip_suffix("\r\n").unwrap_or(&value).to_owned(),
+                normalized.to_owned(),
             ));
         }
         self
@@ -1883,12 +1887,14 @@ impl ConfigBuilder {
             self.administrative_session = administrative_session;
         }
         if let Some(load_balance_info) = ps.get::<&str>("loadbalanceinfo") {
-            self.request_data = Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
-                load_balance_info
-                    .strip_suffix("\r\n")
-                    .unwrap_or(load_balance_info)
-                    .to_owned(),
-            ));
+            let normalized = load_balance_info.strip_suffix("\r\n").unwrap_or(load_balance_info);
+            self.request_data = if normalized.is_empty() {
+                None
+            } else {
+                Some(ironrdp_pdu::nego::NegoRequestData::raw_routing_token(
+                    normalized.to_owned(),
+                ))
+            };
         }
         if let Some(scale) = ps.desktop_scale_factor().ok().flatten() {
             self.desktop_scale_factor = Some(scale);
@@ -2186,6 +2192,29 @@ mod tests {
             .with_client_dir("C:\\")
             .with_platform(MajorPlatformType::WINDOWS)
             .with_client_name("client")
+    }
+
+    #[test]
+    fn load_balance_info_enforces_x224_length_limit() {
+        let maximum = "x".repeat(ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH);
+        assert!(complete_builder().with_load_balance_info(maximum).build().is_ok());
+
+        let oversized = "x".repeat(ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH + 1);
+        assert!(complete_builder().with_load_balance_info(oversized).build().is_err());
+
+        let cleared = complete_builder()
+            .with_load_balance_info("\r\n")
+            .build()
+            .expect("terminator-only load-balance info clears the token");
+        assert!(cleared.connector().request_data.is_none());
+    }
+
+    #[cfg(any(feature = "sound", feature = "rdpdr"))]
+    #[test]
+    fn property_set_rejects_out_of_range_audio_quality() {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.insert("audioqualitymode", -1_i64);
+        assert!(ConfigBuilder::from_property_set(&properties).is_err());
     }
 
     #[cfg(feature = "gateway")]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1397,6 +1397,15 @@ fn build_connector(
     let mut connector =
         ironrdp_connector::ClientConnector::new(connector_config, client_addr).with_static_channel(drdynvc);
 
+    if config.administrative_session {
+        connector = connector.with_cluster_data(ironrdp_pdu::gcc::ClientClusterData {
+            flags: ironrdp_pdu::gcc::RedirectionFlags::REDIRECTION_SUPPORTED
+                | ironrdp_pdu::gcc::RedirectionFlags::REDIRECTED_SESSION_FIELD_VALID,
+            redirection_version: ironrdp_pdu::gcc::RedirectionVersion::V6,
+            redirected_session_id: 0,
+        });
+    }
+
     if let Some(rail_client) = rail_client {
         connector = connector.with_static_channel(rail_client);
     }
@@ -1423,15 +1432,17 @@ fn build_connector(
             match kind {
                 #[cfg(feature = "sound")]
                 RdpsndBackendKind::Playback => {
-                    connector = connector.with_static_channel(ironrdp_rdpsnd::client::Rdpsnd::new(Box::new(
-                        cpal::RdpsndBackend::new(),
-                    )));
+                    connector = connector.with_static_channel(
+                        ironrdp_rdpsnd::client::Rdpsnd::new(Box::new(cpal::RdpsndBackend::new()))
+                            .with_quality_mode(config.audio_quality_mode.into_rdpsnd()),
+                    );
                 }
                 #[cfg(feature = "rdpdr")]
                 RdpsndBackendKind::Noop => {
-                    connector = connector.with_static_channel(ironrdp_rdpsnd::client::Rdpsnd::new(Box::new(
-                        ironrdp_rdpsnd::client::NoopRdpsndBackend,
-                    )));
+                    connector = connector.with_static_channel(
+                        ironrdp_rdpsnd::client::Rdpsnd::new(Box::new(ironrdp_rdpsnd::client::NoopRdpsndBackend))
+                            .with_quality_mode(config.audio_quality_mode.into_rdpsnd()),
+                    );
                 }
             }
         }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1397,6 +1397,10 @@ fn build_connector(
     let mut connector =
         ironrdp_connector::ClientConnector::new(connector_config, client_addr).with_static_channel(drdynvc);
 
+    if let Some(load_balance_info) = &config.load_balance_info {
+        connector = connector.with_load_balance_info(load_balance_info.clone());
+    }
+
     if config.administrative_session {
         connector = connector.with_cluster_data(ironrdp_pdu::gcc::ClientClusterData {
             flags: ironrdp_pdu::gcc::RedirectionFlags::REDIRECTION_SUPPORTED

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -318,6 +318,7 @@ pub struct ClientConnector {
     /// MCS message channel ID assigned by the server, once negotiated.
     pub message_channel_id: Option<u16>,
     cluster_data: Option<gcc::ClientClusterData>,
+    load_balance_info: Option<String>,
     /// X.224 negotiation flags supplied by the server.
     response_flags: nego::ResponseFlags,
     /// Multitransport flags the server advertised in its GCC
@@ -353,6 +354,7 @@ impl ClientConnector {
             static_channels: StaticChannelSet::new(),
             message_channel_id: None,
             cluster_data: None,
+            load_balance_info: None,
             response_flags: nego::ResponseFlags::empty(),
             server_multitransport_flags: None,
             auto_reconnect_cookie: None,
@@ -384,6 +386,13 @@ impl ClientConnector {
     #[must_use]
     pub fn with_cluster_data(mut self, cluster_data: gcc::ClientClusterData) -> Self {
         self.cluster_data = Some(cluster_data);
+        self
+    }
+
+    /// Set opaque load-balancing data for the initial X.224 Connection Request.
+    #[must_use]
+    pub fn with_load_balance_info(mut self, load_balance_info: String) -> Self {
+        self.load_balance_info = Some(load_balance_info);
         self
     }
 
@@ -443,12 +452,16 @@ impl ClientConnector {
         output: &mut WriteBuf,
     ) -> ConnectorResult<Written> {
         let connection_request = nego::ConnectionRequest {
-            nego_data: self.config.request_data.clone().or_else(|| {
-                self.config
-                    .credentials
-                    .username()
-                    .map(|username| nego::NegoRequestData::cookie(username.to_owned()))
-            }),
+            nego_data: if self.load_balance_info.is_none() {
+                self.config.request_data.clone().or_else(|| {
+                    self.config
+                        .credentials
+                        .username()
+                        .map(|username| nego::NegoRequestData::cookie(username.to_owned()))
+                })
+            } else {
+                None
+            },
             flags: nego::RequestFlags::empty(),
             protocol: security_protocol,
             correlation_info: None,
@@ -456,7 +469,16 @@ impl ClientConnector {
 
         debug!(message = ?connection_request, "Send");
 
-        let written = ironrdp_core::encode_buf(&X224(connection_request), output).map_err(ConnectorError::encode)?;
+        let written = if let Some(load_balance_info) = &self.load_balance_info {
+            let request = nego::ConnectionRequestWithOpaqueRoutingToken {
+                request: connection_request,
+                routing_token: nego::OpaqueRoutingToken(load_balance_info.clone()),
+            };
+            ironrdp_core::encode_buf(&X224(request), output)
+        } else {
+            ironrdp_core::encode_buf(&X224(connection_request), output)
+        }
+        .map_err(ConnectorError::encode)?;
         self.state = ClientConnectorState::ConnectionInitiationWaitConfirm {
             requested_protocol: security_protocol,
         };

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -317,6 +317,7 @@ pub struct ClientConnector {
     pub static_channels: StaticChannelSet,
     /// MCS message channel ID assigned by the server, once negotiated.
     pub message_channel_id: Option<u16>,
+    cluster_data: Option<gcc::ClientClusterData>,
     /// X.224 negotiation flags supplied by the server.
     response_flags: nego::ResponseFlags,
     /// Multitransport flags the server advertised in its GCC
@@ -351,6 +352,7 @@ impl ClientConnector {
             client_addr,
             static_channels: StaticChannelSet::new(),
             message_channel_id: None,
+            cluster_data: None,
             response_flags: nego::ResponseFlags::empty(),
             server_multitransport_flags: None,
             auto_reconnect_cookie: None,
@@ -375,6 +377,13 @@ impl ClientConnector {
     #[must_use]
     pub fn with_auto_reconnect_cookie(mut self, cookie: ServerAutoReconnect) -> Self {
         self.auto_reconnect_cookie = Some(cookie);
+        self
+    }
+
+    /// Add GCC Client Cluster Data to advertise or request server-session redirection.
+    #[must_use]
+    pub fn with_cluster_data(mut self, cluster_data: gcc::ClientClusterData) -> Self {
+        self.cluster_data = Some(cluster_data);
         self
     }
 
@@ -1099,6 +1108,7 @@ impl Sequence for ClientConnector {
 
                 let client_gcc_blocks = create_gcc_blocks(
                     &self.config,
+                    self.cluster_data.as_ref(),
                     selected_protocol,
                     self.response_flags
                         .contains(nego::ResponseFlags::EXTENDED_CLIENT_DATA_SUPPORTED),
@@ -1569,6 +1579,7 @@ pub fn encode_send_data_request<T: Encode>(
 #[expect(single_use_lifetimes)] // anonymous lifetimes in `impl Trait` are unstable
 fn create_gcc_blocks<'a>(
     config: &Config,
+    cluster_data: Option<&gcc::ClientClusterData>,
     selected_protocol: nego::SecurityProtocol,
     extended_client_data_supported: bool,
     static_channels: impl Iterator<Item = &'a StaticVirtualChannel>,
@@ -1672,8 +1683,7 @@ fn create_gcc_blocks<'a>(
         } else {
             Some(ClientNetworkData { channels })
         },
-        // TODO(#139): support for Some(ClientClusterData { flags: RedirectionFlags::REDIRECTION_SUPPORTED, redirection_version: RedirectionVersion::V4, redirected_session_id: 0, }),
-        cluster: None,
+        cluster: cluster_data.cloned(),
         monitor: extended_client_data_supported
             .then(|| config.monitor_layout.clone())
             .flatten(),
@@ -1973,8 +1983,14 @@ mod tests {
             multitransport_flags: None,
         };
 
-        let blocks = create_gcc_blocks(&config, nego::SecurityProtocol::empty(), true, core::iter::empty())
-            .expect("valid GCC Client Monitor Data");
+        let blocks = create_gcc_blocks(
+            &config,
+            None,
+            nego::SecurityProtocol::empty(),
+            true,
+            core::iter::empty(),
+        )
+        .expect("valid GCC Client Monitor Data");
 
         assert_eq!(blocks.monitor, config.monitor_layout);
         assert!(
@@ -1987,8 +2003,14 @@ mod tests {
         );
 
         config.monitor_layout = None;
-        let blocks = create_gcc_blocks(&config, nego::SecurityProtocol::empty(), true, core::iter::empty())
-            .expect("valid GCC Client Monitor Data");
+        let blocks = create_gcc_blocks(
+            &config,
+            None,
+            nego::SecurityProtocol::empty(),
+            true,
+            core::iter::empty(),
+        )
+        .expect("valid GCC Client Monitor Data");
 
         assert!(blocks.monitor.is_none());
         assert!(
@@ -2000,8 +2022,14 @@ mod tests {
                 .contains(gcc::ClientEarlyCapabilityFlags::SUPPORT_MONITOR_LAYOUT_PDU)
         );
 
-        let blocks = create_gcc_blocks(&config, nego::SecurityProtocol::empty(), false, core::iter::empty())
-            .expect("valid GCC Client Monitor Data");
+        let blocks = create_gcc_blocks(
+            &config,
+            None,
+            nego::SecurityProtocol::empty(),
+            false,
+            core::iter::empty(),
+        )
+        .expect("valid GCC Client Monitor Data");
 
         assert!(blocks.monitor.is_none());
         assert!(blocks.message_channel.is_none());
@@ -2014,5 +2042,20 @@ mod tests {
                 .expect("early capability flags are present")
                 .contains(gcc::ClientEarlyCapabilityFlags::SUPPORT_MONITOR_LAYOUT_PDU)
         );
+
+        let cluster_data = gcc::ClientClusterData {
+            flags: gcc::RedirectionFlags::REDIRECTION_SUPPORTED | gcc::RedirectionFlags::REDIRECTED_SESSION_FIELD_VALID,
+            redirection_version: gcc::RedirectionVersion::V6,
+            redirected_session_id: 0,
+        };
+        let blocks = create_gcc_blocks(
+            &config,
+            Some(&cluster_data),
+            nego::SecurityProtocol::empty(),
+            true,
+            core::iter::empty(),
+        )
+        .expect("valid GCC Client Cluster Data");
+        assert_eq!(blocks.cluster, Some(cluster_data));
     }
 }

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -168,7 +168,6 @@ impl fmt::Display for FailureCode {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NegoRequestData {
     RoutingToken(RoutingToken),
-    OpaqueRoutingToken(OpaqueRoutingToken),
     Cookie(Cookie),
 }
 
@@ -177,28 +176,20 @@ impl NegoRequestData {
         Self::RoutingToken(RoutingToken(value))
     }
 
-    pub fn raw_routing_token(value: String) -> Self {
-        Self::OpaqueRoutingToken(OpaqueRoutingToken(value))
-    }
-
     pub fn cookie(value: String) -> Self {
         Self::Cookie(Cookie(value))
     }
 
     pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
-        if let Some(token) = RoutingToken::read(src)? {
-            return Ok(Some(Self::RoutingToken(token)));
+        match RoutingToken::read(src)? {
+            Some(token) => Ok(Some(Self::RoutingToken(token))),
+            None => Cookie::read(src)?.map(Self::Cookie).pipe(Ok),
         }
-        if let Some(cookie) = Cookie::read(src)? {
-            return Ok(Some(Self::Cookie(cookie)));
-        }
-        OpaqueRoutingToken::read(src)?.map(Self::OpaqueRoutingToken).pipe(Ok)
     }
 
     pub fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         match self {
             NegoRequestData::RoutingToken(token) => token.write(dst),
-            NegoRequestData::OpaqueRoutingToken(token) => token.write(dst),
             NegoRequestData::Cookie(cookie) => cookie.write(dst),
         }
     }
@@ -206,7 +197,6 @@ impl NegoRequestData {
     pub fn size(&self) -> usize {
         match self {
             NegoRequestData::RoutingToken(token) => token.size(),
-            NegoRequestData::OpaqueRoutingToken(token) => token.size(),
             NegoRequestData::Cookie(cookie) => cookie.size(),
         }
     }
@@ -328,7 +318,104 @@ impl_x224_pdu_pod!(ConnectionRequest);
 
 impl ConnectionRequest {
     const RDP_NEG_REQ_SIZE: u16 = 8;
+
+    fn encode_after_nego_data(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        // [MS-RDPBCGR] mentions the following payload as optional, but it appears that on recent
+        // versions of Windows, the server always expect to find this payload.
+        dst.write_u8(u8::from(NegoMsgType::REQUEST));
+        let mut flags = self.flags;
+        flags.set(RequestFlags::CORRELATION_INFO_PRESENT, self.correlation_info.is_some());
+        dst.write_u8(flags.bits());
+        dst.write_u16(Self::RDP_NEG_REQ_SIZE);
+        dst.write_u32(self.protocol.bits());
+
+        if let Some(correlation_info) = &self.correlation_info {
+            correlation_info.write(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn decode_after_nego_data(
+        src: &mut ReadCursor<'_>,
+        variable_part_rest_size: usize,
+        nego_data: Option<NegoRequestData>,
+    ) -> DecodeResult<Self> {
+        if variable_part_rest_size > 0 && variable_part_rest_size < usize::from(Self::RDP_NEG_REQ_SIZE) {
+            return Err(invalid_field_err!(
+                Self::NAME,
+                "TPDU header variable part",
+                "has a truncated negotiation request"
+            ));
+        }
+
+        if variable_part_rest_size >= usize::from(Self::RDP_NEG_REQ_SIZE) {
+            let msg_type = NegoMsgType::from(src.read_u8());
+
+            if msg_type != NegoMsgType::REQUEST {
+                return Err(unexpected_message_type_err!(Self::NAME, u8::from(msg_type), in: src));
+            }
+
+            let flags = RequestFlags::from_bits_retain(src.read_u8());
+            let length = src.read_u16();
+            if length != Self::RDP_NEG_REQ_SIZE {
+                return Err(invalid_field_err!(Self::NAME, "length", "must be eight bytes", in: src));
+            }
+
+            let protocol = SecurityProtocol::from_bits_retain(src.read_u32());
+            let correlation_info = if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE + CorrelationInfo::SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has invalid correlation information length"
+                    ));
+                }
+                Some(CorrelationInfo::read(src)?)
+            } else {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has unexpected trailing data"
+                    ));
+                }
+                None
+            };
+
+            Ok(Self {
+                nego_data,
+                flags,
+                protocol,
+                correlation_info,
+            })
+        } else {
+            Ok(Self {
+                nego_data,
+                flags: RequestFlags::empty(),
+                protocol: SecurityProtocol::empty(),
+                correlation_info: None,
+            })
+        }
+    }
+
+    fn negotiation_data_size(&self) -> usize {
+        usize::from(Self::RDP_NEG_REQ_SIZE)
+            + self
+                .correlation_info
+                .as_ref()
+                .map_or(0, |_| usize::from(CorrelationInfo::SIZE))
+    }
 }
+
+/// X.224 Connection Request carrying caller-supplied opaque load-balancing data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionRequestWithOpaqueRoutingToken {
+    pub request: ConnectionRequest,
+    pub routing_token: OpaqueRoutingToken,
+}
+
+impl_x224_pdu_pod!(ConnectionRequestWithOpaqueRoutingToken);
 
 /// Connection correlation information carried after an RDP negotiation request.
 ///
@@ -399,20 +486,7 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             nego_data.write(dst)?;
         }
 
-        // [MS-RDPBCGR] mentions the following payload as optional, but it appears that on recent
-        // versions of Windows, the server always expect to find this payload.
-        dst.write_u8(u8::from(NegoMsgType::REQUEST));
-        let mut flags = self.flags;
-        flags.set(RequestFlags::CORRELATION_INFO_PRESENT, self.correlation_info.is_some());
-        dst.write_u8(flags.bits());
-        dst.write_u16(Self::RDP_NEG_REQ_SIZE);
-        dst.write_u32(self.protocol.bits());
-
-        if let Some(correlation_info) = &self.correlation_info {
-            correlation_info.write(dst)?;
-        }
-
-        Ok(())
+        self.encode_after_nego_data(dst)
     }
 
     fn x224_body_decode(src: &mut ReadCursor<'de>, _: &TpktHeader, tpdu: &TpduHeader) -> DecodeResult<Self> {
@@ -433,72 +507,56 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             ));
         };
 
-        if variable_part_rest_size > 0 && variable_part_rest_size < usize::from(Self::RDP_NEG_REQ_SIZE) {
-            return Err(invalid_field_err!(
-                Self::NAME,
-                "TPDU header variable part",
-                "has a truncated negotiation request"
-            ));
-        }
-
-        if variable_part_rest_size >= usize::from(Self::RDP_NEG_REQ_SIZE) {
-            let msg_type = NegoMsgType::from(src.read_u8());
-
-            if msg_type != NegoMsgType::REQUEST {
-                return Err(unexpected_message_type_err!(Self::NAME, u8::from(msg_type), in: src));
-            }
-
-            let flags = RequestFlags::from_bits_retain(src.read_u8());
-            let length = src.read_u16();
-            if length != Self::RDP_NEG_REQ_SIZE {
-                return Err(invalid_field_err!(Self::NAME, "length", "must be eight bytes", in: src));
-            }
-
-            let protocol = SecurityProtocol::from_bits_retain(src.read_u32());
-            let correlation_info = if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
-                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE + CorrelationInfo::SIZE) {
-                    return Err(invalid_field_err!(
-                        Self::NAME,
-                        "TPDU header variable part",
-                        "has invalid correlation information length"
-                    ));
-                }
-                Some(CorrelationInfo::read(src)?)
-            } else {
-                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE) {
-                    return Err(invalid_field_err!(
-                        Self::NAME,
-                        "TPDU header variable part",
-                        "has unexpected trailing data"
-                    ));
-                }
-                None
-            };
-
-            Ok(Self {
-                nego_data,
-                flags,
-                protocol,
-                correlation_info,
-            })
-        } else {
-            Ok(Self {
-                nego_data,
-                flags: RequestFlags::empty(),
-                protocol: SecurityProtocol::empty(),
-                correlation_info: None,
-            })
-        }
+        Self::decode_after_nego_data(src, variable_part_rest_size, nego_data)
     }
 
     fn tpdu_header_variable_part_size(&self) -> usize {
         let optional_nego_data_size = self.nego_data.as_ref().map(|data| data.size()).unwrap_or(0);
-        optional_nego_data_size
-            + usize::from(Self::RDP_NEG_REQ_SIZE)
-            + self
-                .correlation_info
-                .as_ref()
-                .map_or(0, |_| usize::from(CorrelationInfo::SIZE))
+        optional_nego_data_size + self.negotiation_data_size()
+    }
+
+    fn tpdu_user_data_size(&self) -> usize {
+        0
+    }
+}
+
+impl<'de> X224Pdu<'de> for ConnectionRequestWithOpaqueRoutingToken {
+    const X224_NAME: &'static str = "Client X.224 Connection Request with opaque routing token";
+
+    const TPDU_CODE: TpduCode = TpduCode::CONNECTION_REQUEST;
+
+    fn x224_body_encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.routing_token.write(dst)?;
+        self.request.encode_after_nego_data(dst)
+    }
+
+    fn x224_body_decode(src: &mut ReadCursor<'de>, _: &TpktHeader, tpdu: &TpduHeader) -> DecodeResult<Self> {
+        let variable_part_size = tpdu.variable_part_size();
+        ensure_size!(in: src, size: variable_part_size);
+
+        let routing_token = OpaqueRoutingToken::read(src)?.ok_or_else(|| {
+            invalid_field_err!(
+                Self::NAME,
+                "routingToken",
+                "missing opaque routing token",
+                in: src
+            )
+        })?;
+        let variable_part_rest_size = variable_part_size.checked_sub(routing_token.size()).ok_or_else(|| {
+            invalid_field_err!(
+                Self::NAME,
+                "TPDU header variable part",
+                "advertised size too small",
+                in: src
+            )
+        })?;
+        let request = ConnectionRequest::decode_after_nego_data(src, variable_part_rest_size, None)?;
+
+        Ok(Self { request, routing_token })
+    }
+
+    fn tpdu_header_variable_part_size(&self) -> usize {
+        self.routing_token.size() + self.request.negotiation_data_size()
     }
 
     fn tpdu_user_data_size(&self) -> usize {

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -171,17 +171,24 @@ pub enum NegoRequestData {
 
 impl NegoRequestData {
     pub fn routing_token(value: String) -> Self {
-        Self::RoutingToken(RoutingToken(value))
+        Self::RoutingToken(RoutingToken(format!("Cookie: msts={value}")))
     }
 
     pub fn cookie(value: String) -> Self {
         Self::Cookie(Cookie(value))
     }
 
+    /// Creates an opaque load-balance routing token.
+    ///
+    /// Unlike [`Self::routing_token`], this does not add the legacy `Cookie: msts=` prefix.
+    pub fn raw_routing_token(value: String) -> Self {
+        Self::RoutingToken(RoutingToken(value))
+    }
+
     pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
-        match RoutingToken::read(src)? {
-            Some(token) => Ok(Some(Self::RoutingToken(token))),
-            None => Cookie::read(src)?.map(Self::Cookie).pipe(Ok),
+        match Cookie::read(src)? {
+            Some(cookie) => Ok(Some(Self::Cookie(cookie))),
+            None => RoutingToken::read(src)?.map(Self::RoutingToken).pipe(Ok),
         }
     }
 
@@ -220,23 +227,42 @@ impl Cookie {
     }
 }
 
+/// Complete opaque ANSI routing token, excluding the terminating CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RoutingToken(pub String);
 
 impl RoutingToken {
-    const PREFIX: &'static str = "Cookie: msts=";
-
     pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
-        read_nego_data(src, "RoutingToken", Self::PREFIX)?.map(Self).pipe(Ok)
+        let start = src.pos();
+        let Some(length) = src.inner()[start..].windows(2).position(|bytes| bytes == b"\r\n") else {
+            return Ok(None);
+        };
+        let bytes = &src.inner()[start..start + length];
+        if bytes.is_empty() || !bytes.iter().all(|byte| (0x20..=0x7E).contains(byte)) {
+            return Ok(None);
+        }
+
+        let value = core::str::from_utf8(bytes)
+            .map_err(|_| invalid_field_err("RoutingToken", "value", "not valid UTF-8"))?
+            .to_owned();
+        src.advance(length + 2);
+        Ok(Some(Self(value)))
     }
 
     pub fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        write_nego_data(dst, "RoutingToken", Self::PREFIX, &self.0)
+        if self.0.is_empty() || !self.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte)) {
+            return Err(invalid_field_err!(
+                "RoutingToken",
+                "value",
+                "must contain printable ANSI characters"
+            ));
+        }
+        write_nego_data(dst, "RoutingToken", "", &self.0)
     }
 
     pub fn size(&self) -> usize {
-        Self::PREFIX.len() + self.0.len() + 2
+        self.0.len() + 2
     }
 }
 

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -11,6 +11,8 @@ use crate::tpkt::TpktHeader;
 use crate::x224::X224Pdu;
 use crate::{DecodeResult, EncodeResult, Pdu as _, impl_x224_pdu_pod};
 
+pub const MAX_ROUTING_TOKEN_LENGTH: usize = 238;
+
 bitflags! {
     /// A 32-bit, unsigned integer that contains flags indicating the supported security protocols.
     ///
@@ -166,6 +168,7 @@ impl fmt::Display for FailureCode {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NegoRequestData {
     RoutingToken(RoutingToken),
+    OpaqueRoutingToken(OpaqueRoutingToken),
     Cookie(Cookie),
 }
 
@@ -174,27 +177,28 @@ impl NegoRequestData {
         Self::RoutingToken(RoutingToken(format!("Cookie: msts={value}")))
     }
 
+    pub fn raw_routing_token(value: String) -> Self {
+        Self::OpaqueRoutingToken(OpaqueRoutingToken(value))
+    }
+
     pub fn cookie(value: String) -> Self {
         Self::Cookie(Cookie(value))
     }
 
-    /// Creates an opaque load-balance routing token.
-    ///
-    /// Unlike [`Self::routing_token`], this does not add the legacy `Cookie: msts=` prefix.
-    pub fn raw_routing_token(value: String) -> Self {
-        Self::RoutingToken(RoutingToken(value))
-    }
-
     pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
-        match Cookie::read(src)? {
-            Some(cookie) => Ok(Some(Self::Cookie(cookie))),
-            None => RoutingToken::read(src)?.map(Self::RoutingToken).pipe(Ok),
+        if let Some(token) = RoutingToken::read(src)? {
+            return Ok(Some(Self::RoutingToken(token)));
         }
+        if let Some(cookie) = Cookie::read(src)? {
+            return Ok(Some(Self::Cookie(cookie)));
+        }
+        OpaqueRoutingToken::read(src)?.map(Self::OpaqueRoutingToken).pipe(Ok)
     }
 
     pub fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         match self {
             NegoRequestData::RoutingToken(token) => token.write(dst),
+            NegoRequestData::OpaqueRoutingToken(token) => token.write(dst),
             NegoRequestData::Cookie(cookie) => cookie.write(dst),
         }
     }
@@ -202,6 +206,7 @@ impl NegoRequestData {
     pub fn size(&self) -> usize {
         match self {
             NegoRequestData::RoutingToken(token) => token.size(),
+            NegoRequestData::OpaqueRoutingToken(token) => token.size(),
             NegoRequestData::Cookie(cookie) => cookie.size(),
         }
     }
@@ -227,12 +232,32 @@ impl Cookie {
     }
 }
 
-/// Complete opaque ANSI routing token, excluding the terminating CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RoutingToken(pub String);
 
 impl RoutingToken {
+    const PREFIX: &'static str = "Cookie: msts=";
+
+    pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
+        read_nego_data(src, "RoutingToken", Self::PREFIX)?.map(Self).pipe(Ok)
+    }
+
+    pub fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        write_nego_data(dst, "RoutingToken", Self::PREFIX, &self.0)
+    }
+
+    pub fn size(&self) -> usize {
+        Self::PREFIX.len() + self.0.len() + 2
+    }
+}
+
+/// Complete opaque ANSI routing token, excluding the terminating CRLF.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct OpaqueRoutingToken(pub String);
+
+impl OpaqueRoutingToken {
     pub fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Self>> {
         let start = src.pos();
         let Some(length) = src.inner()[start..].windows(2).position(|bytes| bytes == b"\r\n") else {

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -174,7 +174,7 @@ pub enum NegoRequestData {
 
 impl NegoRequestData {
     pub fn routing_token(value: String) -> Self {
-        Self::RoutingToken(RoutingToken(format!("Cookie: msts={value}")))
+        Self::RoutingToken(RoutingToken(value))
     }
 
     pub fn raw_routing_token(value: String) -> Self {
@@ -252,7 +252,7 @@ impl RoutingToken {
     }
 }
 
-/// Complete opaque ANSI routing token, excluding the terminating CRLF.
+/// Opaque printable-ASCII routing token, excluding the terminating CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OpaqueRoutingToken(pub String);
@@ -269,18 +269,21 @@ impl OpaqueRoutingToken {
         }
 
         let value = core::str::from_utf8(bytes)
-            .map_err(|_| invalid_field_err("RoutingToken", "value", "not valid UTF-8"))?
+            .map_err(|_| invalid_field_err("OpaqueRoutingToken", "value", "not valid UTF-8", None))?
             .to_owned();
         src.advance(length + 2);
         Ok(Some(Self(value)))
     }
 
     pub fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if self.0.is_empty() || !self.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte)) {
+        if self.0.is_empty()
+            || self.0.len() > MAX_ROUTING_TOKEN_LENGTH
+            || !self.0.as_bytes().iter().all(|byte| (0x20..=0x7E).contains(byte))
+        {
             return Err(invalid_field_err!(
-                "RoutingToken",
+                "OpaqueRoutingToken",
                 "value",
-                "must contain printable ANSI characters"
+                "must contain 1 to 238 printable ASCII bytes"
             ));
         }
         write_nego_data(dst, "RoutingToken", "", &self.0)

--- a/crates/ironrdp-rdpsnd/src/client.rs
+++ b/crates/ironrdp-rdpsnd/src/client.rs
@@ -73,6 +73,7 @@ struct PendingWave {
 #[derive(Debug)]
 pub struct Rdpsnd {
     handler: Box<dyn RdpsndClientHandler>,
+    quality_mode: pdu::QualityMode,
     state: RdpsndState,
     server_format: Option<ServerAudioFormatPdu>,
     /// Formats advertised to the server, in wire order.
@@ -88,11 +89,18 @@ impl Rdpsnd {
     pub fn new(handler: Box<dyn RdpsndClientHandler>) -> Self {
         Self {
             handler,
+            quality_mode: pdu::QualityMode::High,
             state: RdpsndState::Start,
             server_format: None,
             client_formats: Vec::new(),
             pending_wave: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_quality_mode(mut self, quality_mode: pdu::QualityMode) -> Self {
+        self.quality_mode = quality_mode;
+        self
     }
 
     pub fn get_format(&self, format_no: u16) -> PduResult<&AudioFormat> {
@@ -150,7 +158,7 @@ impl Rdpsnd {
 
     pub fn quality_mode(&mut self) -> PduResult<RdpsndSvcMessages> {
         let pdu = pdu::QualityModePdu {
-            quality_mode: pdu::QualityMode::High,
+            quality_mode: self.quality_mode,
         };
         Ok(RdpsndSvcMessages::new(vec![
             pdu::ClientAudioOutputPdu::QualityMode(pdu).into(),

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -1,8 +1,8 @@
 use expect_test::expect;
 use ironrdp_core::{ReadCursor, WriteCursor};
 use ironrdp_pdu::nego::{
-    ConnectionConfirm, ConnectionRequest, Cookie, CorrelationInfo, FailureCode, NegoRequestData, RequestFlags,
-    ResponseFlags, RoutingToken, SecurityProtocol,
+    ConnectionConfirm, ConnectionRequest, Cookie, CorrelationInfo, FailureCode, NegoRequestData, OpaqueRoutingToken,
+    RequestFlags, ResponseFlags, RoutingToken, SecurityProtocol,
 };
 use ironrdp_pdu::tpdu::{TpduCode, TpduHeader};
 use ironrdp_pdu::tpkt::TpktHeader;
@@ -486,22 +486,26 @@ fn routing_token_decode() {
         .expect("read routing token")
         .expect("routing token");
 
-    assert_eq!(routing_token.0, "Cookie: msts=3640205228.15629.0000");
+    assert_eq!(routing_token.0, "3640205228.15629.0000");
 }
 
 #[test]
 fn raw_routing_token_roundtrip() {
-    let token = RoutingToken("tsv://MS Terminal Services Plugin.1.collection".to_owned());
+    let token = OpaqueRoutingToken("tsv://MS Terminal Services Plugin.1.collection".to_owned());
     let mut buffer = vec![0; token.size()];
     token
         .write(&mut WriteCursor::new(&mut buffer))
         .expect("write raw routing token");
     assert_eq!(buffer, b"tsv://MS Terminal Services Plugin.1.collection\r\n");
 
-    let decoded = RoutingToken::read(&mut ReadCursor::new(&buffer))
+    let decoded = OpaqueRoutingToken::read(&mut ReadCursor::new(&buffer))
         .expect("read raw routing token")
         .expect("raw routing token");
     assert_eq!(decoded, token);
+
+    let oversized = OpaqueRoutingToken("x".repeat(ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH + 1));
+    let mut buffer = vec![0; oversized.size()];
+    assert!(oversized.write(&mut WriteCursor::new(&mut buffer)).is_err());
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -486,7 +486,22 @@ fn routing_token_decode() {
         .expect("read routing token")
         .expect("routing token");
 
-    assert_eq!(routing_token.0, "3640205228.15629.0000");
+    assert_eq!(routing_token.0, "Cookie: msts=3640205228.15629.0000");
+}
+
+#[test]
+fn raw_routing_token_roundtrip() {
+    let token = RoutingToken("tsv://MS Terminal Services Plugin.1.collection".to_owned());
+    let mut buffer = vec![0; token.size()];
+    token
+        .write(&mut WriteCursor::new(&mut buffer))
+        .expect("write raw routing token");
+    assert_eq!(buffer, b"tsv://MS Terminal Services Plugin.1.collection\r\n");
+
+    let decoded = RoutingToken::read(&mut ReadCursor::new(&buffer))
+        .expect("read raw routing token")
+        .expect("raw routing token");
+    assert_eq!(decoded, token);
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -1,8 +1,8 @@
 use expect_test::expect;
 use ironrdp_core::{ReadCursor, WriteCursor};
 use ironrdp_pdu::nego::{
-    ConnectionConfirm, ConnectionRequest, Cookie, CorrelationInfo, FailureCode, NegoRequestData, OpaqueRoutingToken,
-    RequestFlags, ResponseFlags, RoutingToken, SecurityProtocol,
+    ConnectionConfirm, ConnectionRequest, ConnectionRequestWithOpaqueRoutingToken, Cookie, CorrelationInfo,
+    FailureCode, NegoRequestData, OpaqueRoutingToken, RequestFlags, ResponseFlags, RoutingToken, SecurityProtocol,
 };
 use ironrdp_pdu::tpdu::{TpduCode, TpduHeader};
 use ironrdp_pdu::tpkt::TpktHeader;
@@ -502,6 +502,20 @@ fn raw_routing_token_roundtrip() {
         .expect("read raw routing token")
         .expect("raw routing token");
     assert_eq!(decoded, token);
+
+    let request = ConnectionRequestWithOpaqueRoutingToken {
+        request: ConnectionRequest {
+            nego_data: None,
+            flags: RequestFlags::empty(),
+            protocol: SecurityProtocol::SSL,
+            correlation_info: None,
+        },
+        routing_token: token,
+    };
+    let encoded = ironrdp_core::encode_vec(&X224(request.clone())).expect("encode connection request");
+    let decoded = ironrdp_core::decode::<X224<ConnectionRequestWithOpaqueRoutingToken>>(&encoded)
+        .expect("decode connection request");
+    assert_eq!(decoded.0, request);
 
     let oversized = OpaqueRoutingToken("x".repeat(ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH + 1));
     let mut buffer = vec![0; oversized.size()];

--- a/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
@@ -453,6 +453,23 @@ fn ready_audio_format_v6_restarts_negotiation() {
     assert!(matches!(confirm, pdu::ClientAudioOutputPdu::WaveConfirm(_)));
 }
 
+#[test]
+fn configured_quality_mode_is_sent_to_version_six_server() {
+    let backend = RecordingBackend::with_formats(vec![pcm(44100, 2)]);
+    let mut client = Rdpsnd::new(Box::new(backend)).with_quality_mode(pdu::QualityMode::Medium);
+
+    let responses = client
+        .process(&encoded_server_formats(pdu::Version::V6))
+        .expect("negotiate audio formats");
+    let encoded = responses[1].encode_unframed_pdu().expect("encode quality mode");
+    let pdu::ClientAudioOutputPdu::QualityMode(quality) =
+        decode::<pdu::ClientAudioOutputPdu>(&encoded).expect("decode quality mode")
+    else {
+        panic!("expected quality mode");
+    };
+    assert_eq!(quality.quality_mode, pdu::QualityMode::Medium);
+}
+
 // Renegotiation with version < V6 should not send QualityMode.
 #[test]
 fn ready_audio_format_v5_skips_quality_mode() {

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use ironrdp_cfg::PropertySetExt as _;
-use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode};
+use ironrdp_client::config::{AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode};
 use ironrdp_pdu::gcc::{ClientMonitorData, Monitor, MonitorFlags};
+use ironrdp_pdu::nego::NegoRequestData;
 use ironrdp_pdu::rdp::capability_sets::{MajorPlatformType, RailSupportLevel};
 use ironrdp_viewer::cli::parse_config_from;
 use uuid::Uuid;
@@ -351,6 +352,9 @@ fn generic_builder_options_reach_connector_configuration() {
         .with_performance_flags(performance_flags)
         .with_alternate_shell("powershell.exe")
         .with_work_dir("C:\\Users\\test-user")
+        .with_load_balance_info("tsv://MS Terminal Services Plugin.1.collection")
+        .with_administrative_session(true)
+        .with_audio_quality_mode(AudioQualityMode::Dynamic)
         .build()
         .expect("valid generic configuration");
 
@@ -367,6 +371,40 @@ fn generic_builder_options_reach_connector_configuration() {
     assert_eq!(config.connector().performance_flags, performance_flags);
     assert_eq!(config.connector().alternate_shell, "powershell.exe");
     assert_eq!(config.connector().work_dir, "C:\\Users\\test-user");
+    assert!(matches!(
+        config.connector().request_data.as_ref(),
+        Some(NegoRequestData::RoutingToken(token))
+            if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
+    ));
+    assert!(config.administrative_session());
+    assert_eq!(config.audio_quality_mode(), AudioQualityMode::Dynamic);
+    assert_eq!(
+        config.properties().get::<&str>("loadbalanceinfo"),
+        Some("tsv://MS Terminal Services Plugin.1.collection")
+    );
+    assert_eq!(config.properties().get::<bool>("administrative session"), Some(true));
+    assert_eq!(config.properties().get::<u32>("audioqualitymode"), Some(0));
+}
+
+#[test]
+fn rdp_file_maps_routing_admin_and_audio_quality_settings() {
+    let config = parse_config_from_rdp(
+        "full address:s:rdp.example.com\n\
+         username:s:test-user\n\
+         ClearTextPassword:s:test-pass\n\
+         loadbalanceinfo:s:tsv://MS Terminal Services Plugin.1.collection\n\
+         administrative session:i:1\n\
+         audioqualitymode:i:1\n",
+        &[],
+    );
+
+    assert!(matches!(
+        config.connector().request_data.as_ref(),
+        Some(NegoRequestData::RoutingToken(token))
+            if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
+    ));
+    assert!(config.administrative_session());
+    assert_eq!(config.audio_quality_mode(), AudioQualityMode::Medium);
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_client::config::{AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode};
 use ironrdp_pdu::gcc::{ClientMonitorData, Monitor, MonitorFlags};
-use ironrdp_pdu::nego::NegoRequestData;
 use ironrdp_pdu::rdp::capability_sets::{MajorPlatformType, RailSupportLevel};
 use ironrdp_viewer::cli::parse_config_from;
 use uuid::Uuid;
@@ -371,11 +370,10 @@ fn generic_builder_options_reach_connector_configuration() {
     assert_eq!(config.connector().performance_flags, performance_flags);
     assert_eq!(config.connector().alternate_shell, "powershell.exe");
     assert_eq!(config.connector().work_dir, "C:\\Users\\test-user");
-    assert!(matches!(
-        config.connector().request_data.as_ref(),
-        Some(NegoRequestData::OpaqueRoutingToken(token))
-            if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
-    ));
+    assert_eq!(
+        config.load_balance_info(),
+        Some("tsv://MS Terminal Services Plugin.1.collection")
+    );
     assert!(config.administrative_session());
     assert_eq!(config.audio_quality_mode(), AudioQualityMode::Dynamic);
     assert_eq!(
@@ -398,11 +396,10 @@ fn rdp_file_maps_routing_admin_and_audio_quality_settings() {
         &[],
     );
 
-    assert!(matches!(
-        config.connector().request_data.as_ref(),
-        Some(NegoRequestData::OpaqueRoutingToken(token))
-            if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
-    ));
+    assert_eq!(
+        config.load_balance_info(),
+        Some("tsv://MS Terminal Services Plugin.1.collection")
+    );
     assert!(config.administrative_session());
     assert_eq!(config.audio_quality_mode(), AudioQualityMode::Medium);
 }
@@ -427,7 +424,7 @@ fn empty_rdp_load_balance_info_clears_an_existing_token() {
             .build()
             .expect("valid configuration without a routing token");
 
-        assert!(config.connector().request_data.is_none());
+        assert!(config.load_balance_info().is_none());
     }
 }
 

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -373,7 +373,7 @@ fn generic_builder_options_reach_connector_configuration() {
     assert_eq!(config.connector().work_dir, "C:\\Users\\test-user");
     assert!(matches!(
         config.connector().request_data.as_ref(),
-        Some(NegoRequestData::RoutingToken(token))
+        Some(NegoRequestData::OpaqueRoutingToken(token))
             if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
     ));
     assert!(config.administrative_session());
@@ -400,7 +400,7 @@ fn rdp_file_maps_routing_admin_and_audio_quality_settings() {
 
     assert!(matches!(
         config.connector().request_data.as_ref(),
-        Some(NegoRequestData::RoutingToken(token))
+        Some(NegoRequestData::OpaqueRoutingToken(token))
             if token.0 == "tsv://MS Terminal Services Plugin.1.collection"
     ));
     assert!(config.administrative_session());

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -408,6 +408,30 @@ fn rdp_file_maps_routing_admin_and_audio_quality_settings() {
 }
 
 #[test]
+fn empty_rdp_load_balance_info_clears_an_existing_token() {
+    for value in ["", "\r\n"] {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.insert("loadbalanceinfo", value);
+
+        let config = ConfigBuilder::new()
+            .with_destination(Destination::from_parts("rdp.example.com", 3389))
+            .with_username("test-user")
+            .with_password("test-pass")
+            .with_client_build(1)
+            .with_client_dir("C:\\Windows\\System32")
+            .with_client_name("ironrdp-tests")
+            .with_platform(MajorPlatformType::WINDOWS)
+            .with_load_balance_info("tsv://existing")
+            .with_property_set(&properties)
+            .expect("valid empty load-balance property")
+            .build()
+            .expect("valid configuration without a routing token");
+
+        assert!(config.connector().request_data.is_none());
+    }
+}
+
+#[test]
 fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
     let default_config = parse_config_from_rdp(
         "full address:s:rdp.example.com\nusername:s:test-user\nClearTextPassword:s:test-pass\n",


### PR DESCRIPTION
Wire administrative-session GCC data, opaque load-balance routing tokens, and RDPSND quality selection through the ActiveX settings objects and client configuration.

Keep unrelated transport, cache, video, device, and security policy slots as explicit E_NOTIMPL failures.