### PR TITLE
perf(graphics): optimize RemoteFX decoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ These crates exist on disk but are not documented in `ARCHITECTURE.md`. Be aware
 - `ironrdp-rdpdr-native` — native RDPDR backend
 - `ironrdp-rdpsnd-native` — native RDPSND backend
 - `ironrdp-bench` — benchmarking harness
+- `ironrdp-rfxbench` — RemoteFX decode benchmarks and fixtures (native + WASM)
 - `iron-remote-desktop` (under `crates/`) — remote desktop abstractions
 
 ### Workspace Exclusions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,6 +3237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rfxbench"
+version = "0.0.0"
+dependencies = [
+ "criterion",
+ "ironrdp-core 0.2.1",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "ironrdp-session",
+]
+
+[[package]]
 name = "ironrdp-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7889,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "yuv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85a782d94ee43f078bcfd6fa82d4e6a5b2d1cfbbad168e4df5a9f7b39ef48c"
+checksum = "220655e1c245693beb13b377d3174b9efcb1645018d1d4ec53903fc211b135ae"
 dependencies = [
  "num-traits",
 ]

--- a/crates/ironrdp-graphics/Cargo.toml
+++ b/crates/ironrdp-graphics/Cargo.toml
@@ -25,7 +25,7 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } #
 byteorder = "1.5" # TODO: remove
 num-derive.workspace = true # TODO: remove
 num-traits.workspace = true # TODO: remove
-yuv = { version = "0.8", features = ["rdp"] }
+yuv = { version = "0.8.17", features = ["rdp"] }
 wide = "0.7" # portable SIMD for the inverse DWT (wasm/x86/ARM); `std::simd` is still nightly-only
 
 [dev-dependencies]

--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -6,8 +6,6 @@ use bitvec::prelude::*;
 use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
 use yuv::YuvError;
 
-use crate::utils::Bits;
-
 const KP_MAX: u32 = 80;
 const LS_GR: u32 = 3;
 const UP_GR: u32 = 4;
@@ -22,16 +20,6 @@ macro_rules! write_byte {
             $output = &mut $output[1..];
         } else {
             break;
-        }
-    };
-}
-
-macro_rules! try_split_bits {
-    ($bits:ident, $n:expr) => {
-        if $bits.len() < $n {
-            break;
-        } else {
-            $bits.split_to($n)
         }
     };
 }
@@ -252,6 +240,99 @@ fn code_gr(bits: &mut BitStream<'_>, krp: &mut u32, val: u32) {
     }
 }
 
+/// MSB-first bit reader over an encoded tile.
+struct BitReader<'a> {
+    /// Bytes not yet loaded into `acc`.
+    data: &'a [u8],
+    /// Buffered bits: the next bit to be read is bit 63, and every
+    /// bit below `64 - len` is zero.
+    acc: u64,
+    /// Number of valid bits in `acc`, at most 64.
+    len: u32,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        let mut this = Self { data, acc: 0, len: 0 };
+        this.refill();
+        this
+    }
+
+    /// Tops `acc` up to more than 56 bits when input remains, so any read of up
+    /// to 32 bits is served without a second bounds check.
+    #[inline]
+    fn refill(&mut self) {
+        while self.len <= 56 {
+            let Some((&byte, rest)) = self.data.split_first() else {
+                break;
+            };
+            self.data = rest;
+            self.acc |= u64::from(byte) << (56 - self.len);
+            self.len += 8;
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len == 0 && self.data.is_empty()
+    }
+
+    /// Consumes `n` buffered bits. `n` must not exceed `len`, and `len <= 64`.
+    #[inline]
+    fn consume(&mut self, n: u32) {
+        debug_assert!(n < 64 && n <= self.len);
+        self.acc <<= n;
+        self.len -= n;
+    }
+
+    /// Reads `n` bits (`n <= 32`) MSB-first, or returns `None` without consuming
+    /// anything if fewer than `n` bits remain.
+    #[inline]
+    fn read(&mut self, n: u32) -> Option<u32> {
+        debug_assert!(n <= 32);
+        if n == 0 {
+            return Some(0);
+        }
+        self.refill();
+        if self.len < n {
+            return None;
+        }
+        #[expect(clippy::cast_possible_truncation, reason = "n <= 32, so the shift leaves 32 bits")]
+        let value = (self.acc >> (64 - n)) as u32;
+        self.consume(n);
+        Some(value)
+    }
+
+    /// Counts and consumes leading bits equal to `value`, leaving the
+    /// terminating opposite bit for the caller to read.
+    #[inline]
+    fn skip_leading(&mut self, value: bool) -> usize {
+        let mut total = 0usize;
+
+        loop {
+            self.refill();
+            if self.len == 0 {
+                return total;
+            }
+
+            // Count leading zeros either way by inverting for a run of ones.
+            let word = if value { !self.acc } else { self.acc };
+            let run = word.leading_zeros().min(self.len);
+            total += usize::try_from(run).unwrap_or(usize::MAX);
+
+            if run < self.len {
+                // The terminator is in the buffer. Leave it unconsumed.
+                self.consume(run);
+                return total;
+            }
+
+            // The whole buffer matched. Drop it and look at the next one.
+            self.acc = 0;
+            self.len = 0;
+        }
+    }
+}
+
 pub fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Result<(), RlgrError> {
     #![expect(
         clippy::as_conversions,
@@ -268,21 +349,36 @@ pub fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Re
     let mut kp: u32 = k << LS_GR;
     let mut krp: u32 = kr << LS_GR;
 
-    let mut bits = Bits::new(BitSlice::from_slice(tile));
+    let mut bits = BitReader::new(tile);
 
     while !bits.is_empty() && !output.is_empty() {
         match CompressionMode::from(k) {
             CompressionMode::RunLength => {
-                let number_of_zeros = truncate_leading_value(&mut bits, false);
-                try_split_bits!(bits, 1);
-                let run = count_run(number_of_zeros, &mut k, &mut kp) + load_be_u32(try_split_bits!(bits, k as usize));
+                let number_of_zeros = bits.skip_leading(false);
+                if bits.read(1).is_none() {
+                    break;
+                }
+                // `count_run` advances `k`, and the run's low bits are then read
+                // with the updated `k`. Order matters.
+                let run = count_run(number_of_zeros, &mut k, &mut kp);
+                let Some(run_low_bits) = bits.read(k) else {
+                    break;
+                };
+                let run = run + run_low_bits;
 
-                let sign_bit = try_split_bits!(bits, 1).load_be::<u8>();
+                let Some(sign_bit) = bits.read(1) else {
+                    break;
+                };
 
-                let number_of_ones = truncate_leading_value(&mut bits, true);
-                try_split_bits!(bits, 1);
+                let number_of_ones = bits.skip_leading(true);
+                if bits.read(1).is_none() {
+                    break;
+                }
 
-                let code_remainder = load_be_u32(try_split_bits!(bits, kr as usize)) + ((number_of_ones as u32) << kr);
+                let Some(remainder) = bits.read(kr) else {
+                    break;
+                };
+                let code_remainder = remainder + ((number_of_ones as u32) << kr);
 
                 update_parameters_according_to_number_of_ones(number_of_ones, &mut kr, &mut krp);
                 kp = kp.saturating_sub(DN_GR);
@@ -291,15 +387,20 @@ pub fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Re
                 let magnitude = compute_rl_magnitude(sign_bit, code_remainder)?;
 
                 let size = min(run as usize, output.len());
-                fill(&mut output[..size], 0);
+                output[..size].fill(0);
                 output = &mut output[size..];
                 write_byte!(output, magnitude);
             }
             CompressionMode::GolombRice => {
-                let number_of_ones = truncate_leading_value(&mut bits, true);
-                try_split_bits!(bits, 1);
+                let number_of_ones = bits.skip_leading(true);
+                if bits.read(1).is_none() {
+                    break;
+                }
 
-                let code_remainder = load_be_u32(try_split_bits!(bits, kr as usize)) + ((number_of_ones as u32) << kr);
+                let Some(remainder) = bits.read(kr) else {
+                    break;
+                };
+                let code_remainder = remainder + ((number_of_ones as u32) << kr);
 
                 update_parameters_according_to_number_of_ones(number_of_ones, &mut kr, &mut krp);
 
@@ -311,8 +412,12 @@ pub fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Re
                     EntropyAlgorithm::Rlgr3 => {
                         let n_index = compute_n_index(code_remainder);
 
-                        let val1 = load_be_u32(try_split_bits!(bits, n_index));
-                        let val2 = code_remainder - val1;
+                        let Some(val1) = bits.read(n_index) else {
+                            break;
+                        };
+                        let Some(val2) = code_remainder.checked_sub(val1) else {
+                            return Err(RlgrError::InvalidIntegralConversion("code remainder - val1"));
+                        };
                         if val1 != 0 && val2 != 0 {
                             kp = kp.saturating_sub(2 * DQ_GR);
                             k = kp >> LS_GR;
@@ -333,30 +438,9 @@ pub fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Re
     }
 
     // Fill remaining buffer with zeros.
-    fill(output, 0);
+    output.fill(0);
 
     Ok(())
-}
-
-fn fill(buffer: &mut [i16], value: i16) {
-    for v in buffer {
-        *v = value;
-    }
-}
-
-fn load_be_u32(s: &BitSlice<u8, Msb0>) -> u32 {
-    if s.is_empty() { 0 } else { s.load_be::<u32>() }
-}
-
-// Returns number of truncated bits
-fn truncate_leading_value(bits: &mut Bits<'_>, value: bool) -> usize {
-    let leading_values = if value {
-        bits.leading_ones()
-    } else {
-        bits.leading_zeros()
-    };
-    bits.split_to(leading_values);
-    leading_values
 }
 
 fn count_run(number_of_zeros: usize, k: &mut u32, kp: &mut u32) -> u32 {
@@ -371,7 +455,7 @@ fn count_run(number_of_zeros: usize, k: &mut u32, kp: &mut u32) -> u32 {
     .sum()
 }
 
-fn compute_rl_magnitude(sign_bit: u8, code_remainder: u32) -> Result<i16, RlgrError> {
+fn compute_rl_magnitude(sign_bit: u32, code_remainder: u32) -> Result<i16, RlgrError> {
     let rl_magnitude =
         i16::try_from(code_remainder + 1).map_err(|_| RlgrError::InvalidIntegralConversion("code remainder + 1"))?;
 
@@ -409,16 +493,10 @@ fn compute_rlgr3_magnitude(val: u32) -> Result<i16, RlgrError> {
     }
 }
 
-fn compute_n_index(code_remainder: u32) -> usize {
-    if code_remainder == 0 {
-        return 0;
-    }
-
-    let code_bytes = code_remainder.to_be_bytes();
-    let code_bits = BitSlice::<u8, Msb0>::from_slice(code_bytes.as_ref());
-    let leading_zeros = code_bits.leading_zeros();
-
-    32 - leading_zeros
+/// Number of significant bits in `code_remainder`, i.e. the width of the field
+/// that follows it in RLGR3.
+fn compute_n_index(code_remainder: u32) -> u32 {
+    32 - code_remainder.leading_zeros()
 }
 
 fn update_parameters_according_to_number_of_ones(number_of_ones: usize, kr: &mut u32, krp: &mut u32) {
@@ -494,5 +572,343 @@ impl core::error::Error for RlgrError {
 impl From<io::Error> for RlgrError {
     fn from(err: io::Error) -> Self {
         Self::Io(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pre-optimization `bitvec`-based decoder, kept verbatim as an oracle.
+    ///
+    /// The rewrite of [`decode`] only replaced the bit-reading layer; every
+    /// arithmetic and control-flow decision is meant to be unchanged. That is a
+    /// property worth checking directly rather than trusting, because RLGR has
+    /// no test vectors here and a subtle divergence would show up as corrupt
+    /// pixels in a live session rather than as a failing build.
+    mod reference {
+        use bitvec::field::BitField as _;
+        use bitvec::prelude::*;
+
+        use super::super::{
+            CompressionMode, DN_GR, DQ_GR, EntropyAlgorithm, KP_MAX, LS_GR, RlgrError, UQ_GR, compute_rl_magnitude,
+            compute_rlgr1_magnitude, compute_rlgr3_magnitude, count_run, update_parameters_according_to_number_of_ones,
+        };
+        use crate::utils::Bits;
+
+        macro_rules! write_byte {
+            ($output:ident, $value:ident) => {
+                if !$output.is_empty() {
+                    $output[0] = $value;
+                    $output = &mut $output[1..];
+                } else {
+                    break;
+                }
+            };
+        }
+
+        macro_rules! try_split_bits {
+            ($bits:ident, $n:expr) => {
+                if $bits.len() < $n {
+                    break;
+                } else {
+                    $bits.split_to($n)
+                }
+            };
+        }
+
+        fn fill(buffer: &mut [i16], value: i16) {
+            for v in buffer {
+                *v = value;
+            }
+        }
+
+        fn load_be_u32(s: &BitSlice<u8, Msb0>) -> u32 {
+            if s.is_empty() { 0 } else { s.load_be::<u32>() }
+        }
+
+        fn truncate_leading_value(bits: &mut Bits<'_>, value: bool) -> usize {
+            let leading_values = if value {
+                bits.leading_ones()
+            } else {
+                bits.leading_zeros()
+            };
+            bits.split_to(leading_values);
+            leading_values
+        }
+
+        fn compute_n_index(code_remainder: u32) -> usize {
+            if code_remainder == 0 {
+                return 0;
+            }
+
+            let code_bytes = code_remainder.to_be_bytes();
+            let code_bits = BitSlice::<u8, Msb0>::from_slice(code_bytes.as_ref());
+            let leading_zeros = code_bits.leading_zeros();
+
+            32 - leading_zeros
+        }
+
+        #[expect(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            reason = "matches the original"
+        )]
+        pub(super) fn decode(mode: EntropyAlgorithm, tile: &[u8], mut output: &mut [i16]) -> Result<(), RlgrError> {
+            if tile.is_empty() {
+                return Err(RlgrError::EmptyTile);
+            }
+
+            let mut k: u32 = 1;
+            let mut kr: u32 = 1;
+            let mut kp: u32 = k << LS_GR;
+            let mut krp: u32 = kr << LS_GR;
+
+            let mut bits = Bits::new(BitSlice::from_slice(tile));
+
+            while !bits.is_empty() && !output.is_empty() {
+                match CompressionMode::from(k) {
+                    CompressionMode::RunLength => {
+                        let number_of_zeros = truncate_leading_value(&mut bits, false);
+                        try_split_bits!(bits, 1);
+                        let run = count_run(number_of_zeros, &mut k, &mut kp)
+                            + load_be_u32(try_split_bits!(bits, k as usize));
+
+                        let sign_bit = try_split_bits!(bits, 1).load_be::<u8>();
+
+                        let number_of_ones = truncate_leading_value(&mut bits, true);
+                        try_split_bits!(bits, 1);
+
+                        let code_remainder =
+                            load_be_u32(try_split_bits!(bits, kr as usize)) + ((number_of_ones as u32) << kr);
+
+                        update_parameters_according_to_number_of_ones(number_of_ones, &mut kr, &mut krp);
+                        kp = kp.saturating_sub(DN_GR);
+                        k = kp >> LS_GR;
+
+                        let magnitude = compute_rl_magnitude(u32::from(sign_bit), code_remainder)?;
+
+                        let size = core::cmp::min(run as usize, output.len());
+                        fill(&mut output[..size], 0);
+                        output = &mut output[size..];
+                        write_byte!(output, magnitude);
+                    }
+                    CompressionMode::GolombRice => {
+                        let number_of_ones = truncate_leading_value(&mut bits, true);
+                        try_split_bits!(bits, 1);
+
+                        let code_remainder =
+                            load_be_u32(try_split_bits!(bits, kr as usize)) + ((number_of_ones as u32) << kr);
+
+                        update_parameters_according_to_number_of_ones(number_of_ones, &mut kr, &mut krp);
+
+                        match mode {
+                            EntropyAlgorithm::Rlgr1 => {
+                                let magnitude = compute_rlgr1_magnitude(code_remainder, &mut k, &mut kp)?;
+                                write_byte!(output, magnitude);
+                            }
+                            EntropyAlgorithm::Rlgr3 => {
+                                let n_index = compute_n_index(code_remainder);
+
+                                let val1 = load_be_u32(try_split_bits!(bits, n_index));
+                                // Matches the guard added to `super::decode`.
+                                // The original subtraction panicked here in
+                                // debug builds, which would stop this oracle
+                                // from covering malformed input at all.
+                                let Some(val2) = code_remainder.checked_sub(val1) else {
+                                    return Err(RlgrError::InvalidIntegralConversion("code remainder - val1"));
+                                };
+                                if val1 != 0 && val2 != 0 {
+                                    kp = kp.saturating_sub(2 * DQ_GR);
+                                    k = kp >> LS_GR;
+                                } else if val1 == 0 && val2 == 0 {
+                                    kp = core::cmp::min(kp + 2 * UQ_GR, KP_MAX);
+                                    k = kp >> LS_GR;
+                                }
+
+                                let magnitude = compute_rlgr3_magnitude(val1)?;
+                                write_byte!(output, magnitude);
+
+                                let magnitude = compute_rlgr3_magnitude(val2)?;
+                                write_byte!(output, magnitude);
+                            }
+                        }
+                    }
+                }
+            }
+
+            fill(output, 0);
+
+            Ok(())
+        }
+    }
+
+    /// Deterministic xorshift, so a failure is reproducible from the seed alone.
+    struct Rng(u32);
+
+    impl Rng {
+        fn next(&mut self) -> u32 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            self.0 = x;
+            x
+        }
+
+        fn bytes(&mut self, len: usize) -> Vec<u8> {
+            (0..len).map(|_| (self.next() >> 7) as u8).collect()
+        }
+    }
+
+    fn assert_same(mode: EntropyAlgorithm, tile: &[u8], out_len: usize) {
+        let mut fast = vec![0i16; out_len];
+        let mut reference = vec![0i16; out_len];
+
+        let fast_result = decode(mode, tile, &mut fast);
+        let reference_result = reference::decode(mode, tile, &mut reference);
+
+        assert_eq!(
+            fast_result.is_ok(),
+            reference_result.is_ok(),
+            "{mode:?}: ok-ness diverged for tile {tile:02x?}"
+        );
+        assert_eq!(fast, reference, "{mode:?}: output diverged for tile {tile:02x?}");
+    }
+
+    #[test]
+    fn matches_reference_on_random_input() {
+        // Arbitrary bytes are still valid RLGR input -- the format has no
+        // checksum -- so this covers the full state machine, including the
+        // parameter adaptation paths and the truncated-stream exits.
+        let mut rng = Rng(0xC0FF_EE01);
+        for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+            for len in [1usize, 2, 3, 7, 8, 9, 15, 16, 31, 64, 127, 256, 1024] {
+                for _ in 0..40 {
+                    assert_same(mode, &rng.bytes(len), 4096);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_long_runs() {
+        // All-zero and all-one inputs drive the unary prefix scan past a single
+        // 64-bit buffer, which is where the accumulator refill logic differs
+        // most from a bit-at-a-time scan.
+        for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+            for len in [1usize, 8, 9, 63, 64, 65, 128, 300] {
+                assert_same(mode, &vec![0x00; len], 4096);
+                assert_same(mode, &vec![0xff; len], 4096);
+                assert_same(mode, &vec![0xaa; len], 4096);
+                assert_same(mode, &vec![0x55; len], 4096);
+                // A long zero run followed by data, and the reverse.
+                let mut tile = vec![0x00; len];
+                tile.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+                assert_same(mode, &tile, 4096);
+                let mut tile = vec![0xff; len];
+                tile.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+                assert_same(mode, &tile, 4096);
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_with_small_output_buffers() {
+        // The `write_byte!` and run-fill paths both clamp against the output
+        // buffer; a short buffer exercises those exits.
+        let mut rng = Rng(0x1357_9BDF);
+        for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+            for out_len in [1usize, 2, 3, 5, 17, 64, 4095] {
+                for _ in 0..20 {
+                    assert_same(mode, &rng.bytes(128), out_len);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn empty_tile_is_rejected() {
+        let mut out = [0i16; 16];
+        assert!(matches!(
+            decode(EntropyAlgorithm::Rlgr3, &[], &mut out),
+            Err(RlgrError::EmptyTile)
+        ));
+    }
+
+    #[test]
+    fn round_trips_through_the_encoder() {
+        // The encoder is the ground truth a real server provides: whatever it
+        // emits, the decoder must reproduce.
+        let mut rng = Rng(0x2468_ACE0);
+        for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+            for _ in 0..8 {
+                // Coefficient-like input: mostly zeros with occasional spikes,
+                // which is what quantized RFX subbands look like.
+                let input: Vec<i16> = (0..4096)
+                    .map(|_| {
+                        let r = rng.next();
+                        if r % 5 == 0 { ((r >> 8) % 512) as i16 - 256 } else { 0 }
+                    })
+                    .collect();
+
+                let mut encoded = vec![0u8; 4096 * 4];
+                let len = encode(mode, &input, &mut encoded).expect("encode");
+
+                let mut fast = vec![0i16; 4096];
+                let mut reference = vec![0i16; 4096];
+                decode(mode, &encoded[..len], &mut fast).expect("decode");
+                reference::decode(mode, &encoded[..len], &mut reference).expect("reference decode");
+
+                assert_eq!(fast, reference);
+                assert_eq!(fast, input, "{mode:?}: encoder output did not decode back to its input");
+            }
+        }
+    }
+
+    #[test]
+    fn bit_reader_matches_a_naive_reader() {
+        // Direct unit test of the reader itself, independent of RLGR.
+        let mut rng = Rng(0x0BAD_F00D);
+        for _ in 0..200 {
+            let data = rng.bytes(37);
+            let mut reader = BitReader::new(&data);
+            let mut naive: Vec<bool> = Vec::new();
+            for byte in &data {
+                for bit in (0..8).rev() {
+                    naive.push((byte >> bit) & 1 == 1);
+                }
+            }
+            let mut pos = 0usize;
+
+            for _ in 0..40 {
+                match rng.next() % 3 {
+                    0 => {
+                        let n = rng.next() % 33;
+                        let got = reader.read(n);
+                        if pos + n as usize > naive.len() {
+                            assert_eq!(got, None);
+                        } else {
+                            let mut want = 0u32;
+                            for i in 0..n as usize {
+                                want = (want << 1) | u32::from(naive[pos + i]);
+                            }
+                            assert_eq!(got, Some(want), "read({n}) at bit {pos}");
+                            pos += n as usize;
+                        }
+                    }
+                    value => {
+                        let value = value == 1;
+                        let got = reader.skip_leading(value);
+                        let mut want = 0usize;
+                        while pos + want < naive.len() && naive[pos + want] == value {
+                            want += 1;
+                        }
+                        assert_eq!(got, want, "skip_leading({value}) at bit {pos}");
+                        pos += want;
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/ironrdp-rfxbench/.gitignore
+++ b/crates/ironrdp-rfxbench/.gitignore
@@ -1,0 +1,4 @@
+# Built wasm modules and the npm install for the harness.
+wasm/build/
+wasm/node_modules/
+wasm/package-lock.json

--- a/crates/ironrdp-rfxbench/Cargo.toml
+++ b/crates/ironrdp-rfxbench/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ironrdp-rfxbench"
+version = "0.0.0"
+description = "RemoteFX (RFX) decode benchmarks and fixtures"
+edition.workspace = true
+publish = false
+
+# rlib for the criterion bench and unit tests, cdylib so the same fixtures and
+# decode driver can be measured on wasm32 (see wasm/run.mjs).
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+ironrdp-core.path = "../ironrdp-core"
+ironrdp-graphics.path = "../ironrdp-graphics"
+ironrdp-pdu = { path = "../ironrdp-pdu", features = ["std"] }
+ironrdp-session.path = "../ironrdp-session"
+
+[dev-dependencies]
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "rfx_decode"
+path = "benches/rfx_decode.rs"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rfxbench/README.md
+++ b/crates/ironrdp-rfxbench/README.md
@@ -1,0 +1,81 @@
+# ironrdp-rfxbench
+
+Benchmarks for the RemoteFX (RFX) **decode** path, on native targets and on WASM.
+
+`ironrdp-bench` measures the encoder. This crate measures the decoder, which runs
+in WASM for browser-based clients.
+
+## Running
+
+Native, via the standard Criterion harness:
+
+```sh
+cargo bench -p ironrdp-rfxbench --bench rfx_decode
+```
+
+Criterion accepts a regex to select a subset, so you can iterate on
+one stage without re-running the full suite:
+
+```sh
+cargo bench -p ironrdp-rfxbench --bench rfx_decode -- 'stage/rlgr'
+```
+
+### Validating a change
+
+Use Criterion's baselines to compare two runs. First, establish a baseline. Then
+make a change and re-run the benchmarks against the saved baseline. In this
+example we name the baseline `before`.
+
+
+```sh
+# On the unmodified code.
+cargo bench -p ironrdp-rfxbench --bench rfx_decode -- --save-baseline before
+
+# ... make the change ...
+
+cargo bench -p ironrdp-rfxbench --bench rfx_decode -- --baseline before
+```
+
+WASM:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cd crates/ironrdp-rfxbench/wasm
+npm install
+
+# Build with and without SIMD for comparison.
+cargo build -p ironrdp-rfxbench --release --target wasm32-unknown-unknown --lib
+cp ../../../target/wasm32-unknown-unknown/release/ironrdp_rfxbench.wasm build/baseline.wasm
+RUSTFLAGS="-C target-feature=+simd128" \
+  cargo build -p ironrdp-rfxbench --release --target wasm32-unknown-unknown --lib
+cp ../../../target/wasm32-unknown-unknown/release/ironrdp_rfxbench.wasm build/simd128.wasm
+
+node run.mjs build/baseline.wasm build/simd128.wasm
+```
+
+`run.mjs` takes one or more modules, reports the SIMD instruction counts found
+in each, and times them side by side. If given exactly two modules, it also
+prints the speedup of the second over the first. To validate a change on WASM,
+build the modified code into a second `.wasm` and pass both.
+
+The WASM side is driven through the raw `WebAssembly` API with plain
+`extern "C"` exports rather than `wasm-bindgen`, so the numbers are the codec
+and not the bindings.
+
+## Fixtures
+
+Fixtures are auto-generated: a synthetic screen is rendered, encoded with
+`rfx_encode_component`, and the resulting bitstream is decoded.
+
+Patterns, in rough order of decode cost:
+
+| pattern | content | why |
+| --- | --- | --- |
+| `gradient` | smooth 2D ramp | almost everything quantizes away |
+| `desktop` | solid background, windows, borders, taskbar | idle or lightly-used session |
+| `text` | dense small glyphs on white | terminal, editor, spreadsheet |
+| `photo` | smooth blobs plus fine detail | wallpaper, image viewer |
+| `noise` | pseudorandom | not realistic; bounds the entropy decoder |
+
+Everything is deterministic (a fixed xorshift, integer-only rendering) so
+fixtures are identical across runs, machines and targets.

--- a/crates/ironrdp-rfxbench/benches/rfx_decode.rs
+++ b/crates/ironrdp-rfxbench/benches/rfx_decode.rs
@@ -1,0 +1,158 @@
+//! RemoteFX decode benchmarks.
+//!
+//! Benchmarks are broken up into three levels. From lowest to highest:
+//!
+//! * `stage/*` -- each decode stage on its own, to attribute the frame time.
+//! * `tile/*` -- one 64x64 tile, to compare per-tile cost across patterns.
+//! * `frame/*` -- a full-screen frame through `rfx::DecodingContext::decode`.
+//!
+//! Throughput is reported in pixels, so results are comparable across
+//! resolutions and directly convertible to frames per second.
+
+#![allow(unused_crate_dependencies)] // Not every dependency is used by every target.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ironrdp_graphics::color_conversion::{YCbCrBuffer, ycbcr_to_rgba};
+use ironrdp_graphics::{dwt, quantization, rlgr, subband_reconstruction};
+use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
+use ironrdp_rfxbench::{Driver, Pattern, TILE, fixture, stage_fixture};
+
+/// IronRDP advertise RLGR3 in RemoteFX client caps.
+const ALGO: EntropyAlgorithm = EntropyAlgorithm::Rlgr3;
+
+/// Full-screen decode at common screen resolutions.
+fn frame(c: &mut Criterion) {
+    let mut group = c.benchmark_group("frame");
+
+    for (w, h) in [(1280u16, 720u16), (1920, 1080), (2560, 1440)] {
+        for pattern in Pattern::ALL {
+            let fx = fixture(pattern, w, h, ALGO);
+            let mut driver = Driver::new(&fx);
+
+            group.throughput(Throughput::Elements(fx.pixels()));
+            group.bench_function(BenchmarkId::new(format!("{w}x{h}"), pattern.name()), |b| {
+                b.iter(|| driver.decode(&fx.frame))
+            });
+        }
+    }
+
+    group.finish();
+}
+
+/// One 64x64 tile, isolating per-tile cost from the framebuffer blit's cache behaviour.
+fn tile(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tile");
+
+    for pattern in Pattern::ALL {
+        let fx = fixture(pattern, 64, 64, ALGO);
+        let mut driver = Driver::new(&fx);
+
+        group.throughput(Throughput::Elements(fx.pixels()));
+        group.bench_function(pattern.name(), |b| b.iter(|| driver.decode(&fx.frame)));
+    }
+
+    group.finish();
+}
+
+/// Both entropy coders.
+fn entropy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("entropy");
+
+    for algorithm in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+        let fx = fixture(Pattern::Text, 1920, 1080, algorithm);
+        let mut driver = Driver::new(&fx);
+
+        group.throughput(Throughput::Elements(fx.pixels()));
+        group.bench_function(format!("{algorithm:?}"), |b| b.iter(|| driver.decode(&fx.frame)));
+    }
+
+    group.finish();
+}
+
+/// Per-stage cost on one tile's worth of real coefficients. Each stage runs on a
+/// buffer restored to the state its predecessor would have left, so the inputs
+/// are the ones the stage sees in production (coefficient magnitudes drive both
+/// the RLGR and the DWT cost).
+fn stage(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stage");
+    // One tile of one component. Three components per tile, so multiply by 3 to
+    // compare against the per-tile numbers.
+    group.throughput(Throughput::Elements(
+        u64::try_from(TILE * TILE).expect("tile area fits in u64"),
+    ));
+
+    for pattern in [Pattern::Desktop, Pattern::Text, Pattern::Noise] {
+        let sf = stage_fixture(pattern, ALGO);
+        let name = pattern.name();
+        let mut out = vec![0i16; TILE * TILE];
+        let mut temp = vec![0i16; TILE * TILE];
+
+        group.bench_function(BenchmarkId::new("rlgr", name), |b| {
+            b.iter(|| rlgr::decode(ALGO, &sf.encoded[0], &mut out).expect("rlgr"))
+        });
+
+        // Capture each stage's input once, then restore it per iteration. The
+        // restore is a 8 KiB memcpy and is subtracted by measuring it too
+        // (`stage/restore`), which is far cheaper than the stages themselves.
+        let after_rlgr = {
+            let mut v = vec![0i16; TILE * TILE];
+            rlgr::decode(ALGO, &sf.encoded[0], &mut v).expect("rlgr");
+            v
+        };
+        group.bench_function(BenchmarkId::new("subband", name), |b| {
+            b.iter(|| {
+                out.copy_from_slice(&after_rlgr);
+                subband_reconstruction::decode(&mut out[4032..]);
+            })
+        });
+
+        let after_subband = {
+            let mut v = after_rlgr.clone();
+            subband_reconstruction::decode(&mut v[4032..]);
+            v
+        };
+        group.bench_function(BenchmarkId::new("quantization", name), |b| {
+            b.iter(|| {
+                out.copy_from_slice(&after_subband);
+                quantization::decode(&mut out, &sf.quant);
+            })
+        });
+
+        let after_quant = {
+            let mut v = after_subband.clone();
+            quantization::decode(&mut v, &sf.quant);
+            v
+        };
+        group.bench_function(BenchmarkId::new("dwt", name), |b| {
+            b.iter(|| {
+                out.copy_from_slice(&after_quant);
+                dwt::decode(&mut out, &mut temp);
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("restore", name), |b| {
+            b.iter(|| out.copy_from_slice(&after_quant))
+        });
+
+        let planes = sf.planes();
+        let mut rgba = vec![0u8; TILE * TILE * 4];
+        group.bench_function(BenchmarkId::new("ycbcr_to_rgba", name), |b| {
+            b.iter(|| {
+                ycbcr_to_rgba(
+                    YCbCrBuffer {
+                        y: &planes[0],
+                        cb: &planes[1],
+                        cr: &planes[2],
+                    },
+                    &mut rgba,
+                )
+                .expect("ycbcr")
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, frame, tile, entropy, stage);
+criterion_main!(benches);

--- a/crates/ironrdp-rfxbench/src/lib.rs
+++ b/crates/ironrdp-rfxbench/src/lib.rs
@@ -1,0 +1,459 @@
+//! Fixtures and a driver for benchmarking the RemoteFX (RFX) *decode* path.
+//!
+//! This crate builds realistic RFX bitstreams with the encoder and
+//! then measures decoding them.
+//!
+//! The same code is built for `wasm32-unknown-unknown` (see `wasm/run.mjs`) so
+//! the browser target can be measured with the identical workload.
+
+#![allow(unused_crate_dependencies)] // Used by benches.
+
+use ironrdp_core::{Encode as _, WriteCursor};
+use ironrdp_graphics::color_conversion::to_64x64_ycbcr_tile;
+use ironrdp_graphics::image_processing::PixelFormat;
+use ironrdp_graphics::rfx_encode_component;
+use ironrdp_pdu::codecs::rfx::{
+    self, Block, ChannelsPdu, CodecChannel, CodecVersionsPdu, EntropyAlgorithm, FrameBeginPdu, FrameEndPdu,
+    OperatingMode, Quant, RegionPdu, RfxChannel, RfxRectangle, SyncPdu, TileSetPdu,
+};
+use ironrdp_pdu::geometry::InclusiveRectangle;
+use ironrdp_session::image::DecodedImage;
+use ironrdp_session::rfx::DecodingContext;
+
+pub const TILE: usize = 64;
+
+/// Bytes per pixel of the source and decoded images.
+const BPP: usize = 4;
+
+const FORMAT: PixelFormat = PixelFormat::RgbA32;
+
+/// Synthetic screen content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pattern {
+    /// Flat-ish desktop: solid background, a few windows, borders, a taskbar.
+    /// The common case for an idle or lightly-used session.
+    Desktop,
+    /// Dense small text on white. Realistic worst case for real workloads
+    /// (a terminal, an editor, a spreadsheet) and the heaviest on RLGR.
+    Text,
+    /// Smooth 2D gradient: almost everything quantizes away. Best case.
+    Gradient,
+    /// Photographic-ish content: smooth blobs plus fine detail.
+    Photo,
+    /// Pseudorandom bytes. Not realistic, but exercises the RLGR phase well.
+    Noise,
+}
+
+impl Pattern {
+    pub const ALL: [Self; 5] = [Self::Desktop, Self::Text, Self::Gradient, Self::Photo, Self::Noise];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Desktop => "desktop",
+            Self::Text => "text",
+            Self::Gradient => "gradient",
+            Self::Photo => "photo",
+            Self::Noise => "noise",
+        }
+    }
+
+    pub fn from_u32(v: u32) -> Option<Self> {
+        Self::ALL.get(usize::try_from(v).ok()?).copied()
+    }
+}
+
+/// Deterministic xorshift so fixtures are reproducible across runs.
+struct Rng(u32);
+
+impl Rng {
+    fn next(&mut self) -> u32 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.0 = x;
+        x
+    }
+}
+
+/// Renders `pattern` into a `width * height` RGBA buffer.
+pub fn render(pattern: Pattern, width: usize, height: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; width * height * BPP];
+    let mut rng = Rng(0x1234_5678);
+
+    for y in 0..height {
+        for x in 0..width {
+            let [r, g, b] = match pattern {
+                Pattern::Desktop => desktop_px(x, y, width, height),
+                Pattern::Text => text_px(x, y),
+                Pattern::Gradient => gradient_px(x, y, width, height),
+                Pattern::Photo => photo_px(x, y),
+                Pattern::Noise => {
+                    let [r, g, b, _] = rng.next().to_le_bytes();
+                    [r, g, b]
+                }
+            };
+            let o = (y * width + x) * BPP;
+            buf[o] = r;
+            buf[o + 1] = g;
+            buf[o + 2] = b;
+            buf[o + 3] = 0xff;
+        }
+    }
+
+    buf
+}
+
+fn desktop_px(x: usize, y: usize, width: usize, height: usize) -> [u8; 3] {
+    // Taskbar.
+    if y + 40 >= height {
+        return if y + 40 == height {
+            [0x50, 0x50, 0x50]
+        } else {
+            [0x20, 0x20, 0x20]
+        };
+    }
+
+    // Two overlapping windows with title bars, borders and a text region.
+    for (i, (wx, wy, ww, wh)) in [(60usize, 50usize, 700usize, 500usize), (420, 260, 760, 560)]
+        .into_iter()
+        .enumerate()
+    {
+        if x >= wx && x < (wx + ww).min(width) && y >= wy && y < (wy + wh).min(height) {
+            let lx = x - wx;
+            let ly = y - wy;
+            if ly < 2 || lx < 2 || lx + 2 >= ww || ly + 2 >= wh {
+                return [0x70, 0x70, 0x78]; // border
+            }
+            if ly < 32 {
+                return if i == 0 { [0x1f, 0x5f, 0x9f] } else { [0x2f, 0x2f, 0x3f] }; // title bar
+            }
+            // Client area: white with text lines in the upper half.
+            if ly < wh / 2 {
+                return text_px(lx, ly);
+            }
+            return [0xf4, 0xf4, 0xf4];
+        }
+    }
+
+    // Desktop background: a very slow gradient, as most themes have.
+    let v = 0x30 + (x + y) * 0x20 / (width + height);
+    [channel(v / 3), channel(v / 2), channel(v)]
+}
+
+/// Narrow a computed channel value to a byte.
+fn channel(v: usize) -> u8 {
+    u8::try_from(v).unwrap_or(u8::MAX)
+}
+
+/// Simulates a text-like image: dense small (7-pixel) glyphs on a solid background.
+fn text_px(x: usize, y: usize) -> [u8; 3] {
+    let line = y / 13;
+    let row = y % 13;
+    if row >= 9 {
+        return [0xff, 0xff, 0xff]; // leading between lines
+    }
+    let cell = x / 7;
+    let col = x % 7;
+    if col >= 6 {
+        return [0xff, 0xff, 0xff]; // inter-character gap
+    }
+    // Deterministic per-glyph bitmap.
+    let h = (cell.wrapping_mul(2_654_435_761) ^ line.wrapping_mul(40_503) ^ row.wrapping_mul(2_246_822_519)) >> 7;
+    if h & 1 != 0 || (h & 6) == 6 {
+        [0x11, 0x11, 0x11]
+    } else {
+        [0xff, 0xff, 0xff]
+    }
+}
+
+fn gradient_px(x: usize, y: usize, width: usize, height: usize) -> [u8; 3] {
+    [
+        channel(x * 255 / width.max(1)),
+        channel(y * 255 / height.max(1)),
+        channel((x + y) * 255 / (width + height).max(1)),
+    ]
+}
+
+fn photo_px(x: usize, y: usize) -> [u8; 3] {
+    // Cheap integer simulation of a photo with smooth blobs and fine detail.
+    let a = (x * x + y * y) >> 6;
+    let b = (x * 3 + y * 7) >> 1;
+    let c = (x ^ y) & 0x1f;
+    [
+        channel(a % 200 + 28),
+        channel(b % 180 + 40),
+        channel((a / 3 + b / 5 + c) % 210 + 20),
+    ]
+}
+
+/// An RFX bitstream pair for one screen: the header/first frame that primes the
+/// decoder's context, and a steady-state frame with every tile.
+pub struct Fixture {
+    pub pattern: Pattern,
+    pub width: u16,
+    pub height: u16,
+    pub algorithm: EntropyAlgorithm,
+    /// Sync + Context + Channels + CodecVersions + a one-tile frame.
+    pub init: Vec<u8>,
+    /// FrameBegin + Region + TileSet(all tiles) + FrameEnd, as a server sends
+    /// once the context is established.
+    pub frame: Vec<u8>,
+    pub tiles: usize,
+    /// Encoded size of `frame`, i.e. what actually crosses the wire.
+    pub wire_bytes: usize,
+}
+
+impl Fixture {
+    pub fn pixels(&self) -> u64 {
+        u64::from(self.width) * u64::from(self.height)
+    }
+}
+
+/// Encodes `pattern` at `width` x `height` into RFX bitstreams.
+pub fn fixture(pattern: Pattern, width: u16, height: u16, algorithm: EntropyAlgorithm) -> Fixture {
+    let w = usize::from(width);
+    let h = usize::from(height);
+    let image = render(pattern, w, h);
+    let quant = Quant::default();
+
+    let tiles_x = w.div_ceil(TILE);
+    let tiles_y = h.div_ceil(TILE);
+
+    // RLGR does not guarantee compression; a noise tile can expand.
+    let mut store = vec![0u8; tiles_x * tiles_y * 3 * TILE * TILE * 2];
+    let mut tiles = Vec::with_capacity(tiles_x * tiles_y);
+    let mut rest = store.as_mut_slice();
+
+    for ty in 0..tiles_y {
+        for tx in 0..tiles_x {
+            let (buf, tail) = rest.split_at_mut(3 * TILE * TILE * 2);
+            rest = tail;
+            tiles.push(encode_tile(&image, w, h, tx, ty, &quant, algorithm, buf));
+        }
+    }
+
+    let region = RegionPdu {
+        rectangles: vec![RfxRectangle {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }],
+    };
+
+    let frame = encode_blocks(&[
+        Block::CodecChannel(CodecChannel::FrameBegin(FrameBeginPdu {
+            index: 1,
+            number_of_regions: 1,
+        })),
+        Block::CodecChannel(CodecChannel::Region(region.clone())),
+        Block::CodecChannel(CodecChannel::TileSet(TileSetPdu {
+            entropy_algorithm: algorithm,
+            quants: vec![quant.clone()],
+            tiles: tiles.clone(),
+        })),
+        Block::CodecChannel(CodecChannel::FrameEnd(FrameEndPdu)),
+    ]);
+
+    let init = encode_blocks(&[
+        Block::Sync(SyncPdu),
+        Block::CodecChannel(CodecChannel::Context(rfx::ContextPdu {
+            flags: OperatingMode::IMAGE_MODE,
+            entropy_algorithm: algorithm,
+        })),
+        Block::Channels(ChannelsPdu(vec![RfxChannel {
+            width: i16::try_from(width).expect("width fits i16"),
+            height: i16::try_from(height).expect("height fits i16"),
+        }])),
+        Block::CodecVersions(CodecVersionsPdu),
+        Block::CodecChannel(CodecChannel::FrameBegin(FrameBeginPdu {
+            index: 0,
+            number_of_regions: 1,
+        })),
+        Block::CodecChannel(CodecChannel::Region(region)),
+        Block::CodecChannel(CodecChannel::TileSet(TileSetPdu {
+            entropy_algorithm: algorithm,
+            quants: vec![quant],
+            tiles: tiles[..1].to_vec(),
+        })),
+        Block::CodecChannel(CodecChannel::FrameEnd(FrameEndPdu)),
+    ]);
+
+    Fixture {
+        pattern,
+        width,
+        height,
+        algorithm,
+        wire_bytes: frame.len(),
+        init,
+        frame,
+        tiles: tiles.len(),
+    }
+}
+
+#[expect(clippy::too_many_arguments, reason = "internal fixture helper")]
+#[expect(clippy::similar_names, reason = "cb and cr are the RFX component names")]
+fn encode_tile<'a>(
+    image: &[u8],
+    width: usize,
+    height: usize,
+    tx: usize,
+    ty: usize,
+    quant: &Quant,
+    algorithm: EntropyAlgorithm,
+    buf: &'a mut [u8],
+) -> rfx::Tile<'a> {
+    let x = tx * TILE;
+    let y = ty * TILE;
+    let stride = width * BPP;
+
+    let mut comps = [[0i16; TILE * TILE], [0i16; TILE * TILE], [0i16; TILE * TILE]];
+    let [y_plane, cb_plane, cr_plane] = &mut comps;
+
+    to_64x64_ycbcr_tile(
+        &image[y * stride + x * BPP..],
+        u32::try_from((width - x).min(TILE)).expect("tile width fits"),
+        u32::try_from((height - y).min(TILE)).expect("tile height fits"),
+        u32::try_from(stride).expect("stride fits"),
+        FORMAT,
+        y_plane,
+        cb_plane,
+        cr_plane,
+    )
+    .expect("ycbcr conversion");
+
+    let third = buf.len() / 3;
+    let (y_buf, tail) = buf.split_at_mut(third);
+    let (cb_buf, cr_buf) = tail.split_at_mut(third);
+
+    let y_len = rfx_encode_component(y_plane, y_buf, quant, algorithm).expect("encode Y");
+    let cb_len = rfx_encode_component(cb_plane, cb_buf, quant, algorithm).expect("encode Cb");
+    let cr_len = rfx_encode_component(cr_plane, cr_buf, quant, algorithm).expect("encode Cr");
+
+    rfx::Tile {
+        y_quant_index: 0,
+        cb_quant_index: 0,
+        cr_quant_index: 0,
+        x: u16::try_from(tx).expect("tile index fits"),
+        y: u16::try_from(ty).expect("tile index fits"),
+        y_data: &y_buf[..y_len],
+        cb_data: &cb_buf[..cb_len],
+        cr_data: &cr_buf[..cr_len],
+    }
+}
+
+fn encode_blocks(blocks: &[Block<'_>]) -> Vec<u8> {
+    let size: usize = blocks.iter().map(ironrdp_core::Encode::size).sum();
+    let mut out = vec![0u8; size];
+    let mut cursor = WriteCursor::new(&mut out);
+    for block in blocks {
+        block.encode(&mut cursor).expect("encode block");
+    }
+    let pos = cursor.pos();
+    out.truncate(pos);
+    out
+}
+
+/// Holds the decoder state across frames, as a live session does.
+pub struct Driver {
+    context: DecodingContext,
+    image: DecodedImage,
+    destination: InclusiveRectangle,
+}
+
+impl Driver {
+    /// Builds a driver and primes it with the fixture's header frame.
+    pub fn new(fixture: &Fixture) -> Self {
+        let mut this = Self {
+            context: DecodingContext::new(),
+            image: DecodedImage::new(FORMAT, fixture.width, fixture.height),
+            destination: InclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: fixture.width - 1,
+                bottom: fixture.height - 1,
+            },
+        };
+        this.decode(&fixture.init);
+        this
+    }
+
+    /// Decodes one frame and returns a checksum of the touched region, so the
+    /// optimizer cannot discard the work.
+    pub fn decode(&mut self, frame: &[u8]) -> u64 {
+        let mut cursor = ironrdp_core::ReadCursor::new(frame);
+        let (_frame_id, rect) = self
+            .context
+            .decode(&mut self.image, &self.destination, &mut cursor)
+            .expect("decode frame");
+
+        // Sample the updated region rather than hashing every byte: enough to
+        // keep the decode live without the checksum itself showing up in the
+        // measurement.
+        let data = self.image.data();
+        let stride = self.image.stride();
+        let mut sum = u64::from(rect.left) ^ (u64::from(rect.bottom) << 16);
+        let mut row = usize::from(rect.top);
+        while row <= usize::from(rect.bottom) {
+            let off = row * stride + usize::from(rect.left) * BPP;
+            if off < data.len() {
+                sum = sum.wrapping_mul(0x0100_0000_01b3) ^ u64::from(data[off]);
+            }
+            row += 16;
+        }
+        sum
+    }
+
+    pub fn image(&self) -> &DecodedImage {
+        &self.image
+    }
+}
+
+/// Entropy-coded data for a single tile, for benchmarking the decode stages in
+/// isolation.
+pub struct StageFixture {
+    pub quant: Quant,
+    pub algorithm: EntropyAlgorithm,
+    /// Y, Cb and Cr entropy-coded planes, exactly as they arrive on the wire.
+    pub encoded: [Vec<u8>; 3],
+}
+
+impl StageFixture {
+    /// Runs the entropy + subband + dequant + DWT chain, returning the three
+    /// spatial-domain planes that `ycbcr_to_rgba` consumes.
+    pub fn planes(&self) -> [Vec<i16>; 3] {
+        let mut temp = vec![0i16; TILE * TILE];
+        core::array::from_fn(|i| {
+            let mut out = vec![0i16; TILE * TILE];
+            ironrdp_graphics::rlgr::decode(self.algorithm, &self.encoded[i], &mut out).expect("rlgr");
+            ironrdp_graphics::subband_reconstruction::decode(&mut out[4032..]);
+            ironrdp_graphics::quantization::decode(&mut out, &self.quant);
+            ironrdp_graphics::dwt::decode(&mut out, &mut temp);
+            out
+        })
+    }
+}
+
+/// Encodes one representative tile of `pattern` and returns its three planes.
+pub fn stage_fixture(pattern: Pattern, algorithm: EntropyAlgorithm) -> StageFixture {
+    // A 1920x1080 screen with the tile taken from the middle of the image, where
+    // every pattern has content.
+    const W: usize = 1920;
+    const H: usize = 1080;
+    let image = render(pattern, W, H);
+    let quant = Quant::default();
+
+    let mut buf = vec![0u8; 3 * TILE * TILE * 2];
+    let tile = encode_tile(&image, W, H, 8, 6, &quant, algorithm, &mut buf);
+    let encoded = [tile.y_data.to_vec(), tile.cb_data.to_vec(), tile.cr_data.to_vec()];
+
+    StageFixture {
+        quant,
+        algorithm,
+        encoded,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;

--- a/crates/ironrdp-rfxbench/src/wasm.rs
+++ b/crates/ironrdp-rfxbench/src/wasm.rs
@@ -1,0 +1,218 @@
+//! Raw C-ABI exports so the wasm build can be driven from Node with the plain
+//! `WebAssembly` API.
+//!
+//! We're not using `wasm-bindgen` because we want to measure the codec, and a
+//! bindgen boundary would add JS glue, copies and type conversions to every
+//! call.
+
+// This module is private, so `unreachable_pub` fires on every export -- but
+// `no_mangle` puts them in the cdylib's symbol table regardless, which is the
+// only way `wasm/run.mjs` can reach them.
+#![expect(unreachable_pub, reason = "no_mangle exports are reachable from the cdylib")]
+
+use core::cell::RefCell;
+
+use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
+
+use crate::{Driver, Fixture, Pattern, fixture};
+
+struct State {
+    fixture: Fixture,
+    driver: Driver,
+}
+
+thread_local! {
+    static STATE: RefCell<Option<State>> = const { RefCell::new(None) };
+}
+
+/// Builds the fixture and primes the decoder. Returns the encoded size of one
+/// steady-state frame, or 0 if the arguments were out of range.
+///
+/// Encoding happens here rather than in the timed section, so `decode_frame`
+/// measures decoding only.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_setup(pattern: u32, width: u32, height: u32, rlgr3: u32) -> u32 {
+    let Some(pattern) = Pattern::from_u32(pattern) else {
+        return 0;
+    };
+    let (Ok(width), Ok(height)) = (u16::try_from(width), u16::try_from(height)) else {
+        return 0;
+    };
+    let algorithm = if rlgr3 == 0 {
+        EntropyAlgorithm::Rlgr1
+    } else {
+        EntropyAlgorithm::Rlgr3
+    };
+
+    let fx = fixture(pattern, width, height, algorithm);
+    let driver = Driver::new(&fx);
+    let wire_bytes = u32::try_from(fx.wire_bytes).unwrap_or(u32::MAX);
+
+    STATE.with_borrow_mut(|state| {
+        *state = Some(State { fixture: fx, driver });
+    });
+
+    wire_bytes
+}
+
+/// Decodes one full frame. Returns a checksum to prevent it from being
+/// optimized out.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_decode_frame() -> u32 {
+    STATE.with_borrow_mut(|state| {
+        let Some(state) = state.as_mut() else {
+            return 0;
+        };
+        let frame = core::mem::take(&mut state.fixture.frame);
+        let sum = state.driver.decode(&frame);
+        state.fixture.frame = frame;
+        #[expect(clippy::cast_possible_truncation, reason = "checksum, any 32 bits will do")]
+        let sum = sum as u32;
+        sum
+    })
+}
+
+/// Number of tiles in the benchmarked frame.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_tiles() -> u32 {
+    STATE.with_borrow(|state| {
+        state
+            .as_ref()
+            .and_then(|s| u32::try_from(s.fixture.tiles).ok())
+            .unwrap_or(0)
+    })
+}
+
+/// Whether this module was compiled with the wasm SIMD proposal enabled.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_has_simd128() -> u32 {
+    u32::from(cfg!(target_feature = "simd128"))
+}
+
+/// Decode stages, for [`bench_stage`].
+const STAGE_RLGR: u32 = 0;
+const STAGE_SUBBAND: u32 = 1;
+const STAGE_QUANTIZATION: u32 = 2;
+const STAGE_DWT: u32 = 3;
+const STAGE_YCBCR: u32 = 4;
+
+struct StageState {
+    fixture: crate::StageFixture,
+    /// Input each stage starts from, restored per iteration.
+    input: Vec<i16>,
+    work: Vec<i16>,
+    temp: Vec<i16>,
+    planes: [Vec<i16>; 3],
+    rgba: Vec<u8>,
+    stage: u32,
+}
+
+thread_local! {
+    static STAGES: RefCell<Option<StageState>> = const { RefCell::new(None) };
+}
+
+/// Prepares `stage` for `pattern`, seeded with the buffer that stage sees in
+/// production. Returns 1 on success, 0 if the arguments were out of range.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_stage_setup(pattern: u32, stage: u32, rlgr3: u32) -> u32 {
+    let Some(pattern) = Pattern::from_u32(pattern) else {
+        return 0;
+    };
+    if stage > STAGE_YCBCR {
+        return 0;
+    }
+    let algorithm = if rlgr3 == 0 {
+        EntropyAlgorithm::Rlgr1
+    } else {
+        EntropyAlgorithm::Rlgr3
+    };
+
+    let fixture = crate::stage_fixture(pattern, algorithm);
+    let planes = fixture.planes();
+
+    // Replay the pipeline up to `stage` so its input is the real thing.
+    let mut input = vec![0i16; crate::TILE * crate::TILE];
+    let mut temp = vec![0i16; crate::TILE * crate::TILE];
+    if stage >= STAGE_SUBBAND {
+        ironrdp_graphics::rlgr::decode(algorithm, &fixture.encoded[0], &mut input).expect("rlgr");
+    }
+    if stage >= STAGE_QUANTIZATION {
+        ironrdp_graphics::subband_reconstruction::decode(&mut input[4032..]);
+    }
+    if stage >= STAGE_DWT {
+        ironrdp_graphics::quantization::decode(&mut input, &fixture.quant);
+    }
+
+    STAGES.with_borrow_mut(|state| {
+        *state = Some(StageState {
+            fixture,
+            work: input.clone(),
+            input,
+            temp: core::mem::take(&mut temp),
+            planes,
+            rgba: vec![0u8; crate::TILE * crate::TILE * 4],
+            stage,
+        });
+    });
+
+    1
+}
+
+/// Runs the prepared stage once. Returns a checksum so the call cannot be
+/// optimized away.
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_stage_run() -> u32 {
+    STAGES.with_borrow_mut(|s| {
+        let Some(s) = s.as_mut() else {
+            return 0;
+        };
+
+        match s.stage {
+            STAGE_RLGR => {
+                ironrdp_graphics::rlgr::decode(s.fixture.algorithm, &s.fixture.encoded[0], &mut s.work).expect("rlgr");
+            }
+            STAGE_SUBBAND => {
+                s.work.copy_from_slice(&s.input);
+                ironrdp_graphics::subband_reconstruction::decode(&mut s.work[4032..]);
+            }
+            STAGE_QUANTIZATION => {
+                s.work.copy_from_slice(&s.input);
+                ironrdp_graphics::quantization::decode(&mut s.work, &s.fixture.quant);
+            }
+            STAGE_DWT => {
+                s.work.copy_from_slice(&s.input);
+                ironrdp_graphics::dwt::decode(&mut s.work, &mut s.temp);
+            }
+            STAGE_YCBCR => {
+                ironrdp_graphics::color_conversion::ycbcr_to_rgba(
+                    ironrdp_graphics::color_conversion::YCbCrBuffer {
+                        y: &s.planes[0],
+                        cb: &s.planes[1],
+                        cr: &s.planes[2],
+                    },
+                    &mut s.rgba,
+                )
+                .expect("ycbcr");
+                return u32::from(s.rgba[0]) | (u32::from(s.rgba[4096]) << 8);
+            }
+            _ => return 0,
+        }
+
+        #[expect(clippy::cast_sign_loss, reason = "checksum, any bit pattern will do")]
+        let sum = s.work[0] as u32 ^ ((s.work[2048] as u32) << 16);
+        sum
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bench_stage_restore_only() -> u32 {
+    STAGES.with_borrow_mut(|s| {
+        let Some(s) = s.as_mut() else {
+            return 0;
+        };
+        s.work.copy_from_slice(&s.input);
+        #[expect(clippy::cast_sign_loss, reason = "checksum, any bit pattern will do")]
+        let sum = s.work[0] as u32;
+        sum
+    })
+}

--- a/crates/ironrdp-rfxbench/tests/roundtrip.rs
+++ b/crates/ironrdp-rfxbench/tests/roundtrip.rs
@@ -1,0 +1,102 @@
+//! This guards the fixtures by running them through a round trip encode/decode
+//! and making sure that the decoded result is very similar to the original.
+//! (RemoteFX is lossy, so we don't expect to get the original input back verbatim.)
+
+#![allow(unused_crate_dependencies)] // Not every dependency is used by every target.
+
+use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
+use ironrdp_rfxbench::{Driver, Pattern, fixture, render};
+
+/// Mean absolute error per channel between the decoded image and the source.
+#[expect(clippy::as_conversions, reason = "u64 counters averaged as f64")]
+fn mean_abs_error(pattern: Pattern, width: u16, height: u16, algorithm: EntropyAlgorithm) -> f64 {
+    let fx = fixture(pattern, width, height, algorithm);
+    let mut driver = Driver::new(&fx);
+    driver.decode(&fx.frame);
+
+    let source = render(pattern, usize::from(width), usize::from(height));
+    let decoded = driver.image().data();
+    assert_eq!(source.len(), decoded.len());
+
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for (px_src, px_dec) in source.chunks_exact(4).zip(decoded.chunks_exact(4)) {
+        for c in 0..3 {
+            total += u64::from(px_src[c].abs_diff(px_dec[c]));
+            count += 1;
+        }
+    }
+
+    total as f64 / count as f64
+}
+
+#[test]
+fn every_pattern_round_trips() {
+    for pattern in Pattern::ALL {
+        for algorithm in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+            let mae = mean_abs_error(pattern, 640, 384, algorithm);
+            // RFX at the default quantization table is visibly lossy on
+            // high-frequency content, but a decoder that stopped early or
+            // mis-parsed would fail this check.
+            assert!(
+                mae < 24.0,
+                "{pattern:?}/{algorithm:?}: mean abs error {mae:.2} is too high, \
+                 the round trip is broken"
+            );
+            // And it must not be suspiciously perfect either: a fixture that
+            // decoded into an all-zero image would also score well on a
+            // near-black pattern.
+            assert!(mae > 0.0, "{pattern:?}/{algorithm:?}: suspiciously exact round trip");
+        }
+    }
+}
+
+#[test]
+fn decode_matches_its_own_source_far_better_than_an_unrelated_one() {
+    // This checks the decode is actually reconstructing *this* image:
+    // the error against its own source must be far smaller than against
+    // a different pattern of the same size.
+    for pattern in Pattern::ALL {
+        let fx = fixture(pattern, 640, 384, EntropyAlgorithm::Rlgr3);
+        let mut driver = Driver::new(&fx);
+        driver.decode(&fx.frame);
+        let decoded = driver.image().data().to_vec();
+
+        let own = mae_between(&decoded, &render(pattern, 640, 384));
+        for other in Pattern::ALL {
+            if other == pattern {
+                continue;
+            }
+            let cross = mae_between(&decoded, &render(other, 640, 384));
+            assert!(
+                own * 3.0 < cross,
+                "{pattern:?}: error against own source ({own:.2}) is not clearly \
+                 below error against {other:?} ({cross:.2})"
+            );
+        }
+    }
+}
+
+#[expect(clippy::as_conversions, reason = "u64 counters averaged as f64")]
+fn mae_between(a: &[u8], b: &[u8]) -> f64 {
+    assert_eq!(a.len(), b.len());
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for (pa, pb) in a.chunks_exact(4).zip(b.chunks_exact(4)) {
+        for c in 0..3 {
+            total += u64::from(pa[c].abs_diff(pb[c]));
+            count += 1;
+        }
+    }
+    total as f64 / count as f64
+}
+
+#[test]
+fn partial_tiles_are_covered() {
+    // 1080 is not a multiple of 64: the bottom row of tiles is partial, which is
+    // the case a real 1920x1080 session hits on every frame.
+    let fx = fixture(Pattern::Desktop, 1920, 1080, EntropyAlgorithm::Rlgr3);
+    assert_eq!(fx.tiles, 30 * 17);
+    let mut driver = Driver::new(&fx);
+    driver.decode(&fx.frame);
+}

--- a/crates/ironrdp-rfxbench/wasm/countsimd.mjs
+++ b/crates/ironrdp-rfxbench/wasm/countsimd.mjs
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import wabtInit from 'wabt';
+const wabt = await wabtInit();
+const re = /\b(v128\.\w+|i(?:8x16|16x8|32x4|64x2)\.\w+|f(?:32x4|64x2)\.\w+)/g;
+for (const p of process.argv.slice(2)) {
+  const bytes = await readFile(p);
+  const mod = wabt.readWasm(new Uint8Array(bytes), { simd: true, readDebugNames: false });
+  const wat = mod.toText({ foldExprs: false, inlineExport: false });
+  mod.destroy();
+  const counts = new Map();
+  let total = 0;
+  for (const m of wat.matchAll(re)) { total++; counts.set(m[1], (counts.get(m[1]) ?? 0) + 1); }
+  const top = [...counts.entries()].sort((a,b)=>b[1]-a[1]).slice(0,5).map(([k,v])=>`${k}x${v}`).join(' ');
+  console.log(`${basename(p).padEnd(28)} SIMD instrs: ${String(total).padEnd(7)} ${top}`);
+}

--- a/crates/ironrdp-rfxbench/wasm/package.json
+++ b/crates/ironrdp-rfxbench/wasm/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wasm",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "wabt": "^1.0.39"
+  }
+}

--- a/crates/ironrdp-rfxbench/wasm/run.mjs
+++ b/crates/ironrdp-rfxbench/wasm/run.mjs
@@ -1,0 +1,191 @@
+// Drives the ironrdp-rfxbench WASM module and reports RemoteFX decode
+// throughput, so the browser target can be measured with the same workload as
+// the native criterion bench.
+//
+//   node run.mjs <module.wasm> [more.wasm ...]
+//
+// Each module is labelled with whether it was built with wasm SIMD enabled, so
+// a baseline and a +simd128 build can be compared side by side.
+
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import wabtInit from 'wabt';
+
+const wabt = await wabtInit();
+
+const PATTERNS = ['desktop', 'text', 'gradient', 'photo', 'noise'];
+const SIZES = [
+  [1280, 720],
+  [1920, 1080],
+];
+
+// Enough repetitions that timer granularity and JIT noise wash out, but short
+// enough to keep a full sweep to a couple of minutes.
+const WARMUP_MS = 300;
+const BATCH_MS = 150;
+const BATCHES = 9;
+
+async function load(path) {
+  const bytes = await readFile(path);
+  const { instance } = await WebAssembly.instantiate(bytes, {});
+  return { path, exports: instance.exports, simd: countSimd(bytes) };
+}
+
+// Disassembles the module and counts actual SIMD instructions.
+// This checks that vector instructions really made it into the binary.
+function countSimd(bytes) {
+  const mod = wabt.readWasm(new Uint8Array(bytes), { simd: true, readDebugNames: false });
+  const wat = mod.toText({ foldExprs: false, inlineExport: false });
+  mod.destroy();
+  const counts = new Map();
+  // SIMD mnemonics are exactly those containing a lane-type token or `v128`.
+  const re = /\b(v128\.\w+|[iuf]?(?:8x16|16x8|32x4|64x2)\.\w+|i(?:8x16|16x8|32x4|64x2)\.\w+|f(?:32x4|64x2)\.\w+)/g;
+  let total = 0;
+  for (const m of wat.matchAll(re)) {
+    total++;
+    counts.set(m[1], (counts.get(m[1]) ?? 0) + 1);
+  }
+  const top = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6);
+  return { total, top };
+}
+
+function timeBatch(decode, iters) {
+  const start = performance.now();
+  let sink = 0;
+  for (let i = 0; i < iters; i++) sink += decode();
+  const elapsed = performance.now() - start;
+  return { elapsed, sink };
+}
+
+function measure(exports) {
+  const decode = exports.bench_decode_frame;
+
+  // Warm up and simultaneously calibrate the batch size.
+  let iters = 1;
+  const warmStart = performance.now();
+  while (performance.now() - warmStart < WARMUP_MS) {
+    timeBatch(decode, iters);
+    iters *= 2;
+  }
+
+  // Size a batch to run for about BATCH_MS.
+  const probe = timeBatch(decode, 8);
+  const perIter = probe.elapsed / 8;
+  const batchIters = Math.max(1, Math.round(BATCH_MS / Math.max(perIter, 1e-4)));
+
+  const samples = [];
+  for (let b = 0; b < BATCHES; b++) {
+    const { elapsed } = timeBatch(decode, batchIters);
+    samples.push(elapsed / batchIters);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    median: samples[Math.floor(samples.length / 2)],
+    best: samples[0],
+  };
+}
+
+const modules = [];
+for (const path of process.argv.slice(2)) modules.push(await load(path));
+
+if (modules.length === 0) {
+  console.error('usage: node run.mjs <module.wasm> [more.wasm ...]');
+  process.exit(2);
+}
+
+console.log('module                          simd128  SIMD instrs  most frequent');
+for (const m of modules) {
+  const flag = m.exports.bench_has_simd128() ? 'yes' : 'no ';
+  const top = m.simd.top.map(([k, v]) => `${k}x${v}`).join(' ');
+  console.log(`${basename(m.path).padEnd(31)} ${flag}      ${String(m.simd.total).padEnd(12)} ${top}`);
+}
+console.log();
+
+const header = ['resolution', 'pattern'].concat(modules.map((m) => basename(m.path, '.wasm')));
+const rows = [];
+
+for (const [w, h] of SIZES) {
+  for (const pattern of PATTERNS) {
+    const cells = [];
+    for (const m of modules) {
+      const wire = m.exports.bench_setup(PATTERNS.indexOf(pattern), w, h, 1);
+      if (wire === 0) throw new Error(`setup failed for ${pattern} ${w}x${h}`);
+      const { median } = measure(m.exports);
+      const fps = 1000 / median;
+      const mpx = (w * h) / median / 1000;
+      cells.push({ median, fps, mpx });
+    }
+    rows.push({ res: `${w}x${h}`, pattern, cells });
+  }
+}
+
+// ms/frame, frames/s, and megapixels/s
+const w0 = 12;
+const w1 = 10;
+console.log(
+  'resolution'.padEnd(w0) +
+  'pattern'.padEnd(w1) +
+  modules.map((m) => basename(m.path, '.wasm').padStart(22)).join('')
+);
+for (const row of rows) {
+  let line = row.res.padEnd(w0) + row.pattern.padEnd(w1);
+  for (const c of row.cells) {
+    line += `${c.median.toFixed(2)}ms ${c.fps.toFixed(0)}fps ${c.mpx.toFixed(0)}Mpx/s`.padStart(22);
+  }
+  if (row.cells.length === 2) {
+    const speedup = row.cells[0].median / row.cells[1].median;
+    line += `   ${speedup.toFixed(2)}x`;
+  }
+  console.log(line);
+}
+
+if (modules.length === 2) {
+  const ratios = rows.map((r) => r.cells[0].median / r.cells[1].median);
+  ratios.sort((a, b) => a - b);
+  const median = ratios[Math.floor(ratios.length / 2)];
+  console.log(`\nmedian speedup of ${basename(modules[1].path, '.wasm')} over ${basename(modules[0].path, '.wasm')}: ${median.toFixed(2)}x`);
+}
+
+// Per-stage breakdown: says where the frame time goes.
+// Times are per 4096-coefficient component (one third of a tile), except ycbcr which is per whole tile.
+const STAGES = ['rlgr', 'subband', 'quantization', 'dwt', 'ycbcr'];
+// Stages that restore their input buffer each iteration; the copy is measured
+// separately and subtracted.
+const RESTORES = new Set(['subband', 'quantization', 'dwt']);
+
+if (modules.some((m) => m.exports.bench_stage_setup)) {
+  console.log('\nper-stage, us per 4096-coefficient component (ycbcr: per 64x64 tile)');
+  console.log(
+    'pattern'.padEnd(10) +
+    'stage'.padEnd(14) +
+    modules.map((m) => basename(m.path, '.wasm').padStart(14)).join('') +
+    (modules.length === 2 ? '        speedup' : '')
+  );
+
+  for (const pattern of ['desktop', 'text', 'noise']) {
+    for (const stage of STAGES) {
+      const cells = [];
+      for (const m of modules) {
+        if (!m.exports.bench_stage_setup) {
+          cells.push(null);
+          continue;
+        }
+        if (m.exports.bench_stage_setup(PATTERNS.indexOf(pattern), STAGES.indexOf(stage), 1) !== 1) {
+          throw new Error(`stage setup failed for ${pattern}/${stage}`);
+        }
+        let us = measure({ bench_decode_frame: m.exports.bench_stage_run }).median * 1000;
+        if (RESTORES.has(stage)) {
+          const overhead = measure({ bench_decode_frame: m.exports.bench_stage_restore_only }).median * 1000;
+          us = Math.max(0, us - overhead);
+        }
+        cells.push(us);
+      }
+      let line = pattern.padEnd(10) + stage.padEnd(14);
+      for (const c of cells) line += (c === null ? '-' : c.toFixed(3)).padStart(14);
+      if (cells.length === 2 && cells[0] !== null && cells[1] !== null && cells[1] > 0) {
+        line += `        ${(cells[0] / cells[1]).toFixed(2)}x`;
+      }
+      console.log(line);
+    }
+  }
+}


### PR DESCRIPTION
Adds a benchmark suite for the various stages of the RemoteFX decode pipeline, then implements a couple changes that result in noticeable improvements to the metrics.

The optimized bit reader can likely be reused in a few places in the EGFX decode pipeline, but I'll save that for later to keep the change focused on RemoteFX.

This is my first foray into Rust benchmarking, and I also wanted a way to run the benchmarks in WASM since the IronRDP client I work with most runs in the browser. Let me know if I've done something non-standard or if you have any suggestions for improvements.