### PR TITLE
feat(server): wire RdpdrServer into ironrdp-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
  "ironrdp-graphics",
  "ironrdp-nscodec",
  "ironrdp-pdu",
+ "ironrdp-rdpdr",
  "ironrdp-rdpei",
  "ironrdp-rdpeusb",
  "ironrdp-rdpsnd",

--- a/crates/ironrdp-rdpdr/src/server.rs
+++ b/crates/ironrdp-rdpdr/src/server.rs
@@ -323,6 +323,98 @@ enum RdpdrServerState {
     Active,
 }
 
+/// Message sent by the event loop to trigger server-initiated drive I/O.
+///
+/// One variant per [`RdpdrServer`] `drive_*` method (`Create` for `drive_create`,
+/// `Read` for `drive_read`, and so on); each variant's fields match that method's
+/// parameters exactly, `path: impl Into<String>` parameters included as plain
+/// `String` since an enum field can't be generic. Mirrors
+/// `RdpsndServerMessage`'s convention of dropping the channel-name prefix from
+/// variant names, since the enum itself is already `RdpdrServerMessage`.
+#[derive(Debug, Clone)]
+pub enum RdpdrServerMessage {
+    Create {
+        device_id: u32,
+        path: String,
+        desired_access: DesiredAccess,
+        create_disposition: CreateDisposition,
+        create_options: CreateOptions,
+    },
+    Read {
+        device_id: u32,
+        file_id: u32,
+        length: u32,
+        offset: u64,
+    },
+    Write {
+        device_id: u32,
+        file_id: u32,
+        data: Vec<u8>,
+        offset: u64,
+    },
+    Close {
+        device_id: u32,
+        file_id: u32,
+    },
+    FlushBuffers {
+        device_id: u32,
+        file_id: u32,
+    },
+    QueryInformation {
+        device_id: u32,
+        file_id: u32,
+        info_class: FileInformationClassLevel,
+    },
+    SetInformation {
+        device_id: u32,
+        file_id: u32,
+        set_buffer: FileInformationClass,
+    },
+    QueryDirectory {
+        device_id: u32,
+        file_id: u32,
+        info_class: FileInformationClassLevel,
+        path: String,
+        initial_query: bool,
+    },
+    NotifyChangeDirectory {
+        device_id: u32,
+        file_id: u32,
+        watch_tree: bool,
+        completion_filter: u32,
+    },
+    QueryVolumeInformation {
+        device_id: u32,
+        file_id: u32,
+        fs_info_class: FileSystemInformationClassLevel,
+    },
+    LockControl {
+        device_id: u32,
+        file_id: u32,
+        operation: LockOperation,
+        wait: bool,
+        locks: Vec<RdpLockInfo>,
+    },
+    QuerySecurity {
+        device_id: u32,
+        file_id: u32,
+        security_information: SecurityInformation,
+    },
+    SetSecurity {
+        device_id: u32,
+        file_id: u32,
+        security_information: SecurityInformation,
+        security_descriptor: Vec<u8>,
+    },
+    DeviceControl {
+        device_id: u32,
+        file_id: u32,
+        io_control_code: u32,
+        input_buffer: Vec<u8>,
+        output_buffer_length: u32,
+    },
+}
+
 /// Server-side [\[MS-RDPEFS\]] channel handler.
 ///
 /// Initiates the RDPDR handshake, tracks client-announced devices, and sends drive

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -54,6 +54,7 @@ ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8" } # public
 ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.10", features = ["reqwest"] }
 ironrdp-acceptor = { path = "../ironrdp-acceptor", version = "0.10" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
+ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9" } # public
 ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1" } # public
 ironrdp-rdpeusb = { path = "../ironrdp-rdpeusb", version = "0.1", optional = true }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -18,7 +18,7 @@ use super::server::{
 use crate::error::ServerResult;
 #[cfg(feature = "usb")]
 use crate::urbdrc::DeviceFactory;
-use crate::{DisplayUpdate, RdpServerDisplayUpdates, RdpeiServerFactory, SoundServerFactory};
+use crate::{DisplayUpdate, RdpServerDisplayUpdates, RdpdrServerFactory, RdpeiServerFactory, SoundServerFactory};
 
 pub struct WantsAddr {}
 pub struct WantsSecurity {
@@ -44,6 +44,7 @@ pub struct BuilderDone {
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
     sound_factory: Option<Box<dyn SoundServerFactory>>,
     rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
+    rdpdr_factory: Option<Box<dyn RdpdrServerFactory>>,
     connection_handler: Option<Box<dyn ConnectionHandler>>,
     credential_validator: Option<Arc<dyn CredentialValidator>>,
     #[cfg(feature = "egfx")]
@@ -152,6 +153,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 sound_factory: None,
                 cliprdr_factory: None,
                 rdpei_factory: None,
+                rdpdr_factory: None,
                 connection_handler: None,
                 credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
@@ -183,6 +185,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 sound_factory: None,
                 cliprdr_factory: None,
                 rdpei_factory: None,
+                rdpdr_factory: None,
                 connection_handler: None,
                 credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
@@ -224,6 +227,11 @@ impl RdpServerBuilder<BuilderDone> {
     /// Configure MS-RDPEI (multitouch and pen input over a dynamic channel).
     pub fn with_rdpei_factory(mut self, rdpei_factory: Option<Box<dyn RdpeiServerFactory>>) -> Self {
         self.state.rdpei_factory = rdpei_factory;
+        self
+    }
+
+    pub fn with_rdpdr_factory(mut self, rdpdr_factory: Option<Box<dyn RdpdrServerFactory>>) -> Self {
+        self.state.rdpdr_factory = rdpdr_factory;
         self
     }
 
@@ -441,6 +449,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.sound_factory,
             self.state.cliprdr_factory,
             self.state.rdpei_factory,
+            self.state.rdpdr_factory,
             self.state.connection_handler,
             #[cfg(feature = "egfx")]
             self.state.gfx_factory,

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -17,6 +17,7 @@ mod gfx;
 mod handler;
 #[cfg(feature = "helper")]
 mod helper;
+mod rdpdr;
 mod rdpei;
 mod server;
 mod sound;
@@ -39,6 +40,7 @@ pub use ironrdp_acceptor::Acceptor;
 pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 #[cfg(feature = "usb")]
 pub use ironrdp_rdpeusb::io::{CompletionData, DeviceAnnounce, DeviceText, InternalIoControlPacket};
+pub use rdpdr::{NoopRdpdrServerBackend, RdpdrServerBackend, RdpdrServerFactory, RdpdrServerMessage};
 pub use rdpei::{
     CsReadyFlags, CsReadyPdu, DismissHoveringTouchContactPdu, PenContact, PenContactDataFlags, PenContactFields,
     PenContactFlags, PenEventPdu, PenFlags, PenFrame, RdpInputProtocolVersion, RdpeiHandler, RdpeiServer,

--- a/crates/ironrdp-server/src/rdpdr.rs
+++ b/crates/ironrdp-server/src/rdpdr.rs
@@ -1,0 +1,7 @@
+pub use ironrdp_rdpdr::server::{NoopRdpdrServerBackend, RdpdrServerBackend, RdpdrServerMessage};
+
+use crate::ServerEventSender;
+
+pub trait RdpdrServerFactory: ServerEventSender {
+    fn build_backend(&self) -> Box<dyn RdpdrServerBackend>;
+}

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -34,12 +34,14 @@ use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlPdu};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{Action, PduResult, decode_err, mcs, nego, rdp};
+use ironrdp_rdpdr as rdpdr;
 #[cfg(feature = "usb")]
 use ironrdp_rdpeusb::io::RequestId;
 use ironrdp_rdpsnd as rdpsnd;
 use ironrdp_svc::{ChannelFlags, StaticChannelId, StaticChannelSet, SvcProcessor, server_encode_svc_messages};
 use ironrdp_tokio::{FramedRead, FramedWrite, TokioFramed, split_tokio_framed, unsplit_tokio_framed};
 use rand::RngCore as _;
+use rdpdr::server::{RdpdrServer, RdpdrServerMessage};
 use rdpsnd::server::{RdpsndServer, RdpsndServerMessage};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio::net::TcpSocket;
@@ -63,7 +65,7 @@ use crate::urbdrc::{
     DeviceFactory, RawPending, ServerDeviceIoReq, UrbdrcDeviceServerMessage, UrbdrcServerMessage, UsbControlHandle,
     UsbDeviceHandle, UsbDeviceLifecycle,
 };
-use crate::{SoundServerFactory, builder, capabilities};
+use crate::{RdpdrServerFactory, SoundServerFactory, builder, capabilities};
 #[cfg(feature = "usb")]
 use ironrdp_rdpeusb::{InterfaceAlloc, io::CompletionData, server::UrbdrcControlServer, server::UrbdrcDeviceServer};
 
@@ -588,6 +590,7 @@ pub struct RdpServer {
     sound_factory: Option<Box<dyn SoundServerFactory>>,
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
     rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
+    rdpdr_factory: Option<Box<dyn RdpdrServerFactory>>,
     echo_handle: EchoServerHandle,
     #[cfg(feature = "egfx")]
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
@@ -676,6 +679,11 @@ impl AutoReconnectCookieHandle {
     /// The change takes effect only after the server handles this event. `None`
     /// then disables auto-reconnect and invalidates every cookie currently held
     /// by the server.
+    #[expect(
+        clippy::result_large_err,
+        reason = "SendError<ServerEvent> hands the whole event back on a closed channel; ServerEvent's size is \
+                  driven by its largest per-channel payload (RdpdrServerMessage), not by anything this method does"
+    )]
     pub fn set(
         &self,
         cookie: Option<rdp::session_info::ServerAutoReconnect>,
@@ -688,6 +696,7 @@ pub enum ServerEvent {
     Quit(String),
     Clipboard(ClipboardMessage),
     Rdpsnd(RdpsndServerMessage),
+    Rdpdr(RdpdrServerMessage),
     Echo(EchoServerMessage),
     SetCredentials(Credentials),
     /// Replace or clear the Server Auto-Reconnect Cookie.
@@ -716,6 +725,7 @@ impl fmt::Debug for ServerEvent {
             Self::Quit(reason) => f.debug_tuple("Quit").field(reason).finish(),
             Self::Clipboard(..) => f.write_str("Clipboard(..)"),
             Self::Rdpsnd(..) => f.write_str("Rdpsnd(..)"),
+            Self::Rdpdr(..) => f.write_str("Rdpdr(..)"),
             Self::Echo(..) => f.write_str("Echo(..)"),
             Self::SetCredentials(..) => f.write_str("SetCredentials(..)"),
             Self::SetAutoReconnectCookie(Some(..)) => f.write_str("SetAutoReconnectCookie(Some(..))"),
@@ -760,6 +770,7 @@ impl RdpServer {
         mut sound_factory: Option<Box<dyn SoundServerFactory>>,
         mut cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
         mut rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
+        mut rdpdr_factory: Option<Box<dyn RdpdrServerFactory>>,
         connection_handler: Option<Box<dyn ConnectionHandler>>,
         #[cfg(feature = "egfx")] mut gfx_factory: Option<Box<dyn GfxServerFactory>>,
         display_suppressed: Option<Arc<AtomicBool>>,
@@ -778,6 +789,9 @@ impl RdpServer {
         if let Some(rdpei) = rdpei_factory.as_mut() {
             rdpei.set_sender(ev_sender.clone());
         }
+        if let Some(rdpdr) = rdpdr_factory.as_mut() {
+            rdpdr.set_sender(ev_sender.clone());
+        }
         #[cfg(feature = "egfx")]
         if let Some(gfx) = gfx_factory.as_mut() {
             gfx.set_sender(ev_sender.clone());
@@ -792,6 +806,7 @@ impl RdpServer {
             sound_factory,
             cliprdr_factory,
             rdpei_factory,
+            rdpdr_factory,
             echo_handle: EchoServerHandle::new(ev_sender.clone()),
             #[cfg(feature = "egfx")]
             gfx_factory,
@@ -1164,6 +1179,12 @@ impl RdpServer {
             let backend = factory.build_backend();
 
             acceptor.attach_static_channel(RdpsndServer::new(backend));
+        }
+
+        if let Some(factory) = self.rdpdr_factory.as_deref() {
+            let backend = factory.build_backend();
+
+            acceptor.attach_static_channel(RdpdrServer::new(backend));
         }
 
         let dcs_backend = DisplayControlBackend::new(Arc::clone(&self.display));
@@ -1672,6 +1693,106 @@ impl RdpServer {
                         .ok_or_else(|| ServerError::channel("SVC channel not found"))?;
                     let data = server_encode_svc_messages(msgs.into(), channel_id, user_channel_id)
                         .map_err(ServerError::encode)?;
+                    writer
+                        .write_all(&data)
+                        .await
+                        .map_err(|e| ServerError::io("write_all", e))?;
+                }
+                ServerEvent::Rdpdr(msg) => {
+                    let Some(rdpdr) = self.get_svc_processor::<RdpdrServer>() else {
+                        warn!("No rdpdr channel, dropping event");
+                        continue;
+                    };
+                    let msgs = match msg {
+                        RdpdrServerMessage::Create {
+                            device_id,
+                            path,
+                            desired_access,
+                            create_disposition,
+                            create_options,
+                        } => rdpdr.drive_create(device_id, path, desired_access, create_disposition, create_options),
+                        RdpdrServerMessage::Read {
+                            device_id,
+                            file_id,
+                            length,
+                            offset,
+                        } => rdpdr.drive_read(device_id, file_id, length, offset),
+                        RdpdrServerMessage::Write {
+                            device_id,
+                            file_id,
+                            data,
+                            offset,
+                        } => rdpdr.drive_write(device_id, file_id, data, offset),
+                        RdpdrServerMessage::Close { device_id, file_id } => rdpdr.drive_close(device_id, file_id),
+                        RdpdrServerMessage::FlushBuffers { device_id, file_id } => {
+                            rdpdr.drive_flush_buffers(device_id, file_id)
+                        }
+                        RdpdrServerMessage::QueryInformation {
+                            device_id,
+                            file_id,
+                            info_class,
+                        } => rdpdr.drive_query_information(device_id, file_id, info_class),
+                        RdpdrServerMessage::SetInformation {
+                            device_id,
+                            file_id,
+                            set_buffer,
+                        } => rdpdr.drive_set_information(device_id, file_id, set_buffer),
+                        RdpdrServerMessage::QueryDirectory {
+                            device_id,
+                            file_id,
+                            info_class,
+                            path,
+                            initial_query,
+                        } => rdpdr.drive_query_directory(device_id, file_id, info_class, path, initial_query),
+                        RdpdrServerMessage::NotifyChangeDirectory {
+                            device_id,
+                            file_id,
+                            watch_tree,
+                            completion_filter,
+                        } => rdpdr.drive_notify_change_directory(device_id, file_id, watch_tree, completion_filter),
+                        RdpdrServerMessage::QueryVolumeInformation {
+                            device_id,
+                            file_id,
+                            fs_info_class,
+                        } => rdpdr.drive_query_volume_information(device_id, file_id, fs_info_class),
+                        RdpdrServerMessage::LockControl {
+                            device_id,
+                            file_id,
+                            operation,
+                            wait,
+                            locks,
+                        } => rdpdr.drive_lock_control(device_id, file_id, operation, wait, locks),
+                        RdpdrServerMessage::QuerySecurity {
+                            device_id,
+                            file_id,
+                            security_information,
+                        } => rdpdr.drive_query_security(device_id, file_id, security_information),
+                        RdpdrServerMessage::SetSecurity {
+                            device_id,
+                            file_id,
+                            security_information,
+                            security_descriptor,
+                        } => rdpdr.drive_set_security(device_id, file_id, security_information, security_descriptor),
+                        RdpdrServerMessage::DeviceControl {
+                            device_id,
+                            file_id,
+                            io_control_code,
+                            input_buffer,
+                            output_buffer_length,
+                        } => rdpdr.drive_device_control(
+                            device_id,
+                            file_id,
+                            io_control_code,
+                            input_buffer,
+                            output_buffer_length,
+                        ),
+                    }
+                    .map_err_kind("failed to send rdpdr event", ServerErrorKind::Pdu)?;
+                    let channel_id = self
+                        .get_channel_id_by_type::<RdpdrServer>()
+                        .ok_or_else(|| ServerError::channel("SVC channel not found"))?;
+                    let data =
+                        server_encode_svc_messages(msgs, channel_id, user_channel_id).map_err(ServerError::encode)?;
                     writer
                         .write_all(&data)
                         .await

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -2,5 +2,6 @@ mod acceptor;
 mod autodetect;
 mod credential_validator;
 mod fast_path;
+mod rdpdr;
 mod rdpei;
 mod remotefx_entropy_coder;

--- a/crates/ironrdp-testsuite-core/tests/server/rdpdr.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/rdpdr.rs
@@ -1,0 +1,122 @@
+use ironrdp_rdpdr::pdu::efs::{
+    CreateDisposition, CreateOptions, DesiredAccess, FileDispositionInformation, FileInformationClass,
+    FileInformationClassLevel, FileSystemInformationClassLevel, LockOperation, RdpLockInfo, SecurityInformation,
+};
+use ironrdp_server::RdpdrServerMessage;
+
+/// One value per `RdpdrServerMessage` variant, matching `ironrdp-rdpdr::server::RdpdrServer`'s
+/// fourteen `drive_*` methods. `RdpServer::dispatch_server_events` matches this enum
+/// exhaustively (no wildcard arm) to route each variant to its `drive_*` call; this test
+/// exercises the same exhaustive match here so that a future variant added to one side
+/// without the other fails to compile instead of silently falling through a wildcard.
+fn all_variants() -> Vec<RdpdrServerMessage> {
+    vec![
+        RdpdrServerMessage::Create {
+            device_id: 1,
+            path: "\\file.txt".to_owned(),
+            desired_access: DesiredAccess::empty(),
+            create_disposition: CreateDisposition::FILE_OPEN,
+            create_options: CreateOptions::empty(),
+        },
+        RdpdrServerMessage::Read {
+            device_id: 1,
+            file_id: 2,
+            length: 4096,
+            offset: 0,
+        },
+        RdpdrServerMessage::Write {
+            device_id: 1,
+            file_id: 2,
+            data: vec![1, 2, 3],
+            offset: 0,
+        },
+        RdpdrServerMessage::Close {
+            device_id: 1,
+            file_id: 2,
+        },
+        RdpdrServerMessage::FlushBuffers {
+            device_id: 1,
+            file_id: 2,
+        },
+        RdpdrServerMessage::QueryInformation {
+            device_id: 1,
+            file_id: 2,
+            info_class: FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        },
+        RdpdrServerMessage::SetInformation {
+            device_id: 1,
+            file_id: 2,
+            set_buffer: FileInformationClass::Disposition(FileDispositionInformation { delete_pending: 1 }),
+        },
+        RdpdrServerMessage::QueryDirectory {
+            device_id: 1,
+            file_id: 2,
+            info_class: FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+            path: "\\".to_owned(),
+            initial_query: true,
+        },
+        RdpdrServerMessage::NotifyChangeDirectory {
+            device_id: 1,
+            file_id: 2,
+            watch_tree: false,
+            completion_filter: 0,
+        },
+        RdpdrServerMessage::QueryVolumeInformation {
+            device_id: 1,
+            file_id: 2,
+            fs_info_class: FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION,
+        },
+        RdpdrServerMessage::LockControl {
+            device_id: 1,
+            file_id: 2,
+            operation: LockOperation::Shared,
+            wait: false,
+            locks: vec![RdpLockInfo { length: 1, offset: 0 }],
+        },
+        RdpdrServerMessage::QuerySecurity {
+            device_id: 1,
+            file_id: 2,
+            security_information: SecurityInformation::empty(),
+        },
+        RdpdrServerMessage::SetSecurity {
+            device_id: 1,
+            file_id: 2,
+            security_information: SecurityInformation::empty(),
+            security_descriptor: vec![0u8; 4],
+        },
+        RdpdrServerMessage::DeviceControl {
+            device_id: 1,
+            file_id: 2,
+            io_control_code: 0,
+            input_buffer: Vec::new(),
+            output_buffer_length: 0,
+        },
+    ]
+}
+
+/// Every variant clones and formats without panicking, and matches exhaustively (no
+/// wildcard arm) against the fourteen variants above.
+#[test]
+fn rdpdr_server_message_variants_clone_debug_and_match_exhaustively() {
+    for message in all_variants() {
+        let cloned = message.clone();
+        let _ = format!("{cloned:?}");
+
+        match cloned {
+            RdpdrServerMessage::Create { .. }
+            | RdpdrServerMessage::Read { .. }
+            | RdpdrServerMessage::Write { .. }
+            | RdpdrServerMessage::Close { .. }
+            | RdpdrServerMessage::FlushBuffers { .. }
+            | RdpdrServerMessage::QueryInformation { .. }
+            | RdpdrServerMessage::SetInformation { .. }
+            | RdpdrServerMessage::QueryDirectory { .. }
+            | RdpdrServerMessage::NotifyChangeDirectory { .. }
+            | RdpdrServerMessage::QueryVolumeInformation { .. }
+            | RdpdrServerMessage::LockControl { .. }
+            | RdpdrServerMessage::QuerySecurity { .. }
+            | RdpdrServerMessage::SetSecurity { .. }
+            | RdpdrServerMessage::DeviceControl { .. } => {}
+        }
+    }
+}


### PR DESCRIPTION
## Depends on #1783

Stacked on `feat/rdpdr-server-core` (#1783), which itself depends on #1779. Neither PDU codec bidirectionality nor RdpdrServer's orchestration is reachable from ironrdp-server without this.

## Summary

- Wires RdpdrServer into ironrdp-server, mirroring SoundServerFactory and RdpsndServer exactly. RDPDR is a static virtual channel with the same build-a-backend-then-attach shape as audio, not a dynamic channel like EGFX and not a combined backend-plus-factory like clipboard.
- RdpdrServerFactory extends the ServerEventSender supertrait rather than inlining a set_sender method, matching the live convention SoundServerFactory and CliprdrServerFactory already use. build_backend is named to match SoundServerFactory::build_backend.
- Server-initiated drive I/O needs the same async relay every other channel uses. Added RdpdrServerMessage, one variant per RdpdrServer drive_* method, and a ServerEvent::Rdpdr(RdpdrServerMessage) arm in dispatch_server_events that looks up the live RdpdrServer instance, calls the matching drive_* method, and writes the encoded result, the same shape as the existing Rdpsnd arm.
- Adding a fourteen-variant enum to ServerEvent pushed AutoReconnectCookieHandle::set's Result past clippy's result_large_err threshold, a method this change otherwise has nothing to do with. Suppressed locally with an explained reason rather than boxing the Rdpdr payload, which would have changed ServerEvent's public shape for a size concern from one unrelated method.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Added an exhaustive-match test over every RdpdrServerMessage variant in ironrdp-testsuite-core/tests/server/rdpdr.rs (no wildcard arm), so a future variant added to one side of the dispatch without the other fails to compile rather than silently falling through.

## Notes

This closes out the RDPDR server-side contribution's three-part sequence (PDU codec, RdpdrServer orchestration, ironrdp-server wiring).
