### PR TITLE
fix(server)!: drop the tokio and tokio_rustls re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,7 @@ dependencies = [
  "pico-args",
  "rand 0.9.4",
  "sspi",
+ "tokio",
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -35,7 +35,7 @@ __bench = ["dep:visibility"]
 
 [dependencies]
 rand = "0.9"
-tokio = { version = "1", features = ["net", "macros", "sync", "rt", "time"] } # public
+tokio = { version = "1", features = ["net", "macros", "sync", "rt", "time"] }
 tokio-rustls = "0.26" # public
 async-trait = "0.1"
 ironrdp-async = { path = "../ironrdp-async", version = "0.10" }

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -2,8 +2,6 @@
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 #![allow(clippy::arithmetic_side_effects)] // TODO: should we enable this lint back?
 
-pub use {tokio, tokio_rustls};
-
 mod macros;
 
 pub mod autodetect;

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -89,6 +89,7 @@ x509-cert = { version = "0.3", default-features = false, features = ["std"] }
 sspi = { version = "0.21", features = ["network_client"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-rustls = "0.26"
 rand = "0.9"
 opus2 = "0.4"

--- a/crates/ironrdp/examples/server.rs
+++ b/crates/ironrdp/examples/server.rs
@@ -14,15 +14,15 @@ use ironrdp::cliprdr::backend::{CliprdrBackend, CliprdrBackendFactory};
 use ironrdp::connector::DesktopSize;
 use ironrdp::rdpsnd::pdu::{AudioFormat, WaveFormat};
 use ironrdp::rdpsnd::server::{NegotiatedFormat, RdpsndError, RdpsndServerHandler, RdpsndServerMessage};
-use ironrdp::server::tokio::sync::mpsc::UnboundedSender;
-use ironrdp::server::tokio::time::{self, Duration, sleep};
 use ironrdp::server::{
     BitmapUpdate, CliprdrServerFactory, Credentials, DisplayUpdate, KeyboardEvent, MouseEvent, PixelFormat, RdpServer,
     RdpServerDisplay, RdpServerDisplayUpdates, RdpServerInputHandler, ServerEvent, ServerEventSender,
-    SoundServerFactory, TlsIdentityCtx, tokio,
+    SoundServerFactory, TlsIdentityCtx,
 };
 use ironrdp_cliprdr_native::StubCliprdrBackend;
 use rand::prelude::*;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::time::{self, Duration, sleep};
 use tracing::{debug, info, warn};
 
 const HELP: &str = "\

--- a/crates/ironrdp/src/lib.rs
+++ b/crates/ironrdp/src/lib.rs
@@ -5,7 +5,8 @@
 #[cfg(test)]
 use {
     anyhow as _, async_trait as _, image as _, ironrdp_blocking as _, ironrdp_cliprdr_native as _, opus2 as _,
-    pico_args as _, rand as _, sspi as _, tokio_rustls as _, tracing as _, tracing_subscriber as _, x509_cert as _,
+    pico_args as _, rand as _, sspi as _, tokio as _, tokio_rustls as _, tracing as _, tracing_subscriber as _,
+    x509_cert as _,
 };
 
 #[cfg(feature = "acceptor")]


### PR DESCRIPTION
## Summary

`ironrdp-server` re-exported both `tokio` and `tokio_rustls` wholesale so consumers did not need their own `tokio` dependency. This pins every consumer's `tokio` version to whatever `ironrdp-server` picks, with no way to upgrade independently. Drops the re-export.

```diff
-pub use {tokio, tokio_rustls};
```

## Public API changes

- `ironrdp_server::tokio` and `ironrdp_server::tokio_rustls` no longer exist. Consumers using either path need their own `tokio` and `tokio-rustls` dependencies.
- `tokio-rustls` stays marked `# public` in `Cargo.toml`: `TlsAcceptor` genuinely appears in public signatures (`with_tls`, `with_hybrid`, `TransportTls::Tls`). `tokio`'s `# public` marker is dropped since no public signature returns or takes a bare `tokio` type; it was only public via the re-export.

## Internal changes

- The one workspace consumer, `crates/ironrdp/examples/server.rs`, now imports `tokio` directly instead of through the facade.
- `tokio` added as a direct dev-dependency of the `ironrdp` facade crate, and to its existing `#[cfg(test)] use { ... as _ }` unused-dependency silencer, the same pattern already used there for every other example-only dependency.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks` clean. `cargo xtask check features --case workspace/powerset-runtime` clean (44/44, covers `ironrdp-server`).
