### PR TITLE
fix(client): restore Noop RDPDR channel fallback, fixing audio regres…

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1402,7 +1402,14 @@ fn build_connector(
     }
 
     #[cfg(feature = "rdpdr")]
-    let rdpdr_channel = build_rdpdr_channel(rdpdr_factory, &config.channels.rdpdr, rdpdr_drives_allowed)?;
+    let rdpdr_channel =
+        build_rdpdr_channel(rdpdr_factory, &config.channels.rdpdr, rdpdr_drives_allowed)?.or_else(|| {
+            config
+                .channels
+                .rdpdr
+                .enabled
+                .then(|| ironrdp_rdpdr::Rdpdr::new(Box::new(ironrdp_rdpdr::NoopRdpdrBackend), "IronRDP".to_owned()))
+        });
 
     // Windows servers only issue RDPDR traffic when RDPSND is also advertised.
     #[cfg(any(feature = "sound", feature = "rdpdr"))]


### PR DESCRIPTION
…sion

Regression introduced in 1fbc9bab ("feat: wire RDPDR backends into client connections", #1600).

Before that commit, the RDPDR static channel was always attached (using NoopRdpdrBackend when no real backend was needed), regardless of whether a native RdpdrBackendFactory was available. #1600 changed this so the channel is only attached when build_rdpdr_channel() returns Some(_), i.e. when a factory is supplied and produces at least one device.

On platforms without a native RDPDR factory (currently: everything except Windows, since ironrdp-rdpdr-native is a target `cfg(windows)` dependencies entry and attach_windows_rdpdr_backend() is gated `#[cfg(windows)]`), rdpdr_factory is always None, so the RDPDR channel is now never attached at all.

This silently broke RDPSND audio playback on the client side: with the RDPDR channel entirely absent from the static channel set, the locally created "Remote Audio" playback device stopped appearing (confirmed via git bisect, first bad commit 1fbc9bab, reproduced on Linux). The sound feature itself, the rdpsnd_backend_kind() selection, and the enable_audio_playback flag in the Client Info PDU are unaffected by #1600 and behave the same before/after — only the presence of the RDPDR channel differs.

Fix: fall back to attaching Rdpdr::new(NoopRdpdrBackend, ...) whenever config.channels.rdpdr.enabled is true but build_rdpdr_channel() returned None, restoring pre-#1600 behavior on platforms without a native RDPDR factory.