### PR TITLE
fix(server): honor the client's negotiated pointer cache size

### DIFF
--- a/benches/src/perfenc.rs
+++ b/benches/src/perfenc.rs
@@ -59,8 +59,17 @@ async fn main() -> Result<(), anyhow::Error> {
         OptCodec::QoiZ => update_codecs.set_qoiz(Some(0)),
     };
 
-    let mut encoder = UpdateEncoder::new(DesktopSize { width, height }, flags, update_codecs, 8 * 1024 * 1024)
-        .context("failed to initialize update encoder")?;
+    // u16::MAX: this benchmark replays a fixed update file and isn't exercising the
+    // client capability gate, so don't let a default of 0 silently start dropping any
+    // pointer updates the replay file happens to contain.
+    let mut encoder = UpdateEncoder::new(
+        DesktopSize { width, height },
+        flags,
+        update_codecs,
+        8 * 1024 * 1024,
+        u16::MAX,
+    )
+    .context("failed to initialize update encoder")?;
 
     let mut total_raw = 0u64;
     let mut total_enc = 0u64;

--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -127,6 +127,11 @@ pub(crate) struct UpdateEncoder {
     /// oversized bitmaps into strips that fit within the limit when sent as
     /// uncompressed surface commands.
     max_request_size: usize,
+    /// Client's advertised New Pointer Update cache size (MS-RDPBCGR 2.2.7.1.5
+    /// `pointerCacheSize`). Zero means the client did not advertise support for the
+    /// New Pointer Update; `RGBAPointer`/`CachedPointer` emission is skipped in that
+    /// case rather than sending a PDU the client did not agree to accept.
+    pointer_cache_size: u16,
 }
 
 impl fmt::Debug for UpdateEncoder {
@@ -144,6 +149,7 @@ impl UpdateEncoder {
         surface_flags: CmdFlags,
         codecs: UpdateEncoderCodecs,
         max_request_size: u32,
+        pointer_cache_size: u16,
     ) -> ServerResult<Self> {
         let bitmap_updater = if surface_flags.contains(CmdFlags::SET_SURFACE_BITS) {
             match codecs {
@@ -179,6 +185,7 @@ impl UpdateEncoder {
             bitmap_updater: Some(bitmap_updater),
             max_request_size: usize::try_from(max_request_size)
                 .map_err(|e| ServerError::custom("max_request_size", e))?,
+            pointer_cache_size,
         })
     }
 
@@ -418,11 +425,25 @@ impl EncoderIter<'_> {
                         continue;
                     }
                     DisplayUpdate::PointerPosition(pos) => UpdateEncoder::pointer_position(pos),
-                    DisplayUpdate::RGBAPointer(ptr) => UpdateEncoder::rgba_pointer(ptr),
+                    DisplayUpdate::RGBAPointer(ptr) => {
+                        if encoder.pointer_cache_size == 0 {
+                            debug!("Dropping RGBAPointer update: client did not advertise New Pointer Update support");
+                            continue;
+                        }
+                        UpdateEncoder::rgba_pointer(ptr)
+                    }
                     DisplayUpdate::ColorPointer(ptr) => UpdateEncoder::color_pointer(ptr),
                     DisplayUpdate::HidePointer => UpdateEncoder::hide_pointer(),
                     DisplayUpdate::DefaultPointer => UpdateEncoder::default_pointer(),
-                    DisplayUpdate::CachedPointer(idx) => UpdateEncoder::cached_pointer(idx),
+                    DisplayUpdate::CachedPointer(idx) => {
+                        if encoder.pointer_cache_size == 0 {
+                            debug!(
+                                "Dropping CachedPointer update: client did not advertise New Pointer Update support"
+                            );
+                            continue;
+                        }
+                        UpdateEncoder::cached_pointer(idx)
+                    }
                     DisplayUpdate::Resize(_) => return None,
                 },
                 State::BitmapDiffs { diffs, bitmap, pos } => {

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -2261,6 +2261,7 @@ impl RdpServer {
 
         let mut update_codecs = UpdateEncoderCodecs::new();
         let mut surface_flags = CmdFlags::empty();
+        let mut pointer_cache_size: u16 = 0;
         for c in result.capabilities {
             match c {
                 CapabilitySet::General(c) => {
@@ -2344,12 +2345,28 @@ impl RdpServer {
                         }
                     }
                 }
+                CapabilitySet::Pointer(p) => {
+                    // MS-RDPBCGR 2.2.7.1.5: pointerCacheSize is the client's advertised cache
+                    // size for the New Pointer Update specifically (colorPointerCacheSize is
+                    // the separate, always-supported Color Pointer Update cache). A zero or
+                    // absent pointerCacheSize means the client did not advertise New Pointer
+                    // Update support at all, so `UpdateEncoder` must not emit RGBAPointer, and
+                    // must not reference a cache slot via CachedPointer either, since nothing
+                    // else in this crate populates that cache via the Color Pointer Update.
+                    pointer_cache_size = p.pointer_cache_size;
+                }
                 _ => {}
             }
         }
 
         let desktop_size = self.display.lock().await.size().await;
-        let encoder = UpdateEncoder::new(desktop_size, surface_flags, update_codecs, self.opts.max_request_size)?;
+        let encoder = UpdateEncoder::new(
+            desktop_size,
+            surface_flags,
+            update_codecs,
+            self.opts.max_request_size,
+            pointer_cache_size,
+        )?;
 
         self.send_next_auto_reconnect_cookie(writer, result.io_channel_id, result.user_channel_id)
             .await?;


### PR DESCRIPTION
## Summary

- MS-RDPBCGR 2.2.7.1.5 (Pointer Capability Set): pointerCacheSize is the client's advertised cache size for the New Pointer Update specifically (colorPointerCacheSize is the separate, always-supported Color Pointer Update cache). A zero or absent pointerCacheSize means the client did not advertise New Pointer Update support at all, and the server must not use it.
- client_accepted() already decodes the client's Pointer capability set correctly, but the value was discarded: CapabilitySet::Pointer(_) fell into a wildcard arm and never reached anything downstream. RGBAPointer and CachedPointer (the New Pointer Update and its cache-reference companion) were emitted unconditionally regardless of what the client actually negotiated.
- Threads the negotiated pointerCacheSize into UpdateEncoder, alongside the other capability-derived construction parameters (surface_flags, codecs) it already receives from the same capabilities loop. RGBAPointer and CachedPointer are now dropped with a debug log rather than encoded when pointerCacheSize is zero, the same drop-and-log shape the encoder already uses for a Bitmap update that exceeds the desktop size.
- ColorPointer is left alone: nothing in this crate currently constructs a ColorPointer update, so gating it on the separate colorPointerCacheSize field would be validation for a path that can't happen yet.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass.

## Notes

Found while scoping server-driven cursor shape support for a downstream embedder: RGBAPointer emission needs this gate to be spec-compliant before it can be used at all.
