### PR TITLE
feat(activex): expand OLE clipboard snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,6 +2611,7 @@ dependencies = [
  "ironrdp-cfg",
  "ironrdp-client",
  "ironrdp-cliprdr",
+ "ironrdp-cliprdr-format",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
  "ironrdp-core 0.2.1",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 anyhow = "1"
 ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "smartcard", "sound", "webauthn"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
+ironrdp-cliprdr-format = { path = "../ironrdp-cliprdr-format", version = "0.2.0" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-connector = { path = "../ironrdp-connector", version = "0.10" }

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -646,11 +646,31 @@ connection while the RDP worker owns the protocol backend; shutdown removes the 
 activation; its explicit sync methods succeed at that point because the backend performs
 synchronization automatically. They return `E_UNEXPECTED` before connection or when clipboard
 redirection was disabled for the session.
-For the same active state, `IOleObject::GetClipboardData(0)` returns an immutable OLE `IDataObject` snapshot of the current Windows clipboard's valid `CF_UNICODETEXT` payload.
+For the same active state, `IOleObject::GetClipboardData(0)` returns an immutable OLE `IDataObject` snapshot of each currently available, valid payload in this allowlist:
+
+| Format | Snapshot validation |
+| --- | --- |
+| `CF_UNICODETEXT` | Even-sized, null-terminated valid UTF-16, trimmed at the first terminator |
+| `CF_TEXT`, `CF_OEMTEXT` | Null-terminated bytes, trimmed at the first terminator |
+| `CF_LOCALE` | Exactly the first four-byte locale identifier |
+| `CF_DIB`, `CF_DIBV5` | Bounded 24/32-bpp DIB accepted by `ironrdp-cliprdr-format`; embedded V5 profiles are rejected |
+| Registered `HTML Format` | Bounded CF_HTML with valid offsets and UTF-8 fragment, trimmed at `EndHTML` |
+
+Text and HTML clipboard allocations are limited to 16 MiB each.
+DIB allocations and the complete retained snapshot are limited to 64 MiB.
+Invalid, oversized, truncated, or unsupported payloads are omitted rather than advertised.
+
 The object supports source retrieval only (`DATADIR_GET`) with `DVASPECT_CONTENT`, `lindex = -1`, no target device, and `TYMED_HGLOBAL`.
-It validates those `FORMATETC` fields and returns a newly allocated `STGMEDIUM` for each `GetData` call, so the caller owns and must release that medium.
-Delayed rendering remains in the STA-bound native CLIPRDR backend while the snapshot is created; after creation the object has no live clipboard or RDP-worker dependency.
-No other clipboard format, conversion, inbound `SetData`, destination enumeration, `GetDataHere`, or data-advisory contract is claimed.
+`EnumFormatEtc` lists exactly the retained formats, and `QueryGetData` accepts exactly those formats and constraints.
+Each `GetData` call returns a separate `GMEM_MOVEABLE` allocation with `pUnkForRelease = NULL`.
+The caller owns that `STGMEDIUM` and must pass it to `ReleaseStgMedium`.
+
+Snapshot creation resolves native CLIPRDR delayed rendering on the ActiveX STA.
+It opens the Windows clipboard only around one format retrieval, closes it on every result path before trying another format, and aborts if the clipboard sequence changes between retrievals.
+Each remote delayed format can require a synchronous CLIPRDR round trip, so `GetClipboardData` can take one native-backend timeout per candidate format even though the clipboard lock is released between attempts.
+After creation, the object has no live clipboard or RDP-worker dependency.
+The snapshot does not expose `CF_HDROP`, `FileGroupDescriptorW`, file contents, RTF, arbitrary registered formats, GDI-handle formats, inbound `SetData`, destination enumeration, `GetDataHere`, or data advisories.
+File formats stay excluded because a correct OLE surface would also require path-safe descriptors, stream-index lifetime, CLIPRDR lock/unlock sequencing, bounded range reads, and explicit user-authorized file disclosure.
 `GetClipboardData` rejects a nonzero reserved value and reports `OLE_E_NOTRUNNING` before clipboard redirection is active.
 
 `IMsRdpClientNonScriptable5::UseMultimon` is disabled by default and can be changed only while the connection settings are mutable.
@@ -766,6 +786,6 @@ The worker translates supported Automation settings into `ironrdp-client::Config
 Connection points retain sinks through `Advise`/`Unadvise`, enumerate correctly, and query the supplied
 sink for the event interface IID before retaining its `IDispatch`.
 
-This is an Automation, lifecycle, hosting, framebuffer, basic input, RemoteApp projection, persistence, static virtual-channel, and Unicode-text OLE clipboard-snapshot foundation.
-It does not implement non-text or writable OLE clipboard exchange, monikers, non-filesystem RDPDR device redirection, or arbitrary persisted designer state.
+This is an Automation, lifecycle, hosting, framebuffer, basic input, RemoteApp projection, persistence, static virtual-channel, and bounded read-only OLE clipboard-snapshot foundation.
+It does not implement writable or file-backed OLE clipboard exchange, monikers, non-filesystem RDPDR device redirection, or arbitrary persisted designer state.
 Those contracts must be added as exact ABI implementations before advertising their individual methods as supported.

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -18,6 +18,8 @@ use ironrdp_client::rdp::{
     AutoReconnectDecision, CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent,
 };
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
+use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png};
+use ironrdp_cliprdr_format::html::cf_html_to_plain_html;
 use ironrdp_cliprdr_native::WinClipboard;
 use ironrdp_connector::{ConnectorError, ConnectorErrorKind, Credentials};
 use ironrdp_core::{DecodeError, DecodeErrorKind, ReadCursor, encode_vec};
@@ -45,11 +47,11 @@ use sha2::{Digest as _, Sha256};
 use tokio::sync::{mpsc, oneshot};
 use windows::Win32::Foundation::{
     DATA_S_SAMEFORMATETC, DISP_E_BADPARAMCOUNT, DISP_E_MEMBERNOTFOUND, DISP_E_TYPEMISMATCH, DISP_E_UNKNOWNNAME,
-    DV_E_DVASPECT, DV_E_DVTARGETDEVICE, DV_E_FORMATETC, DV_E_LINDEX, DV_E_TYMED, E_FAIL, E_INVALIDARG, E_NOTIMPL,
-    E_OUTOFMEMORY, E_POINTER, E_UNEXPECTED, ERROR_CANCELLED, ERROR_CLASS_DOES_NOT_EXIST, FreeLibrary, GlobalFree,
-    HGLOBAL, HMODULE, HWND, LPARAM, LRESULT, OLE_E_ADVISENOTSUPPORTED, OLE_E_NOCONNECTION, OLE_E_NOTRUNNING,
-    OLEOBJ_S_INVALIDVERB, POINT, RECT, RECTL, S_FALSE, S_OK, SIZE, SysStringLen, VARIANT_BOOL, VARIANT_FALSE,
-    VARIANT_TRUE, WPARAM,
+    DV_E_DVASPECT, DV_E_DVTARGETDEVICE, DV_E_FORMATETC, DV_E_LINDEX, DV_E_TYMED, E_ABORT, E_FAIL, E_INVALIDARG,
+    E_NOTIMPL, E_OUTOFMEMORY, E_POINTER, E_UNEXPECTED, ERROR_CANCELLED, ERROR_CLASS_DOES_NOT_EXIST, FreeLibrary,
+    GlobalFree, HGLOBAL, HMODULE, HWND, LPARAM, LRESULT, OLE_E_ADVISENOTSUPPORTED, OLE_E_NOCONNECTION,
+    OLE_E_NOTRUNNING, OLEOBJ_S_INVALIDVERB, POINT, RECT, RECTL, S_FALSE, S_OK, SIZE, SysStringLen, VARIANT_BOOL,
+    VARIANT_FALSE, VARIANT_TRUE, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BLACKNESS, BeginPaint, CreateCompatibleDC, CreateDIBSection, CreateRectRgn,
@@ -72,17 +74,19 @@ use windows::Win32::System::Com::{
     TYMED_HGLOBAL,
 };
 use windows::Win32::System::DataExchange::{
-    CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
+    CloseClipboard, GetClipboardData, GetClipboardSequenceNumber, IsClipboardFormatAvailable, OpenClipboard,
+    RegisterClipboardFormatW,
 };
 use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress, LoadLibraryW};
 use windows::Win32::System::Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock};
 use windows::Win32::System::Ole::{
-    CF_UNICODETEXT, CONTROLINFO, DVEXTENTINFO, HITRESULT_HIT, HITRESULT_OUTSIDE, IEnumOLEVERB, IEnumOLEVERB_Impl,
-    IOleClientSite, IOleControl, IOleControl_Impl, IOleControlSite, IOleControlSite_Vtbl, IOleInPlaceActiveObject,
-    IOleInPlaceActiveObject_Impl, IOleInPlaceObject, IOleInPlaceObject_Impl, IOleInPlaceSite, IOleInPlaceUIWindow,
-    IOleObject, IOleObject_Impl, IOleWindow_Impl, IViewObject, IViewObject_Impl, IViewObject2, IViewObject2_Impl,
-    IViewObjectEx, IViewObjectEx_Impl, KEYMODIFIERS, OLECLOSE, OLEGETMONIKER, OLEMISC, OLEVERB, OLEVERB_PRIMARY,
-    OLEVERBATTRIB_NEVERDIRTIES, OLEWHICHMK, USERCLASSTYPE, VIEWSTATUS_OPAQUE, VIEWSTATUS_SOLIDBKGND,
+    CF_DIB, CF_DIBV5, CF_LOCALE, CF_OEMTEXT, CF_TEXT, CF_UNICODETEXT, CONTROLINFO, DVEXTENTINFO, HITRESULT_HIT,
+    HITRESULT_OUTSIDE, IEnumOLEVERB, IEnumOLEVERB_Impl, IOleClientSite, IOleControl, IOleControl_Impl, IOleControlSite,
+    IOleControlSite_Vtbl, IOleInPlaceActiveObject, IOleInPlaceActiveObject_Impl, IOleInPlaceObject,
+    IOleInPlaceObject_Impl, IOleInPlaceSite, IOleInPlaceUIWindow, IOleObject, IOleObject_Impl, IOleWindow_Impl,
+    IViewObject, IViewObject_Impl, IViewObject2, IViewObject2_Impl, IViewObjectEx, IViewObjectEx_Impl, KEYMODIFIERS,
+    OLECLOSE, OLEGETMONIKER, OLEMISC, OLEVERB, OLEVERB_PRIMARY, OLEVERBATTRIB_NEVERDIRTIES, OLEWHICHMK, USERCLASSTYPE,
+    VIEWSTATUS_OPAQUE, VIEWSTATUS_SOLIDBKGND,
 };
 use windows::Win32::System::Registry::{
     HKEY, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE, REG_BINARY, REG_OPTION_NON_VOLATILE, RegCloseKey, RegCreateKeyExW,
@@ -5250,6 +5254,8 @@ struct ClipboardState {
 }
 
 const MAX_OLE_CLIPBOARD_TEXT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_OLE_CLIPBOARD_BINARY_BYTES: usize = 64 * 1024 * 1024;
+const MAX_OLE_CLIPBOARD_TOTAL_BYTES: usize = 64 * 1024 * 1024;
 
 impl ClipboardState {
     fn is_available(&self) -> bool {
@@ -5699,16 +5705,16 @@ impl IMsRdpClipboard_Impl for ClipboardCapabilities_Impl {
 #[implement(IEnumFORMATETC)]
 struct ClipboardFormatEnumerator {
     _lifetime: ServerObjectLifetime,
-    has_unicode_text: bool,
-    consumed: Cell<bool>,
+    formats: Vec<u16>,
+    position: Cell<usize>,
 }
 
 impl ClipboardFormatEnumerator {
-    fn new(has_unicode_text: bool, consumed: bool) -> Self {
+    fn new(formats: Vec<u16>, position: usize) -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
-            has_unicode_text,
-            consumed: Cell::new(consumed),
+            formats,
+            position: Cell::new(position),
         }
     }
 }
@@ -5726,35 +5732,30 @@ impl IEnumFORMATETC_Impl for ClipboardFormatEnumerator_Impl {
                 fetched.write(0);
             }
         }
-        if celt == 0 {
-            return S_OK;
-        }
-        if self.consumed.get() || !self.has_unicode_text {
-            return S_FALSE;
-        }
 
-        unsafe {
-            formats.write(unicode_text_format());
-        }
-        self.consumed.set(true);
-        if !fetched.is_null() {
+        let requested = usize::try_from(celt).expect("u32 fits in usize on Windows");
+        let position = self.position.get();
+        let copied = requested.min(self.formats.len().saturating_sub(position));
+        for (offset, format_id) in self.formats[position..position + copied].iter().enumerate() {
             unsafe {
-                fetched.write(1);
+                formats.add(offset).write(clipboard_format(*format_id));
             }
         }
-        if celt == 1 { S_OK } else { S_FALSE }
+        self.position.set(position + copied);
+        if !fetched.is_null() {
+            unsafe {
+                fetched.write(u32::try_from(copied).expect("copied count is bounded by celt"));
+            }
+        }
+        if copied == requested { S_OK } else { S_FALSE }
     }
 
     fn Skip(&self, celt: u32) -> Result<()> {
-        if celt == 0 {
-            return Ok(());
-        }
-        if self.consumed.get() || !self.has_unicode_text {
-            return Err(Error::from_hresult(S_FALSE));
-        }
-
-        self.consumed.set(true);
-        if celt == 1 {
+        let requested = usize::try_from(celt).expect("u32 fits in usize on Windows");
+        let position = self.position.get();
+        let skipped = requested.min(self.formats.len().saturating_sub(position));
+        self.position.set(position + skipped);
+        if skipped == requested {
             Ok(())
         } else {
             Err(Error::from_hresult(S_FALSE))
@@ -5762,82 +5763,92 @@ impl IEnumFORMATETC_Impl for ClipboardFormatEnumerator_Impl {
     }
 
     fn Reset(&self) -> Result<()> {
-        self.consumed.set(false);
+        self.position.set(0);
         Ok(())
     }
 
     fn Clone(&self) -> Result<IEnumFORMATETC> {
-        Ok(ClipboardFormatEnumerator::new(self.has_unicode_text, self.consumed.get()).into())
+        Ok(ClipboardFormatEnumerator::new(self.formats.clone(), self.position.get()).into())
     }
+}
+
+#[derive(Clone, Copy)]
+enum ClipboardSnapshotKind {
+    UnicodeText,
+    NullTerminatedText,
+    Locale,
+    Dib,
+    DibV5,
+    Html,
+}
+
+struct ClipboardSnapshotFormat {
+    id: u16,
+    data: Vec<u8>,
 }
 
 #[implement(IDataObject)]
 struct ClipboardDataObject {
     _lifetime: ServerObjectLifetime,
-    unicode_text: Option<Vec<u8>>,
+    formats: Vec<ClipboardSnapshotFormat>,
 }
 
 impl ClipboardDataObject {
     fn snapshot() -> Result<Self> {
-        let unicode_text = if unsafe { IsClipboardFormatAvailable(u32::from(CF_UNICODETEXT.0)) }.is_ok() {
-            unsafe {
-                OpenClipboard(None)?;
+        let html_format = u16::try_from(unsafe { RegisterClipboardFormatW(w!("HTML Format")) })
+            .ok()
+            .filter(|format| *format != 0);
+
+        let mut candidates = vec![
+            (CF_UNICODETEXT.0, ClipboardSnapshotKind::UnicodeText),
+            (CF_TEXT.0, ClipboardSnapshotKind::NullTerminatedText),
+            (CF_OEMTEXT.0, ClipboardSnapshotKind::NullTerminatedText),
+            (CF_LOCALE.0, ClipboardSnapshotKind::Locale),
+            (CF_DIB.0, ClipboardSnapshotKind::Dib),
+            (CF_DIBV5.0, ClipboardSnapshotKind::DibV5),
+        ];
+        if let Some(html_format) = html_format {
+            candidates.push((html_format, ClipboardSnapshotKind::Html));
+        }
+
+        let mut clipboard_sequence = unsafe { GetClipboardSequenceNumber() };
+        let mut total_bytes = 0usize;
+        let mut formats = Vec::with_capacity(candidates.len());
+        for (format_id, kind) in candidates {
+            let (data, next_sequence) = snapshot_clipboard_format(format_id, kind, clipboard_sequence)?;
+            clipboard_sequence = next_sequence;
+            let Some(data) = data else {
+                continue;
+            };
+            let Some(next_total) = total_bytes.checked_add(data.len()) else {
+                continue;
+            };
+            if next_total > MAX_OLE_CLIPBOARD_TOTAL_BYTES {
+                continue;
             }
-
-            let result = (|| {
-                let handle = match unsafe { GetClipboardData(u32::from(CF_UNICODETEXT.0)) } {
-                    Ok(handle) => HGLOBAL(handle.0),
-                    Err(_) => return Ok(None),
-                };
-                let byte_count = unsafe { GlobalSize(handle) };
-                if !(2..=MAX_OLE_CLIPBOARD_TEXT_BYTES).contains(&byte_count) || byte_count % 2 != 0 {
-                    return Ok(None);
-                }
-
-                let source = unsafe { GlobalLock(handle) }.cast::<u8>();
-                if source.is_null() {
-                    return Ok(None);
-                }
-                let snapshot = {
-                    let data = unsafe { slice::from_raw_parts(source, byte_count) };
-                    validated_unicode_text_snapshot(data)
-                };
-                match (snapshot, unlock_global_memory(handle)) {
-                    (Err(error), _) => Err(error),
-                    (Ok(_), Err(error)) => Err(error),
-                    (Ok(data), Ok(())) => Ok(data),
-                }
-            })();
-
-            let close_result = unsafe { CloseClipboard() };
-            match (result, close_result) {
-                (Ok(data), Ok(())) => data,
-                (Ok(_), Err(error)) => return Err(error),
-                (Err(error), _) => return Err(error),
-            }
-        } else {
-            None
-        };
+            total_bytes = next_total;
+            formats.push(ClipboardSnapshotFormat { id: format_id, data });
+        }
 
         Ok(Self {
             _lifetime: ServerObjectLifetime::new(),
-            unicode_text,
+            formats,
         })
     }
 
     #[cfg(test)]
-    fn from_unicode_text(unicode_text: Option<Vec<u8>>) -> Self {
+    fn from_formats(formats: Vec<(u16, Vec<u8>)>) -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
-            unicode_text,
+            formats: formats
+                .into_iter()
+                .map(|(id, data)| ClipboardSnapshotFormat { id, data })
+                .collect(),
         }
     }
 
-    fn validate_format(&self, format: *const FORMATETC) -> Result<()> {
+    fn validate_format(&self, format: *const FORMATETC) -> Result<&ClipboardSnapshotFormat> {
         let format = unsafe { format.as_ref() }.ok_or_else(|| Error::from_hresult(E_POINTER))?;
-        if format.cfFormat != CF_UNICODETEXT.0 {
-            return Err(Error::from_hresult(DV_E_FORMATETC));
-        }
         if !format.ptd.is_null() {
             return Err(Error::from_hresult(DV_E_DVTARGETDEVICE));
         }
@@ -5850,20 +5861,16 @@ impl ClipboardDataObject {
         if format.tymed & TYMED_HGLOBAL.0 as u32 == 0 {
             return Err(Error::from_hresult(DV_E_TYMED));
         }
-        if self.unicode_text.is_none() {
-            return Err(Error::from_hresult(DV_E_FORMATETC));
-        }
-        Ok(())
+        self.formats
+            .iter()
+            .find(|snapshot| snapshot.id == format.cfFormat)
+            .ok_or_else(|| Error::from_hresult(DV_E_FORMATETC))
     }
 }
 
 impl IDataObject_Impl for ClipboardDataObject_Impl {
     fn GetData(&self, format: *const FORMATETC) -> Result<STGMEDIUM> {
-        self.validate_format(format)?;
-        let data = self
-            .unicode_text
-            .as_ref()
-            .ok_or_else(|| Error::from_hresult(DV_E_FORMATETC))?;
+        let data = &self.validate_format(format)?.data;
 
         let memory = unsafe { GlobalAlloc(GMEM_MOVEABLE, data.len()) }?;
         let destination = unsafe { GlobalLock(memory) }.cast::<u8>();
@@ -5901,7 +5908,7 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
 
     fn QueryGetData(&self, format: *const FORMATETC) -> HRESULT {
         match self.validate_format(format) {
-            Ok(()) => S_OK,
+            Ok(_) => S_OK,
             Err(error) => error.code(),
         }
     }
@@ -5942,7 +5949,7 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
 
     fn EnumFormatEtc(&self, direction: u32) -> Result<IEnumFORMATETC> {
         if direction == DATADIR_GET.0 as u32 {
-            Ok(ClipboardFormatEnumerator::new(self.unicode_text.is_some(), false).into())
+            Ok(ClipboardFormatEnumerator::new(self.formats.iter().map(|format| format.id).collect(), 0).into())
         } else if direction == DATADIR_SET.0 as u32 {
             Err(Error::from_hresult(E_NOTIMPL))
         } else {
@@ -5963,14 +5970,158 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
     }
 }
 
-fn unicode_text_format() -> FORMATETC {
+fn clipboard_format(format_id: u16) -> FORMATETC {
     FORMATETC {
-        cfFormat: CF_UNICODETEXT.0,
+        cfFormat: format_id,
         ptd: ptr::null_mut(),
         dwAspect: DVASPECT_CONTENT.0,
         lindex: -1,
         tymed: TYMED_HGLOBAL.0 as u32,
     }
+}
+
+fn snapshot_clipboard_format(
+    format_id: u16,
+    kind: ClipboardSnapshotKind,
+    expected_sequence: u32,
+) -> Result<(Option<Vec<u8>>, u32)> {
+    unsafe {
+        OpenClipboard(None)?;
+    }
+
+    let result = (|| {
+        let opened_sequence = unsafe { GetClipboardSequenceNumber() };
+        if expected_sequence != 0 && opened_sequence != 0 && opened_sequence != expected_sequence {
+            return Err(Error::from_hresult(E_ABORT));
+        }
+        if unsafe { IsClipboardFormatAvailable(u32::from(format_id)) }.is_err() {
+            return Ok((None, opened_sequence));
+        }
+
+        let handle = match unsafe { GetClipboardData(u32::from(format_id)) } {
+            Ok(handle) => HGLOBAL(handle.0),
+            Err(_) => return Ok((None, unsafe { GetClipboardSequenceNumber() })),
+        };
+        let byte_count = unsafe { GlobalSize(handle) };
+        let max_bytes = match kind {
+            ClipboardSnapshotKind::UnicodeText
+            | ClipboardSnapshotKind::NullTerminatedText
+            | ClipboardSnapshotKind::Html => MAX_OLE_CLIPBOARD_TEXT_BYTES,
+            ClipboardSnapshotKind::Locale => size_of::<u32>() * 4,
+            ClipboardSnapshotKind::Dib | ClipboardSnapshotKind::DibV5 => MAX_OLE_CLIPBOARD_BINARY_BYTES,
+        };
+        if byte_count == 0 || byte_count > max_bytes {
+            return Ok((None, unsafe { GetClipboardSequenceNumber() }));
+        }
+
+        let source = unsafe { GlobalLock(handle) }.cast::<u8>();
+        if source.is_null() {
+            return Ok((None, unsafe { GetClipboardSequenceNumber() }));
+        }
+        let snapshot = {
+            let data = unsafe { slice::from_raw_parts(source, byte_count) };
+            validated_clipboard_snapshot(kind, data)
+        };
+        match (snapshot, unlock_global_memory(handle)) {
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Ok(data), Ok(())) => Ok((data, unsafe { GetClipboardSequenceNumber() })),
+        }
+    })();
+
+    match (result, unsafe { CloseClipboard() }) {
+        (Ok(data), Ok(())) => Ok(data),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), _) => Err(error),
+    }
+}
+
+fn validated_clipboard_snapshot(kind: ClipboardSnapshotKind, data: &[u8]) -> Result<Option<Vec<u8>>> {
+    match kind {
+        ClipboardSnapshotKind::UnicodeText => validated_unicode_text_snapshot(data),
+        ClipboardSnapshotKind::NullTerminatedText => Ok(data
+            .iter()
+            .position(|byte| *byte == 0)
+            .and_then(|terminator| terminator.checked_add(1))
+            .map(|length| data[..length].to_vec())),
+        ClipboardSnapshotKind::Locale => {
+            Ok((data.len() >= size_of::<u32>()).then(|| data[..size_of::<u32>()].to_vec()))
+        }
+        ClipboardSnapshotKind::Dib => Ok(validated_dib_snapshot(data, false)),
+        ClipboardSnapshotKind::DibV5 => Ok(validated_dib_snapshot(data, true)),
+        ClipboardSnapshotKind::Html => Ok(validated_html_snapshot(data)),
+    }
+}
+
+fn validated_dib_snapshot(data: &[u8], v5: bool) -> Option<Vec<u8>> {
+    let header_size = if v5 { 124usize } else { 40usize };
+    if data.len() < header_size || usize::try_from(u32_at(data, 0)?).ok()? != header_size {
+        return None;
+    }
+
+    let width = i32::from_le_bytes(data.get(4..8)?.try_into().ok()?);
+    let height = i32::from_le_bytes(data.get(8..12)?.try_into().ok()?);
+    let width = usize::try_from(width).ok()?;
+    let height = usize::try_from(height.checked_abs()?).ok()?;
+    if width == 0 || width > 10_000 || height == 0 || height > 10_000 {
+        return None;
+    }
+
+    let bit_count = usize::from(u16_at(data, 14)?);
+    let bits_per_row = width.checked_mul(bit_count)?;
+    let stride = bits_per_row.checked_add(31)?.checked_div(32)?.checked_mul(4)?;
+    let image_bytes = stride.checked_mul(height)?;
+    let declared_image_bytes = usize::try_from(u32_at(data, 20)?).ok()?;
+    if declared_image_bytes != 0 && declared_image_bytes != image_bytes {
+        return None;
+    }
+    if v5 && (u32_at(data, 112)? != 0 || u32_at(data, 116)? != 0) {
+        return None;
+    }
+
+    let payload_bytes = header_size.checked_add(image_bytes)?;
+    if payload_bytes > MAX_OLE_CLIPBOARD_BINARY_BYTES || payload_bytes > data.len() {
+        return None;
+    }
+    let payload = &data[..payload_bytes];
+    let valid = if v5 {
+        dibv5_to_png(payload).is_ok()
+    } else {
+        dib_to_png(payload).is_ok()
+    };
+    valid.then(|| payload.to_vec())
+}
+
+fn validated_html_snapshot(data: &[u8]) -> Option<Vec<u8>> {
+    const END_HTML: &[u8] = b"EndHTML:";
+    const MAX_HTML_HEADER_BYTES: usize = 4096;
+
+    let header = &data[..data.len().min(MAX_HTML_HEADER_BYTES)];
+    let marker = header.windows(END_HTML.len()).position(|window| window == END_HTML)?;
+    let value = &header[marker + END_HTML.len()..];
+    let value_end = value.iter().position(|byte| matches!(byte, b'\r' | b'\n'))?;
+    let end_html = core::str::from_utf8(&value[..value_end])
+        .ok()?
+        .trim()
+        .parse::<usize>()
+        .ok()?;
+    if end_html == 0 || end_html > data.len() {
+        return None;
+    }
+    cf_html_to_plain_html(&data[..end_html]).ok()?;
+    Some(data[..end_html].to_vec())
+}
+
+fn u16_at(data: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        data.get(offset..offset.checked_add(2)?)?.try_into().ok()?,
+    ))
+}
+
+fn u32_at(data: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        data.get(offset..offset.checked_add(4)?)?.try_into().ok()?,
+    ))
 }
 
 fn unlock_global_memory(memory: HGLOBAL) -> Result<()> {
@@ -17878,23 +18029,49 @@ mod tests {
     }
 
     #[test]
-    fn ole_clipboard_data_object_is_a_unicode_text_snapshot() {
-        let data_object: IDataObject =
-            ClipboardDataObject::from_unicode_text(Some(vec![b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0])).into();
-        let format = unicode_text_format();
+    fn ole_clipboard_data_object_enumerates_and_copies_rich_snapshot_formats() {
+        let unicode_text = vec![b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0];
+        let ansi_text = b"iron\0".to_vec();
+        let html_format = 0xC123;
+        let html = ironrdp_cliprdr_format::html::plain_html_to_cf_html("<b>iron</b>").into_bytes();
+        let data_object: IDataObject = ClipboardDataObject::from_formats(vec![
+            (CF_UNICODETEXT.0, unicode_text.clone()),
+            (CF_TEXT.0, ansi_text.clone()),
+            (html_format, html.clone()),
+        ])
+        .into();
+        let format = clipboard_format(CF_UNICODETEXT.0);
 
         assert_eq!(unsafe { data_object.QueryGetData(&format) }, S_OK);
 
         let enumerator =
             unsafe { data_object.EnumFormatEtc(DATADIR_GET.0 as u32) }.expect("enumerate source clipboard formats");
-        let mut formats = [FORMATETC::default()];
+        let mut formats = [FORMATETC::default(); 2];
         let mut fetched = 0;
         assert_eq!(unsafe { enumerator.Next(&mut formats, Some(&mut fetched)) }, S_OK);
-        assert_eq!(fetched, 1);
+        assert_eq!(fetched, 2);
         assert_eq!(formats[0].cfFormat, CF_UNICODETEXT.0);
+        assert_eq!(formats[1].cfFormat, CF_TEXT.0);
         assert_eq!(formats[0].tymed, TYMED_HGLOBAL.0 as u32);
-        assert_eq!(unsafe { enumerator.Next(&mut formats, Some(&mut fetched)) }, S_FALSE);
+        let clone = unsafe { enumerator.Clone() }.expect("clone format enumerator at its current position");
+        assert_eq!(unsafe { enumerator.Next(&mut formats[..1], Some(&mut fetched)) }, S_OK);
+        assert_eq!(formats[0].cfFormat, html_format);
+        assert_eq!(unsafe { clone.Next(&mut formats[..1], Some(&mut fetched)) }, S_OK);
+        assert_eq!(formats[0].cfFormat, html_format);
+        assert_eq!(
+            unsafe { enumerator.Next(&mut formats[..1], Some(&mut fetched)) },
+            S_FALSE
+        );
         assert_eq!(fetched, 0);
+        unsafe { enumerator.Reset() }.expect("reset format enumerator");
+        unsafe { enumerator.Skip(2) }.expect("skip available formats");
+        assert_eq!(unsafe { enumerator.Next(&mut formats[..1], Some(&mut fetched)) }, S_OK);
+        assert_eq!(formats[0].cfFormat, html_format);
+        unsafe { enumerator.Skip(1) }.expect("S_FALSE remains a successful COM status");
+        assert_eq!(
+            unsafe { enumerator.Next(&mut formats[..1], Some(&mut fetched)) },
+            S_FALSE
+        );
 
         let alternate_tymed = FORMATETC {
             tymed: TYMED_HGLOBAL.0 as u32 | windows::Win32::System::Com::TYMED_FILE.0 as u32,
@@ -17917,20 +18094,69 @@ mod tests {
         assert_eq!(aliasing_format.tymed, alternate_tymed.tymed);
         assert!(aliasing_format.ptd.is_null());
 
-        let mut medium = unsafe { data_object.GetData(&format) }.expect("retrieve clipboard snapshot");
-        assert_eq!(medium.tymed, TYMED_HGLOBAL.0 as u32);
-        let memory = unsafe { medium.u.hGlobal };
-        let source = unsafe { GlobalLock(memory) }.cast::<u8>();
+        let mut first_medium = unsafe { data_object.GetData(&format) }.expect("retrieve first clipboard snapshot copy");
+        let mut second_medium =
+            unsafe { data_object.GetData(&format) }.expect("retrieve second clipboard snapshot copy");
+        assert_eq!(first_medium.tymed, TYMED_HGLOBAL.0 as u32);
+        assert!(first_medium.pUnkForRelease.is_none());
+        let first_memory = unsafe { first_medium.u.hGlobal };
+        let second_memory = unsafe { second_medium.u.hGlobal };
+        assert_ne!(first_memory, second_memory);
+        let source = unsafe { GlobalLock(first_memory) }.cast::<u8>();
         assert!(!source.is_null());
-        let copied = unsafe { slice::from_raw_parts(source, GlobalSize(memory)) };
-        assert_eq!(copied, [b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0]);
-        unlock_global_memory(memory).expect("unlock returned clipboard medium");
+        let copied = unsafe { slice::from_raw_parts(source, GlobalSize(first_memory)) };
+        assert_eq!(copied, unicode_text);
+        unlock_global_memory(first_memory).expect("unlock returned clipboard medium");
+        let source = unsafe { GlobalLock(second_memory) }.cast::<u8>();
+        assert!(!source.is_null());
+        let copied = unsafe { slice::from_raw_parts(source, GlobalSize(second_memory)) };
+        assert_eq!(copied, unicode_text);
+        unlock_global_memory(second_memory).expect("unlock independently returned clipboard medium");
         unsafe {
-            ReleaseStgMedium(&mut medium);
+            ReleaseStgMedium(&mut first_medium);
+            ReleaseStgMedium(&mut second_medium);
+        }
+
+        let ansi_format = clipboard_format(CF_TEXT.0);
+        let mut ansi_medium = unsafe { data_object.GetData(&ansi_format) }.expect("retrieve ANSI clipboard snapshot");
+        let ansi_memory = unsafe { ansi_medium.u.hGlobal };
+        let source = unsafe { GlobalLock(ansi_memory) }.cast::<u8>();
+        assert_eq!(
+            unsafe { slice::from_raw_parts(source, GlobalSize(ansi_memory)) },
+            ansi_text
+        );
+        unlock_global_memory(ansi_memory).expect("unlock ANSI clipboard medium");
+        unsafe {
+            ReleaseStgMedium(&mut ansi_medium);
+        }
+
+        let html_formatetc = clipboard_format(html_format);
+        let mut html_medium =
+            unsafe { data_object.GetData(&html_formatetc) }.expect("retrieve HTML clipboard snapshot");
+        let html_memory = unsafe { html_medium.u.hGlobal };
+        let source = unsafe { GlobalLock(html_memory) }.cast::<u8>();
+        assert_eq!(unsafe { slice::from_raw_parts(source, GlobalSize(html_memory)) }, html);
+        unlock_global_memory(html_memory).expect("unlock HTML clipboard medium");
+        unsafe {
+            ReleaseStgMedium(&mut html_medium);
         }
 
         let invalid_tymed = FORMATETC { tymed: 0, ..format };
         assert_eq!(unsafe { data_object.QueryGetData(&invalid_tymed) }, DV_E_TYMED);
+        let invalid_format = FORMATETC {
+            cfFormat: CF_DIB.0,
+            ..format
+        };
+        assert_eq!(unsafe { data_object.QueryGetData(&invalid_format) }, DV_E_FORMATETC);
+        let mut target_device = DVTARGETDEVICE::default();
+        let targeted_format = FORMATETC {
+            ptd: &mut target_device,
+            ..format
+        };
+        assert_eq!(
+            unsafe { data_object.QueryGetData(&targeted_format) },
+            DV_E_DVTARGETDEVICE
+        );
         let mut caller_medium = STGMEDIUM::default();
         assert_eq!(
             unsafe { data_object.GetDataHere(&format, &mut caller_medium) }
@@ -17954,7 +18180,7 @@ mod tests {
     }
 
     #[test]
-    fn ole_clipboard_snapshot_validation_rejects_malformed_text() {
+    fn ole_clipboard_snapshot_validation_rejects_hostile_formats_and_trims_payloads() {
         assert_eq!(
             validated_unicode_text_snapshot(&[0]).expect("reject undersized text"),
             None
@@ -17975,15 +18201,81 @@ mod tests {
             validated_unicode_text_snapshot(&[0, 0xd8, 0, 0]).expect("reject invalid UTF-16"),
             None
         );
-    }
-
-    #[test]
-    fn ole_clipboard_snapshot_stops_at_first_terminator() {
-        let snapshot = validated_unicode_text_snapshot(&[b'i', 0, 0, 0, b'r', 0])
+        let unicode_snapshot = validated_unicode_text_snapshot(&[b'i', 0, 0, 0, b'r', 0])
             .expect("accept valid Unicode text")
             .expect("return the text before the terminator");
+        assert_eq!(unicode_snapshot, [b'i', 0, 0, 0]);
 
-        assert_eq!(snapshot, [b'i', 0, 0, 0]);
+        let ansi_snapshot = validated_clipboard_snapshot(ClipboardSnapshotKind::NullTerminatedText, b"iron\0private")
+            .expect("validate ANSI text")
+            .expect("return ANSI text before allocator padding");
+        assert_eq!(ansi_snapshot, b"iron\0");
+        assert_eq!(
+            validated_clipboard_snapshot(ClipboardSnapshotKind::NullTerminatedText, b"unterminated")
+                .expect("reject unterminated ANSI text"),
+            None
+        );
+
+        let html = ironrdp_cliprdr_format::html::plain_html_to_cf_html("<b>iron</b>");
+        let mut padded_html = html.as_bytes().to_vec();
+        padded_html.extend_from_slice(b"private");
+        assert_eq!(
+            validated_html_snapshot(&padded_html).expect("accept valid CF_HTML"),
+            html.as_bytes()
+        );
+        let mut invalid_html = html.into_bytes();
+        let marker = invalid_html
+            .windows(b"EndHTML:".len())
+            .position(|window| window == b"EndHTML:")
+            .expect("generated CF_HTML has EndHTML");
+        invalid_html[marker + b"EndHTML:".len()..marker + b"EndHTML:".len() + 10].copy_from_slice(b"9999999999");
+        assert_eq!(validated_html_snapshot(&invalid_html), None);
+
+        let mut dib = vec![0u8; 44];
+        dib[0..4].copy_from_slice(&40u32.to_le_bytes());
+        dib[4..8].copy_from_slice(&1i32.to_le_bytes());
+        dib[8..12].copy_from_slice(&1i32.to_le_bytes());
+        dib[12..14].copy_from_slice(&1u16.to_le_bytes());
+        dib[14..16].copy_from_slice(&32u16.to_le_bytes());
+        dib[20..24].copy_from_slice(&4u32.to_le_bytes());
+        dib[40..44].copy_from_slice(&[0x10, 0x20, 0x30, 0xFF]);
+        let mut padded_dib = dib.clone();
+        padded_dib.extend_from_slice(b"private");
+        let dib_snapshot = validated_dib_snapshot(&padded_dib, false).expect("accept bounded DIB");
+        assert_eq!(dib_snapshot, dib);
+        let data_object: IDataObject = ClipboardDataObject::from_formats(vec![(CF_DIB.0, dib_snapshot.clone())]).into();
+        let mut medium =
+            unsafe { data_object.GetData(&clipboard_format(CF_DIB.0)) }.expect("round-trip validated DIB snapshot");
+        let memory = unsafe { medium.u.hGlobal };
+        let source = unsafe { GlobalLock(memory) }.cast::<u8>();
+        assert_eq!(
+            unsafe { slice::from_raw_parts(source, GlobalSize(memory)) },
+            dib_snapshot
+        );
+        unlock_global_memory(memory).expect("unlock DIB clipboard medium");
+        unsafe {
+            ReleaseStgMedium(&mut medium);
+        }
+        assert_eq!(validated_dib_snapshot(&dib[..43], false), None);
+        let mut oversized_dib = dib.clone();
+        oversized_dib[4..8].copy_from_slice(&10_001i32.to_le_bytes());
+        assert_eq!(validated_dib_snapshot(&oversized_dib, false), None);
+        let mut inconsistent_dib = dib;
+        inconsistent_dib[20..24].copy_from_slice(&8u32.to_le_bytes());
+        assert_eq!(validated_dib_snapshot(&inconsistent_dib, false), None);
+
+        let mut dibv5 = vec![0u8; 128];
+        dibv5[0..4].copy_from_slice(&124u32.to_le_bytes());
+        dibv5[4..8].copy_from_slice(&1i32.to_le_bytes());
+        dibv5[8..12].copy_from_slice(&(-1i32).to_le_bytes());
+        dibv5[12..14].copy_from_slice(&1u16.to_le_bytes());
+        dibv5[14..16].copy_from_slice(&32u16.to_le_bytes());
+        dibv5[20..24].copy_from_slice(&4u32.to_le_bytes());
+        dibv5[56..60].copy_from_slice(&0x7352_4742u32.to_le_bytes());
+        dibv5[124..128].copy_from_slice(&[0x10, 0x20, 0x30, 0xFF]);
+        assert_eq!(validated_dib_snapshot(&dibv5, true), Some(dibv5.clone()));
+        dibv5[116..120].copy_from_slice(&4u32.to_le_bytes());
+        assert_eq!(validated_dib_snapshot(&dibv5, true), None);
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -18,8 +18,8 @@ use ironrdp_client::rdp::{
     AutoReconnectDecision, CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent,
 };
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
-use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png};
-use ironrdp_cliprdr_format::html::cf_html_to_plain_html;
+use ironrdp_cliprdr_format::bitmap::{validate_dib, validate_dibv5};
+use ironrdp_cliprdr_format::html::validate_cf_html;
 use ironrdp_cliprdr_native::WinClipboard;
 use ironrdp_connector::{ConnectorError, ConnectorErrorKind, Credentials};
 use ironrdp_core::{DecodeError, DecodeErrorKind, ReadCursor, encode_vec};
@@ -6054,74 +6054,17 @@ fn validated_clipboard_snapshot(kind: ClipboardSnapshotKind, data: &[u8]) -> Res
 }
 
 fn validated_dib_snapshot(data: &[u8], v5: bool) -> Option<Vec<u8>> {
-    let header_size = if v5 { 124usize } else { 40usize };
-    if data.len() < header_size || usize::try_from(u32_at(data, 0)?).ok()? != header_size {
-        return None;
-    }
-
-    let width = i32::from_le_bytes(data.get(4..8)?.try_into().ok()?);
-    let height = i32::from_le_bytes(data.get(8..12)?.try_into().ok()?);
-    let width = usize::try_from(width).ok()?;
-    let height = usize::try_from(height.checked_abs()?).ok()?;
-    if width == 0 || width > 10_000 || height == 0 || height > 10_000 {
-        return None;
-    }
-
-    let bit_count = usize::from(u16_at(data, 14)?);
-    let bits_per_row = width.checked_mul(bit_count)?;
-    let stride = bits_per_row.checked_add(31)?.checked_div(32)?.checked_mul(4)?;
-    let image_bytes = stride.checked_mul(height)?;
-    let declared_image_bytes = usize::try_from(u32_at(data, 20)?).ok()?;
-    if declared_image_bytes != 0 && declared_image_bytes != image_bytes {
-        return None;
-    }
-    if v5 && (u32_at(data, 112)? != 0 || u32_at(data, 116)? != 0) {
-        return None;
-    }
-
-    let payload_bytes = header_size.checked_add(image_bytes)?;
-    if payload_bytes > MAX_OLE_CLIPBOARD_BINARY_BYTES || payload_bytes > data.len() {
-        return None;
-    }
-    let payload = &data[..payload_bytes];
-    let valid = if v5 {
-        dibv5_to_png(payload).is_ok()
+    let payload_bytes = if v5 {
+        validate_dibv5(data).ok()?
     } else {
-        dib_to_png(payload).is_ok()
+        validate_dib(data).ok()?
     };
-    valid.then(|| payload.to_vec())
+    Some(data[..payload_bytes].to_vec())
 }
 
 fn validated_html_snapshot(data: &[u8]) -> Option<Vec<u8>> {
-    const END_HTML: &[u8] = b"EndHTML:";
-    const MAX_HTML_HEADER_BYTES: usize = 4096;
-
-    let header = &data[..data.len().min(MAX_HTML_HEADER_BYTES)];
-    let marker = header.windows(END_HTML.len()).position(|window| window == END_HTML)?;
-    let value = &header[marker + END_HTML.len()..];
-    let value_end = value.iter().position(|byte| matches!(byte, b'\r' | b'\n'))?;
-    let end_html = core::str::from_utf8(&value[..value_end])
-        .ok()?
-        .trim()
-        .parse::<usize>()
-        .ok()?;
-    if end_html == 0 || end_html > data.len() {
-        return None;
-    }
-    cf_html_to_plain_html(&data[..end_html]).ok()?;
-    Some(data[..end_html].to_vec())
-}
-
-fn u16_at(data: &[u8], offset: usize) -> Option<u16> {
-    Some(u16::from_le_bytes(
-        data.get(offset..offset.checked_add(2)?)?.try_into().ok()?,
-    ))
-}
-
-fn u32_at(data: &[u8], offset: usize) -> Option<u32> {
-    Some(u32::from_le_bytes(
-        data.get(offset..offset.checked_add(4)?)?.try_into().ok()?,
-    ))
+    let payload_bytes = validate_cf_html(data).ok()?;
+    Some(data[..payload_bytes].to_vec())
 }
 
 fn unlock_global_memory(memory: HGLOBAL) -> Result<()> {

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -503,6 +503,10 @@ fn validate_v5_header(header: &BitmapV5Header) -> Result<(), BitmapError> {
         return Err(BitmapError::Unsupported("not supported color space"));
     }
 
+    if header.profile_data != 0 || header.profile_size != 0 {
+        return Err(BitmapError::Unsupported("embedded color profile is not supported"));
+    }
+
     Ok(())
 }
 
@@ -538,6 +542,57 @@ fn rgb_bmp_stride(width: u16, bit_count: u16) -> usize {
     {
         (((usize::from(width) * usize::from(bit_count)) + 31) & !31) >> 3
     }
+}
+
+fn bitmap_data<'a>(header: &BitmapInfoHeader, header_size: usize, input: &'a [u8]) -> Result<&'a [u8], BitmapError> {
+    let image_size = rgb_bmp_stride(header.width(), header.bit_count)
+        .checked_mul(usize::from(header.height()))
+        .ok_or(BitmapError::BufferTooBig)?;
+    let declared_size = usize::try_from(header.size_image).map_err(|_| BitmapError::InvalidSize)?;
+    if declared_size != 0 && declared_size != image_size {
+        return Err(BitmapError::InvalidSize);
+    }
+    let total_size = header_size.checked_add(image_size).ok_or(BitmapError::BufferTooBig)?;
+    if total_size > MAX_BUFFER_SIZE {
+        return Err(BitmapError::BufferTooBig);
+    }
+
+    input.get(..image_size).ok_or(BitmapError::InvalidSize)
+}
+
+fn decode_dib(input: &[u8]) -> Result<(BitmapInfoHeader, &[u8]), BitmapError> {
+    let mut src = ReadCursor::new(input);
+    let header = BitmapInfoHeader::decode(&mut src).map_err(BitmapError::Decode)?;
+    validate_v1_header(&header)?;
+    if header.compression != BitmapCompression::RGB {
+        return Err(BitmapError::Unsupported("unsupported compression"));
+    }
+    let bitmap = bitmap_data(&header, BitmapInfoHeader::FIXED_PART_SIZE, src.remaining())?;
+    Ok((header, bitmap))
+}
+
+fn decode_dibv5(input: &[u8]) -> Result<(BitmapV5Header, &[u8]), BitmapError> {
+    let mut src = ReadCursor::new(input);
+    let header = BitmapV5Header::decode(&mut src).map_err(BitmapError::Decode)?;
+    validate_v5_header(&header)?;
+    let bitmap = bitmap_data(&header.v1, BitmapV5Header::FIXED_PART_SIZE, src.remaining())?;
+    Ok((header, bitmap))
+}
+
+/// Validates a `CF_DIB` payload without allocating and returns its logical byte length.
+pub fn validate_dib(input: &[u8]) -> Result<usize, BitmapError> {
+    let (_, bitmap) = decode_dib(input)?;
+    BitmapInfoHeader::FIXED_PART_SIZE
+        .checked_add(bitmap.len())
+        .ok_or(BitmapError::BufferTooBig)
+}
+
+/// Validates a `CF_DIBV5` payload without allocating and returns its logical byte length.
+pub fn validate_dibv5(input: &[u8]) -> Result<usize, BitmapError> {
+    let (_, bitmap) = decode_dibv5(input)?;
+    BitmapV5Header::FIXED_PART_SIZE
+        .checked_add(bitmap.len())
+        .ok_or(BitmapError::BufferTooBig)
 }
 
 fn bgra_to_top_down_rgba(
@@ -645,32 +700,15 @@ fn encode_png(ctx: &PngEncoderContext) -> Result<Vec<u8>, BitmapError> {
 
 /// Converts `CF_DIB` to PNG.
 pub fn dib_to_png(input: &[u8]) -> Result<Vec<u8>, BitmapError> {
-    let mut src = ReadCursor::new(input);
-    let header = BitmapInfoHeader::decode(&mut src).map_err(BitmapError::Decode)?;
-
-    validate_v1_header(&header)?;
-
-    // We support only uncompressed DIB bitmaps as it is the most common case for clipboard-copied bitmaps.
-    // However, for DIBv1 specifically, BitmapCompression::BITFIELDS is not supported even when the order is BGRA,
-    // because there is an additional variable-sized header holding the color masks that we don’t support yet.
-    const DIBV1_SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB];
-
-    if !DIBV1_SUPPORTED_COMPRESSION.contains(&header.compression) {
-        return Err(BitmapError::Unsupported("unsupported compression"));
-    }
-
-    let png_ctx = bgra_to_top_down_rgba(&header, src.remaining(), false)?;
+    let (header, bitmap) = decode_dib(input)?;
+    let png_ctx = bgra_to_top_down_rgba(&header, bitmap, false)?;
     encode_png(&png_ctx)
 }
 
-/// Converts `CF_DIB` to PNG.
+/// Converts `CF_DIBV5` to PNG.
 pub fn dibv5_to_png(input: &[u8]) -> Result<Vec<u8>, BitmapError> {
-    let mut src = ReadCursor::new(input);
-    let header = BitmapV5Header::decode(&mut src).map_err(BitmapError::Decode)?;
-
-    validate_v5_header(&header)?;
-
-    let png_ctx = bgra_to_top_down_rgba(&header.v1, src.remaining(), true)?;
+    let (header, bitmap) = decode_dibv5(input)?;
+    let png_ctx = bgra_to_top_down_rgba(&header.v1, bitmap, true)?;
     encode_png(&png_ctx)
 }
 

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -40,6 +40,164 @@ impl From<core::num::ParseIntError> for HtmlError {
     }
 }
 
+struct CfHtml<'a> {
+    fragment: &'a str,
+    payload_len: usize,
+}
+
+#[derive(Default)]
+struct CfHtmlHeaders<'a> {
+    version: Option<&'a str>,
+    start_html: Option<i64>,
+    end_html: Option<i64>,
+    start_fragment: Option<i64>,
+    end_fragment: Option<i64>,
+    start_selection: Option<i64>,
+    end_selection: Option<i64>,
+}
+
+impl CfHtmlHeaders<'_> {
+    fn has_required_fields(&self) -> bool {
+        self.version.is_some()
+            && self.start_html.is_some()
+            && self.end_html.is_some()
+            && self.start_fragment.is_some()
+            && self.end_fragment.is_some()
+    }
+}
+
+fn parse_cf_html(input: &[u8]) -> Result<CfHtml<'_>, HtmlError> {
+    const EOL_CONTROL_CHARS: &[u8] = b"\r\n";
+    const START_FRAGMENT_MARKER: &[u8] = b"<!--StartFragment-->";
+    const END_FRAGMENT_MARKER: &[u8] = b"<!--EndFragment-->";
+
+    let mut headers = CfHtmlHeaders::default();
+    let mut header_len = 0;
+    while !headers.has_required_fields() {
+        header_len = parse_header_line(input, header_len, &mut headers)?;
+    }
+
+    if !matches!(headers.version, Some("0.9" | "1.0")) {
+        return Err(HtmlError::InvalidFormat);
+    }
+
+    let start_fragment = positive_offset(headers.start_fragment)?;
+    let end_fragment = positive_offset(headers.end_fragment)?;
+    if !(header_len <= start_fragment && start_fragment < end_fragment && end_fragment <= input.len()) {
+        return Err(HtmlError::InvalidFormat);
+    }
+
+    let marker_start = start_fragment
+        .checked_sub(START_FRAGMENT_MARKER.len())
+        .ok_or(HtmlError::InvalidFormat)?;
+    let header_boundary = match headers.start_html {
+        Some(-1) => marker_start,
+        Some(start) => usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?,
+        None => return Err(HtmlError::InvalidFormat),
+    };
+    while header_len < header_boundary {
+        header_len = parse_header_line(input, header_len, &mut headers)?;
+    }
+    if header_len != header_boundary {
+        return Err(HtmlError::InvalidFormat);
+    }
+
+    if input.get(marker_start..start_fragment) != Some(START_FRAGMENT_MARKER) {
+        return Err(HtmlError::InvalidFormat);
+    }
+    let marker_end = end_fragment
+        .checked_add(END_FRAGMENT_MARKER.len())
+        .ok_or(HtmlError::InvalidFormat)?;
+    if input.get(end_fragment..marker_end) != Some(END_FRAGMENT_MARKER) {
+        return Err(HtmlError::InvalidFormat);
+    }
+
+    let payload_len = match (headers.start_html, headers.end_html) {
+        (Some(-1), Some(-1)) => marker_end,
+        (Some(start), Some(end)) if 0 <= start && 0 <= end => {
+            let start = usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?;
+            let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
+            if !(header_len == start && start <= marker_start && marker_end <= end && end <= input.len()) {
+                return Err(HtmlError::InvalidFormat);
+            }
+            end
+        }
+        _ => return Err(HtmlError::InvalidFormat),
+    };
+
+    match (headers.start_selection, headers.end_selection) {
+        (None, None) => {}
+        (Some(start), Some(end)) => {
+            let start = usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?;
+            let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
+            if !(start_fragment <= start && start <= end && end <= end_fragment) {
+                return Err(HtmlError::InvalidFormat);
+            }
+        }
+        _ => return Err(HtmlError::InvalidFormat),
+    }
+
+    core::str::from_utf8(&input[..payload_len])?;
+    let fragment = core::str::from_utf8(&input[start_fragment..end_fragment])?;
+
+    fn parse_header_line<'a>(
+        input: &'a [u8],
+        offset: usize,
+        headers: &mut CfHtmlHeaders<'a>,
+    ) -> Result<usize, HtmlError> {
+        let rest = input.get(offset..).ok_or(HtmlError::InvalidFormat)?;
+        let eol_pos = rest
+            .iter()
+            .position(|byte| EOL_CONTROL_CHARS.contains(byte))
+            .ok_or(HtmlError::InvalidFormat)?;
+        let line = core::str::from_utf8(&rest[..eol_pos])?;
+        let (key, value) = line.split_once(':').ok_or(HtmlError::InvalidFormat)?;
+        match key {
+            "Version" if headers.version.replace(value).is_some() => return Err(HtmlError::InvalidFormat),
+            "StartHTML" if headers.start_html.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            "EndHTML" if headers.end_html.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            "StartFragment" if headers.start_fragment.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            "EndFragment" if headers.end_fragment.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            "StartSelection" if headers.start_selection.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            "EndSelection" if headers.end_selection.replace(parse_offset(value)?).is_some() => {
+                return Err(HtmlError::InvalidFormat);
+            }
+            _ => {}
+        }
+
+        let mut next = offset.checked_add(eol_pos).ok_or(HtmlError::InvalidConversion)?;
+        while matches!(input.get(next), Some(b'\n' | b'\r')) {
+            next = next.checked_add(1).ok_or(HtmlError::InvalidConversion)?;
+        }
+        Ok(next)
+    }
+
+    fn parse_offset(value: &str) -> Result<i64, HtmlError> {
+        Ok(value.trim().parse()?)
+    }
+
+    fn positive_offset(value: Option<i64>) -> Result<usize, HtmlError> {
+        usize::try_from(value.ok_or(HtmlError::InvalidFormat)?).map_err(|_| HtmlError::InvalidConversion)
+    }
+
+    Ok(CfHtml { fragment, payload_len })
+}
+
+/// Validates a `CF_HTML` payload and returns its logical byte length.
+pub fn validate_cf_html(input: &[u8]) -> Result<usize, HtmlError> {
+    Ok(parse_cf_html(input)?.payload_len)
+}
+
 /// Converts `CF_HTML` format to plain HTML text.
 ///
 /// Note that the `CF_HTML` format is using UTF-8, and the input is expected to be valid UTF-8.
@@ -50,70 +208,7 @@ impl From<core::num::ParseIntError> for HtmlError {
 /// Because of that, this function takes the input as a byte slice and finds the end of the payload itself.
 /// This is expected to be more convenient at the callsite.
 pub fn cf_html_to_plain_html(input: &[u8]) -> Result<&str, HtmlError> {
-    const EOL_CONTROL_CHARS: &[u8] = b"\r\n";
-
-    let mut start_fragment = None;
-    let mut end_fragment = None;
-
-    // We’ll move the lower bound of this slice until all headers are read.
-    let mut cursor = input;
-
-    loop {
-        let line = {
-            // We use a custom logic for splitting lines, instead of something like `str::lines`.
-            // That’s because `str::lines` does not split at carriage return (`\r`) not followed by line feed (`\n`).
-            // In `CF_HTML` format, the line ending could be represented using `\r` alone.
-            let eol_pos = cursor
-                .iter()
-                .position(|byte| EOL_CONTROL_CHARS.contains(byte))
-                .ok_or(HtmlError::InvalidFormat)?;
-            core::str::from_utf8(&cursor[..eol_pos])?
-        };
-
-        match line.split_once(':') {
-            Some((key, value)) => match key {
-                "StartFragment" => {
-                    start_fragment = Some(header_value_to_u32(value)?);
-                }
-                "EndFragment" => {
-                    end_fragment = Some(header_value_to_u32(value)?);
-                }
-                _ => {
-                    // We are not interested in other headers.
-                }
-            },
-            None => {
-                // At this point, we reached the end of the headers.
-                if let (Some(start), Some(end)) = (start_fragment, end_fragment) {
-                    let start = usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?;
-                    let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
-
-                    // Ensure start and end values are properly bounded.
-                    if !(start < end && end < input.len()) {
-                        return Err(HtmlError::InvalidFormat);
-                    }
-
-                    // Extract the fragment from the original buffer.
-                    let fragment = core::str::from_utf8(&input[start..end])?;
-
-                    return Ok(fragment);
-                } else {
-                    // If required headers were not found, the input is considered invalid.
-                    return Err(HtmlError::InvalidFormat);
-                }
-            }
-        };
-
-        // Skip EOL control characters and prepare for next line.
-        cursor = &cursor[line.len()..];
-        while let Some(b'\n' | b'\r') = cursor.first() {
-            cursor = &cursor[1..];
-        }
-    }
-
-    fn header_value_to_u32(value: &str) -> Result<u32, core::num::ParseIntError> {
-        value.trim_start_matches('0').parse::<u32>()
-    }
+    Ok(parse_cf_html(input)?.fragment)
 }
 
 /// Converts plain HTML text to `CF_HTML` format.

--- a/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
@@ -1,9 +1,12 @@
-use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png, png_to_cf_dib, png_to_cf_dibv5};
-use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html};
+use ironrdp_cliprdr_format::bitmap::{
+    dib_to_png, dibv5_to_png, png_to_cf_dib, png_to_cf_dibv5, validate_dib, validate_dibv5,
+};
+use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html, validate_cf_html};
 
 #[test]
 fn dib_to_png_conversion_1() {
     let input = include_bytes!("../../test_data/pdu/clipboard/cf_dib.pdu");
+    assert_eq!(validate_dib(input).unwrap(), input.len());
     let png = dib_to_png(input).unwrap();
     let converted = png_to_cf_dib(&png).unwrap();
     assert_eq!(converted, input);
@@ -12,6 +15,7 @@ fn dib_to_png_conversion_1() {
 #[test]
 fn dibv5_to_png_conversion_1() {
     let input = include_bytes!("../../test_data/pdu/clipboard/cf_dibv5.pdu");
+    assert_eq!(validate_dibv5(input).unwrap(), input.len());
     let png = dibv5_to_png(input).unwrap();
     let converted = png_to_cf_dibv5(&png).unwrap();
     assert_eq!(converted, input);
@@ -49,6 +53,38 @@ fn test_cf_html_to_text() {
     // potentially padded with arbitrary fill bytes).
     let mut cf_html = cf_html.into_bytes();
     cf_html.extend_from_slice(&[0xFF; 10]);
+    assert_eq!(validate_cf_html(&cf_html).unwrap(), cf_html.len() - 10);
     let roundtrip_html_text = cf_html_to_plain_html(&cf_html).unwrap();
     assert_eq!(actual, roundtrip_html_text);
+}
+
+#[test]
+fn html_without_context_is_validated_and_trimmed() {
+    let fragment = "<b>Remote Desktop Protocol</b>";
+    let template =
+        "Version:1.0\r\nStartHTML:-1\r\nEndHTML:-1\r\nStartFragment:0000000000\r\nEndFragment:0000000000\r\n";
+    let start_fragment = template.len() + "<!--StartFragment-->".len();
+    let end_fragment = start_fragment + fragment.len();
+    let mut cf_html = format!(
+        "Version:1.0\r\nStartHTML:-1\r\nEndHTML:-1\r\nStartFragment:{start_fragment:010}\r\nEndFragment:{end_fragment:010}\r\n<!--StartFragment-->{fragment}<!--EndFragment-->"
+    )
+    .into_bytes();
+    let payload_len = cf_html.len();
+    cf_html.extend_from_slice(b"allocator padding");
+
+    assert_eq!(validate_cf_html(&cf_html).unwrap(), payload_len);
+    assert_eq!(cf_html_to_plain_html(&cf_html).unwrap(), fragment);
+}
+
+#[test]
+fn html_rejects_missing_or_ambiguous_required_headers() {
+    let valid = plain_html_to_cf_html("<b>Remote Desktop Protocol</b>");
+    let missing_start_html = valid.replacen("StartHTML:", "Unknown:", 1);
+    assert!(validate_cf_html(missing_start_html.as_bytes()).is_err());
+
+    let embedded_end_html = valid.replacen("EndHTML:", "UnknownEndHTML:", 1);
+    assert!(validate_cf_html(embedded_end_html.as_bytes()).is_err());
+
+    let duplicate_version = format!("Version:1.0\r\n{valid}");
+    assert!(validate_cf_html(duplicate_version.as_bytes()).is_err());
 }


### PR DESCRIPTION
Expose bounded read-only snapshots for text, locale, DIB/DIBV5, and Windows HTML formats. Validate FORMATETC and payloads, return independent HGLOBAL media, and keep file, write, and advisory paths disabled.