### PR TITLE
fix(egfx): use exclusive AVC region bounds

### DIFF
--- a/crates/ironrdp-egfx/src/pdu/avc.rs
+++ b/crates/ironrdp-egfx/src/pdu/avc.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use bit_field::BitField as _;
 use bitflags::bitflags;
-use ironrdp_pdu::geometry::InclusiveRectangle;
+use ironrdp_pdu::geometry::ExclusiveRectangle;
 use ironrdp_pdu::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
     ensure_size, invalid_field_err,
@@ -77,7 +77,8 @@ impl<'de> Decode<'de> for QuantQuality {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Avc420BitmapStream<'a> {
-    pub rectangles: Vec<InclusiveRectangle>,
+    /// Region masks encoded as `RDPGFX_RECT16` with exclusive right/bottom bounds.
+    pub rectangles: Vec<ExclusiveRectangle>,
     pub quant_qual_vals: Vec<QuantQuality>,
     pub data: &'a [u8],
 }
@@ -138,13 +139,13 @@ impl<'de> Decode<'de> for Avc420BitmapStream<'de> {
         // malicious num_regions: each region needs at least one rectangle
         // (8 bytes) plus one QuantQuality entry (2 bytes). The actual read
         // loop will fail with NotEnoughBytes if num_regions is bogus.
-        let per_region = InclusiveRectangle::FIXED_PART_SIZE + QuantQuality::FIXED_PART_SIZE;
+        let per_region = ExclusiveRectangle::ENCODED_SIZE + QuantQuality::FIXED_PART_SIZE;
         let max_possible = src.len() / per_region;
         let bounded_capacity = num_regions_usize.min(max_possible);
         let mut rectangles = Vec::with_capacity(bounded_capacity);
         let mut quant_qual_vals = Vec::with_capacity(bounded_capacity);
         for _ in 0..num_regions {
-            rectangles.push(InclusiveRectangle::decode(src)?);
+            rectangles.push(ExclusiveRectangle::decode(src)?);
         }
         for _ in 0..num_regions {
             quant_qual_vals.push(QuantQuality::decode(src)?);
@@ -291,7 +292,7 @@ impl<'de> Decode<'de> for Avc444BitmapStream<'de> {
 /// // Create a region covering a 1920x1080 frame
 /// let region = Avc420Region::full_frame(1920, 1080, 22);
 /// assert_eq!(region.left, 0);
-/// assert_eq!(region.right, 1919);
+/// assert_eq!(region.right, 1920);
 /// ```
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -300,9 +301,9 @@ pub struct Avc420Region {
     pub left: u16,
     /// Top edge of the region (inclusive)
     pub top: u16,
-    /// Right edge of the region (inclusive)
+    /// Right edge of the region (exclusive)
     pub right: u16,
-    /// Bottom edge of the region (inclusive)
+    /// Bottom edge of the region (exclusive)
     pub bottom: u16,
     /// H.264 quantization parameter (0-51, lower = higher quality)
     pub quantization_parameter: u8,
@@ -323,8 +324,8 @@ impl Avc420Region {
         Self {
             left: 0,
             top: 0,
-            right: width.saturating_sub(1),
-            bottom: height.saturating_sub(1),
+            right: width,
+            bottom: height,
             quantization_parameter: qp,
             quality: 100,
         }
@@ -343,10 +344,10 @@ impl Avc420Region {
         }
     }
 
-    /// Convert to `InclusiveRectangle` for PDU encoding
+    /// Convert to the exclusive `RDPGFX_RECT16` representation for PDU encoding.
     #[must_use]
-    pub fn to_rectangle(&self) -> InclusiveRectangle {
-        InclusiveRectangle {
+    pub fn to_rectangle(&self) -> ExclusiveRectangle {
+        ExclusiveRectangle {
             left: self.left,
             top: self.top,
             right: self.right,
@@ -567,7 +568,7 @@ pub const fn align_to_16(dimension: u32) -> u32 {
 /// Panics if internal encoding fails (should not happen with valid inputs).
 #[must_use]
 pub fn encode_avc420_bitmap_stream(regions: &[Avc420Region], h264_data: &[u8]) -> Vec<u8> {
-    let rectangles: Vec<InclusiveRectangle> = regions.iter().map(Avc420Region::to_rectangle).collect();
+    let rectangles: Vec<ExclusiveRectangle> = regions.iter().map(Avc420Region::to_rectangle).collect();
 
     let quant_qual_vals: Vec<QuantQuality> = regions.iter().map(Avc420Region::to_quant_quality).collect();
 

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -1369,6 +1369,87 @@ impl GraphicsPipelineServer {
         chroma_regions: Option<&[Avc420Region]>,
         timestamp_ms: u32,
     ) -> Option<u32> {
+        let (encoding, stream2_data, stream2_regions) =
+            if let (Some(chroma_data), Some(chroma_regions)) = (chroma_data, chroma_regions) {
+                (Encoding::LUMA_AND_CHROMA, Some(chroma_data), Some(chroma_regions))
+            } else {
+                (Encoding::LUMA, None, None)
+            };
+
+        self.send_avc444_frame_with_encoding(
+            Codec1Type::Avc444,
+            surface_id,
+            encoding,
+            luma_data,
+            luma_regions,
+            stream2_data,
+            stream2_regions,
+            timestamp_ms,
+        )
+    }
+
+    /// Queue an H.264 AVC444v2 frame for transmission.
+    ///
+    /// `encoding` selects the AVC444v2 stream layout: LC=0 carries luma in
+    /// stream 1 and chroma in stream 2, LC=1 carries luma in stream 1, and LC=2
+    /// carries chroma in stream 1.
+    ///
+    /// Returns `Some(frame_id)` if queued, `None` if the stream shape is
+    /// invalid, AVC444 is not supported, or backpressure is active.
+    ///
+    /// [2.2.4.6 RFX_AVC444V2_BITMAP_STREAM]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/3b337b87-f478-4786-a63b-97794aa72075
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the public API mirrors the two AVC444v2 streams"
+    )]
+    pub fn send_avc444v2_frame(
+        &mut self,
+        surface_id: u16,
+        encoding: Encoding,
+        stream1_data: &[u8],
+        stream1_regions: &[Avc420Region],
+        stream2_data: Option<&[u8]>,
+        stream2_regions: Option<&[Avc420Region]>,
+        timestamp_ms: u32,
+    ) -> Option<u32> {
+        self.send_avc444_frame_with_encoding(
+            Codec1Type::Avc444v2,
+            surface_id,
+            encoding,
+            stream1_data,
+            stream1_regions,
+            stream2_data,
+            stream2_regions,
+            timestamp_ms,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the shared implementation receives both AVC444 streams"
+    )]
+    fn send_avc444_frame_with_encoding(
+        &mut self,
+        codec_id: Codec1Type,
+        surface_id: u16,
+        encoding: Encoding,
+        stream1_data: &[u8],
+        stream1_regions: &[Avc420Region],
+        stream2_data: Option<&[u8]>,
+        stream2_regions: Option<&[Avc420Region]>,
+        timestamp_ms: u32,
+    ) -> Option<u32> {
+        let valid_stream_shape = if encoding == Encoding::LUMA_AND_CHROMA {
+            stream2_data.is_some() && stream2_regions.is_some()
+        } else if encoding == Encoding::LUMA || encoding == Encoding::CHROMA {
+            stream2_data.is_none() && stream2_regions.is_none()
+        } else {
+            false
+        };
+        if !valid_stream_shape {
+            return None;
+        }
+
         if !self.is_ready() {
             return None;
         }
@@ -1385,29 +1466,28 @@ impl GraphicsPipelineServer {
         let timestamp = Self::make_timestamp(timestamp_ms);
         let frame_id = self.frames.begin_frame(timestamp);
 
-        let luma_rectangles: Vec<_> = luma_regions.iter().map(Avc420Region::to_rectangle).collect();
-        let luma_quant_vals: Vec<_> = luma_regions.iter().map(Avc420Region::to_quant_quality).collect();
+        let stream1_rectangles: Vec<_> = stream1_regions.iter().map(Avc420Region::to_rectangle).collect();
+        let stream1_quant_vals: Vec<_> = stream1_regions.iter().map(Avc420Region::to_quant_quality).collect();
 
         let stream1 = Avc420BitmapStream {
-            rectangles: luma_rectangles,
-            quant_qual_vals: luma_quant_vals,
-            data: luma_data,
+            rectangles: stream1_rectangles,
+            quant_qual_vals: stream1_quant_vals,
+            data: stream1_data,
         };
 
-        let (encoding, stream2) = if let (Some(chroma), Some(chroma_regs)) = (chroma_data, chroma_regions) {
-            let chroma_rectangles: Vec<_> = chroma_regs.iter().map(Avc420Region::to_rectangle).collect();
-            let chroma_quant_vals: Vec<_> = chroma_regs.iter().map(Avc420Region::to_quant_quality).collect();
+        let stream2 = if encoding == Encoding::LUMA_AND_CHROMA {
+            let stream2_data = stream2_data?;
+            let stream2_regions = stream2_regions?;
+            let stream2_rectangles: Vec<_> = stream2_regions.iter().map(Avc420Region::to_rectangle).collect();
+            let stream2_quant_vals: Vec<_> = stream2_regions.iter().map(Avc420Region::to_quant_quality).collect();
 
-            (
-                Encoding::LUMA_AND_CHROMA,
-                Some(Avc420BitmapStream {
-                    rectangles: chroma_rectangles,
-                    quant_qual_vals: chroma_quant_vals,
-                    data: chroma,
-                }),
-            )
+            Some(Avc420BitmapStream {
+                rectangles: stream2_rectangles,
+                quant_qual_vals: stream2_quant_vals,
+                data: stream2_data,
+            })
         } else {
-            (Encoding::LUMA, None)
+            None
         };
 
         let avc444_stream = Avc444BitmapStream {
@@ -1417,14 +1497,14 @@ impl GraphicsPipelineServer {
         };
 
         let encoded_stream = encode_avc444_bitmap_stream(&avc444_stream);
-        let target_rect = Self::compute_dest_rect(luma_regions, surface.width, surface.height);
+        let target_rect = Self::compute_dest_rect(stream1_regions, surface.width, surface.height);
 
         self.output_queue
             .push_back(GfxPdu::StartFrame(StartFramePdu { timestamp, frame_id }));
 
         self.output_queue.push_back(GfxPdu::WireToSurface1(WireToSurface1Pdu {
             surface_id,
-            codec_id: Codec1Type::Avc444,
+            codec_id,
             pixel_format: surface.pixel_format,
             destination_rectangle: target_rect,
             bitmap_data: encoded_stream,

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -1274,9 +1274,8 @@ impl GraphicsPipelineServer {
 
     /// Compute bounding rectangle from regions.
     ///
-    /// Avc420Region uses inclusive bounds; the wire format (RDPGFX_RECT16) is
-    /// exclusive, so the returned ExclusiveRectangle adds 1 to the max right
-    /// and bottom of the inclusive bounding box.
+    /// `Avc420Region` and the wire-format `RDPGFX_RECT16` both use exclusive
+    /// right and bottom bounds.
     fn compute_dest_rect(regions: &[Avc420Region], default_width: u16, default_height: u16) -> ExclusiveRectangle {
         if let Some(first) = regions.first() {
             let mut left = first.left;
@@ -1294,8 +1293,8 @@ impl GraphicsPipelineServer {
             ExclusiveRectangle {
                 left,
                 top,
-                right: right.saturating_add(1),
-                bottom: bottom.saturating_add(1),
+                right,
+                bottom,
             }
         } else {
             ExclusiveRectangle {

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -1496,7 +1496,11 @@ impl GraphicsPipelineServer {
         };
 
         let encoded_stream = encode_avc444_bitmap_stream(&avc444_stream);
-        let target_rect = Self::compute_dest_rect(stream1_regions, surface.width, surface.height);
+        let target_rect = if let Some(stream2_regions) = stream2_regions {
+            Self::compute_dest_rect_for_streams(stream1_regions, stream2_regions, surface.width, surface.height)
+        } else {
+            Self::compute_dest_rect(stream1_regions, surface.width, surface.height)
+        };
 
         self.output_queue
             .push_back(GfxPdu::StartFrame(StartFramePdu { timestamp, frame_id }));
@@ -1512,6 +1516,23 @@ impl GraphicsPipelineServer {
         self.output_queue.push_back(GfxPdu::EndFrame(EndFramePdu { frame_id }));
 
         Some(frame_id)
+    }
+
+    fn compute_dest_rect_for_streams(
+        stream1_regions: &[Avc420Region],
+        stream2_regions: &[Avc420Region],
+        default_width: u16,
+        default_height: u16,
+    ) -> ExclusiveRectangle {
+        let stream1 = Self::compute_dest_rect(stream1_regions, default_width, default_height);
+        let stream2 = Self::compute_dest_rect(stream2_regions, default_width, default_height);
+
+        ExclusiveRectangle {
+            left: stream1.left.min(stream2.left),
+            top: stream1.top.min(stream2.top),
+            right: stream1.right.max(stream2.right),
+            bottom: stream1.bottom.max(stream2.bottom),
+        }
     }
 
     /// Queue a pre-encoded RDP6 Planar bitmap stream for transmission via EGFX.

--- a/crates/ironrdp-testsuite-core/src/graphics_messages.rs
+++ b/crates/ironrdp-testsuite-core/src/graphics_messages.rs
@@ -9,7 +9,7 @@ use ironrdp_egfx::pdu::{
     SurfaceToSurfacePdu, Timestamp, WireToSurface1Pdu, WireToSurface2Pdu,
 };
 use ironrdp_pdu::gcc::{Monitor, MonitorFlags};
-use ironrdp_pdu::geometry::{ExclusiveRectangle, InclusiveRectangle};
+use ironrdp_pdu::geometry::ExclusiveRectangle;
 
 pub const WIRE_TO_SURFACE_1_BUFFER: [u8; 218] = [
     0x00, 0x00, 0x08, 0x00, 0x20, 0xa5, 0x03, 0xde, 0x02, 0xab, 0x03, 0xe7, 0x02, 0xc9, 0x00, 0x00, 0x00, 0x01, 0x0e,
@@ -438,7 +438,7 @@ pub static CACHE_IMPORT_REPLY: LazyLock<CacheImportReplyPdu> = LazyLock::new(|| 
 pub static AVC_444_BITMAP: LazyLock<Avc444BitmapStream<'static>> = LazyLock::new(|| Avc444BitmapStream {
     encoding: Encoding::CHROMA,
     stream1: Avc420BitmapStream {
-        rectangles: vec![InclusiveRectangle {
+        rectangles: vec![ExclusiveRectangle {
             left: 1792,
             top: 1056,
             right: 1808,

--- a/crates/ironrdp-testsuite-core/tests/egfx/avc.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/avc.rs
@@ -6,8 +6,8 @@ fn avc420_region_full_frame() {
     let region = Avc420Region::full_frame(1920, 1080, 22);
     assert_eq!(region.left, 0);
     assert_eq!(region.top, 0);
-    assert_eq!(region.right, 1919);
-    assert_eq!(region.bottom, 1079);
+    assert_eq!(region.right, 1920);
+    assert_eq!(region.bottom, 1080);
     assert_eq!(region.quantization_parameter, 22);
     assert_eq!(region.quality, 100);
 }

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -202,8 +202,8 @@ fn avc444v2_sender_preserves_codec_and_lc_wire_shape() {
 
     let stream1_data = [0x00, 0x00, 0x00, 0x01, 0x67];
     let stream2_data = [0x00, 0x00, 0x00, 0x01, 0x68];
-    let stream1_regions = [Avc420Region::full_frame(64, 64, 22)];
-    let stream2_regions = [Avc420Region::full_frame(64, 64, 24)];
+    let stream1_regions = [Avc420Region::new(0, 0, 32, 32, 22, 78)];
+    let stream2_regions = [Avc420Region::new(16, 8, 64, 48, 24, 76)];
     let cases = [
         (
             Encoding::LUMA_AND_CHROMA,
@@ -244,11 +244,15 @@ fn avc444v2_sender_preserves_codec_and_lc_wire_shape() {
         let stream = Avc444BitmapStream::decode(&mut cursor).expect("decode AVC444v2 bitmap stream");
         assert_eq!(stream.encoding, encoding);
         assert_eq!(stream.stream2.is_some(), encoding == Encoding::LUMA_AND_CHROMA);
-        assert_eq!(wire.destination_rectangle.right, 64);
-        assert_eq!(wire.destination_rectangle.bottom, 64);
-        assert_eq!(stream.stream1.rectangles[0], wire.destination_rectangle);
+        let expected_right = if encoding == Encoding::LUMA_AND_CHROMA { 64 } else { 32 };
+        let expected_bottom = if encoding == Encoding::LUMA_AND_CHROMA { 48 } else { 32 };
+        assert_eq!(wire.destination_rectangle.right, expected_right);
+        assert_eq!(wire.destination_rectangle.bottom, expected_bottom);
+        assert_eq!(stream.stream1.rectangles[0].right, 32);
+        assert_eq!(stream.stream1.rectangles[0].bottom, 32);
         if let Some(stream2) = stream.stream2 {
-            assert_eq!(stream2.rectangles[0], wire.destination_rectangle);
+            assert_eq!(stream2.rectangles[0].right, 64);
+            assert_eq!(stream2.rectangles[0].bottom, 48);
         }
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -149,6 +149,46 @@ fn test_server_not_ready_before_capabilities() {
 }
 
 #[test]
+fn avc420_sender_preserves_exclusive_metadata_and_destination_rectangles() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8_1 {
+        flags: CapabilitiesV81Flags::AVC420_ENABLED,
+    }]));
+    server
+        .process(0, &encode_pdu(&client_caps_pdu))
+        .expect("process capabilities");
+    let surface_id = server.create_surface(64, 64).expect("create surface");
+    server.drain_output();
+
+    let data = [0x00, 0x00, 0x00, 0x01, 0x67];
+    let regions = [Avc420Region::new(4, 6, 20, 22, 22, 78)];
+    server
+        .send_avc420_frame(surface_id, &data, &regions, 42)
+        .expect("queue AVC420 frame");
+
+    let output = server.drain_output();
+    let mut decompressor = Decompressor::new();
+    let encoded = encode_vec(output[1].as_ref()).expect("encode DVC message");
+    let mut decoded = Vec::new();
+    decompressor
+        .decompress(&encoded, &mut decoded)
+        .expect("decompress WireToSurface1");
+    let mut cursor = ReadCursor::new(&decoded);
+    let GfxPdu::WireToSurface1(wire) = GfxPdu::decode(&mut cursor).expect("decode WireToSurface1") else {
+        panic!("expected WireToSurface1");
+    };
+    assert_eq!(wire.destination_rectangle.left, 4);
+    assert_eq!(wire.destination_rectangle.top, 6);
+    assert_eq!(wire.destination_rectangle.right, 20);
+    assert_eq!(wire.destination_rectangle.bottom, 22);
+
+    let mut cursor = ReadCursor::new(&wire.bitmap_data);
+    let stream = ironrdp_egfx::pdu::Avc420BitmapStream::decode(&mut cursor).expect("decode AVC420 bitmap stream");
+    assert_eq!(stream.rectangles[0], wire.destination_rectangle);
+}
+
+#[test]
 fn avc444v2_sender_preserves_codec_and_lc_wire_shape() {
     let handler = Box::new(TestHandler::new());
     let mut server = GraphicsPipelineServer::new(handler);
@@ -204,6 +244,12 @@ fn avc444v2_sender_preserves_codec_and_lc_wire_shape() {
         let stream = Avc444BitmapStream::decode(&mut cursor).expect("decode AVC444v2 bitmap stream");
         assert_eq!(stream.encoding, encoding);
         assert_eq!(stream.stream2.is_some(), encoding == Encoding::LUMA_AND_CHROMA);
+        assert_eq!(wire.destination_rectangle.right, 64);
+        assert_eq!(wire.destination_rectangle.bottom, 64);
+        assert_eq!(stream.stream1.rectangles[0], wire.destination_rectangle);
+        if let Some(stream2) = stream.stream2 {
+            assert_eq!(stream2.rectangles[0], wire.destination_rectangle);
+        }
     }
 }
 

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -1,8 +1,8 @@
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor, encode_vec};
 use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_egfx::pdu::{
-    Avc420Region, CapabilitiesAdvertisePdu, CapabilitiesV8Flags, CapabilitiesV10Flags, CapabilitiesV81Flags,
-    CapabilitySet, Codec1Type, GfxPdu, PixelFormat,
+    Avc420Region, Avc444BitmapStream, CapabilitiesAdvertisePdu, CapabilitiesV8Flags, CapabilitiesV10Flags,
+    CapabilitiesV81Flags, CapabilitySet, Codec1Type, Encoding, GfxPdu, PixelFormat,
 };
 use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer, QoeMetrics, Surface};
 use ironrdp_graphics::zgfx::Decompressor;
@@ -146,6 +146,143 @@ fn test_server_not_ready_before_capabilities() {
 
     let result = server.send_avc420_frame(0, &h264_data, &regions, 0);
     assert!(result.is_none());
+}
+
+#[test]
+fn avc444v2_sender_preserves_codec_and_lc_wire_shape() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
+        flags: CapabilitiesV10Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    server.process(0, &payload).expect("process capabilities");
+    let surface_id = server.create_surface(64, 64).expect("create surface");
+    server.drain_output();
+
+    let stream1_data = [0x00, 0x00, 0x00, 0x01, 0x67];
+    let stream2_data = [0x00, 0x00, 0x00, 0x01, 0x68];
+    let stream1_regions = [Avc420Region::full_frame(64, 64, 22)];
+    let stream2_regions = [Avc420Region::full_frame(64, 64, 24)];
+    let cases = [
+        (
+            Encoding::LUMA_AND_CHROMA,
+            Some(stream2_data.as_slice()),
+            Some(stream2_regions.as_slice()),
+        ),
+        (Encoding::LUMA, None, None),
+        (Encoding::CHROMA, None, None),
+    ];
+
+    for (encoding, second_data, second_regions) in cases {
+        server
+            .send_avc444v2_frame(
+                surface_id,
+                encoding,
+                &stream1_data,
+                &stream1_regions,
+                second_data,
+                second_regions,
+                42,
+            )
+            .expect("queue AVC444v2 frame");
+
+        let output = server.drain_output();
+        let mut decompressor = Decompressor::new();
+        let encoded = encode_vec(output[1].as_ref()).expect("encode DVC message");
+        let mut decoded = Vec::new();
+        decompressor
+            .decompress(&encoded, &mut decoded)
+            .expect("decompress WireToSurface1");
+        let mut cursor = ReadCursor::new(&decoded);
+        let GfxPdu::WireToSurface1(wire) = GfxPdu::decode(&mut cursor).expect("decode WireToSurface1") else {
+            panic!("expected WireToSurface1");
+        };
+        assert_eq!(wire.codec_id, Codec1Type::Avc444v2);
+
+        let mut cursor = ReadCursor::new(&wire.bitmap_data);
+        let stream = Avc444BitmapStream::decode(&mut cursor).expect("decode AVC444v2 bitmap stream");
+        assert_eq!(stream.encoding, encoding);
+        assert_eq!(stream.stream2.is_some(), encoding == Encoding::LUMA_AND_CHROMA);
+    }
+}
+
+#[test]
+fn avc444_sender_preserves_existing_codec_and_stream_selection() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
+        flags: CapabilitiesV10Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    server.process(0, &payload).expect("process capabilities");
+    let surface_id = server.create_surface(64, 64).expect("create surface");
+    server.drain_output();
+
+    let luma_data = [0x00, 0x00, 0x00, 0x01, 0x67];
+    let chroma_data = [0x00, 0x00, 0x00, 0x01, 0x68];
+    let luma_regions = [Avc420Region::full_frame(64, 64, 22)];
+    let chroma_regions = [Avc420Region::full_frame(64, 64, 24)];
+    for (expected_encoding, second_data, second_regions) in [
+        (Encoding::LUMA, None, None),
+        (
+            Encoding::LUMA_AND_CHROMA,
+            Some(chroma_data.as_slice()),
+            Some(chroma_regions.as_slice()),
+        ),
+    ] {
+        server
+            .send_avc444_frame(surface_id, &luma_data, &luma_regions, second_data, second_regions, 42)
+            .expect("queue AVC444 frame");
+
+        let output = server.drain_output();
+        let mut decompressor = Decompressor::new();
+        let encoded = encode_vec(output[1].as_ref()).expect("encode DVC message");
+        let mut decoded = Vec::new();
+        decompressor
+            .decompress(&encoded, &mut decoded)
+            .expect("decompress WireToSurface1");
+        let mut cursor = ReadCursor::new(&decoded);
+        let GfxPdu::WireToSurface1(wire) = GfxPdu::decode(&mut cursor).expect("decode WireToSurface1") else {
+            panic!("expected WireToSurface1");
+        };
+        assert_eq!(wire.codec_id, Codec1Type::Avc444);
+
+        let mut cursor = ReadCursor::new(&wire.bitmap_data);
+        let stream = Avc444BitmapStream::decode(&mut cursor).expect("decode AVC444 bitmap stream");
+        assert_eq!(stream.encoding, expected_encoding);
+        assert_eq!(stream.stream2.is_some(), expected_encoding == Encoding::LUMA_AND_CHROMA);
+    }
+}
+
+#[test]
+fn avc444v2_sender_rejects_invalid_stream_shapes_without_queueing() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
+        flags: CapabilitiesV10Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    server.process(0, &payload).expect("process capabilities");
+    let surface_id = server.create_surface(64, 64).expect("create surface");
+    server.drain_output();
+
+    let data = [0x00, 0x00, 0x00, 0x01, 0x67];
+    let regions = [Avc420Region::full_frame(64, 64, 22)];
+    for (encoding, second_data, second_regions) in [
+        (Encoding::LUMA_AND_CHROMA, None, None),
+        (Encoding::LUMA, Some(data.as_slice()), Some(regions.as_slice())),
+        (Encoding::CHROMA, Some(data.as_slice()), Some(regions.as_slice())),
+        (Encoding::from_bits_retain(3), None, None),
+    ] {
+        assert!(
+            server
+                .send_avc444v2_frame(surface_id, encoding, &data, &regions, second_data, second_regions, 42,)
+                .is_none()
+        );
+        assert!(!server.has_pending_output());
+        assert_eq!(server.frames_in_flight(), 0);
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
MS-RDPEGFX 2.2.1.2 defines `RDPGFX_RECT16` with exclusive `right` and `bottom`, and 2.2.4.4.1 gives `regionRects` in `RFX_AVC420_METABLOCK` that same type. `Avc420Region` documented its edges as inclusive, `full_frame()` built `width - 1` / `height - 1`, and `to_rectangle()` handed those to an `InclusiveRectangle` that encoded them unchanged, so every `regionRects` entry went out a pixel short on the right and bottom edge. `GraphicsPipelineServer::compute_dest_rect()`, used for the `WireToSurface1` destination, does add that pixel back: the two call sites disagreed about whether the conversion had already happened.

`Avc420Region` is exclusive throughout now and `to_rectangle` produces an `ExclusiveRectangle`, so the asymmetric adjustment disappears. `fix(egfx): bound both AVC444 streams` then computes the destination rectangle from both streams rather than from the luma one, so a chroma region larger than luma is no longer cut short. `feat(egfx): add explicit AVC444v2 frame sender` separates the AVC444v2 path from AVC444; both fixes build on it.

What the defect costs: with `ironrdp-server` on master, Windows App on macOS drops the connection right after the encoder starts, the server reporting `peer closed connection without sending TLS close_notify`. Pinning the session resolution, so that no deactivation-reactivation happens at all, changes nothing. With these three commits the same server build and the same client run normally. FreeRDP-based clients accept the frames either way, which is why this shows only against the Microsoft client. That is not proof this field is the trigger - 2.2.4.4.1 also calls the metablock informational - only that the field is wrong on the wire and that these commits make that client work.

`avc.rs` lost its inline test module to #1736 while these sat in a fork, so the `full_frame` expectation is updated in `testsuite-core/tests/egfx/avc.rs` instead.

Please rebase-merge rather than squash. The three commits are @MuNeNiCK's with his authorship intact, and the breaking change is confined to the middle one; squashing would collapse both.

BREAKING CHANGE: `Avc420BitmapStream::rectangles` is now `Vec<ExclusiveRectangle>`, and `Avc420Region::to_rectangle` returns `ExclusiveRectangle`. Callers that build or match `InclusiveRectangle` there have to switch, and a region built with `Avc420Region::full_frame` no longer subtracts one from the width and height.

Issue: #1712
