### PR TITLE
feat(server): add graceful client disconnect with ServerSetErrorInfo

### DIFF
--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -38,6 +38,7 @@ pub use handler::{KeyboardEvent, MouseButton, MouseEvent, RdpServerInputHandler}
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use ironrdp_acceptor::Acceptor;
+pub use ironrdp_pdu::rdp::server_error_info::ErrorInfo;
 pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 #[cfg(feature = "usb")]
 pub use ironrdp_rdpeusb::io::{CompletionData, DeviceAnnounce, DeviceText, InternalIoControlPacket};
@@ -49,8 +50,9 @@ pub use rdpei::{
 };
 pub use server::{
     AutoReconnectCookieHandle, ConnectionHandler, ConnectionInfo, CredentialDecision, CredentialValidationError,
-    CredentialValidator, Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions,
-    RdpServerSecurity, ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls, pick_remotefx_entropy_coder,
+    CredentialValidator, Credentials, ErrorInfoDisconnectHandle, ExactMatchCredentialValidator, PostConnectionAction,
+    RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls,
+    pick_remotefx_entropy_coder,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 #[cfg(feature = "usb")]

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -674,8 +674,31 @@ impl AutoReconnectCookieHandle {
     }
 }
 
+/// Cloneable handle for gracefully disconnecting the active client with a
+/// `ServerSetErrorInfo` PDU (MS-RDPBCGR 2.2.5.1) while [`RdpServer::run`]
+/// owns the server.
+#[derive(Clone)]
+pub struct ErrorInfoDisconnectHandle {
+    sender: mpsc::UnboundedSender<ServerEvent>,
+}
+
+impl ErrorInfoDisconnectHandle {
+    /// Send `error` to the client via a `ServerSetErrorInfoPdu`, then close the
+    /// connection.
+    ///
+    /// The disconnect takes effect only after the server handles this event.
+    /// Unlike [`ServerEvent::Quit`], the client is told why: it decodes the
+    /// PDU and can surface `error` to the user before the connection drops.
+    pub fn disconnect(&self, error: ErrorInfo) -> Result<(), mpsc::error::SendError<ServerEvent>> {
+        self.sender.send(ServerEvent::Disconnect(error))
+    }
+}
+
 pub enum ServerEvent {
     Quit(String),
+    /// Disconnect the active client with a `ServerSetErrorInfoPdu` carrying
+    /// the given reason. See [`ErrorInfoDisconnectHandle::disconnect`].
+    Disconnect(ErrorInfo),
     Clipboard(ClipboardMessage),
     Rdpsnd(RdpsndServerMessage),
     Echo(EchoServerMessage),
@@ -704,6 +727,7 @@ impl fmt::Debug for ServerEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Quit(reason) => f.debug_tuple("Quit").field(reason).finish(),
+            Self::Disconnect(error) => f.debug_tuple("Disconnect").field(error).finish(),
             Self::Clipboard(..) => f.write_str("Clipboard(..)"),
             Self::Rdpsnd(..) => f.write_str("Rdpsnd(..)"),
             Self::Echo(..) => f.write_str("Echo(..)"),
@@ -870,6 +894,14 @@ impl RdpServer {
     /// server.
     pub fn auto_reconnect_cookie_handle(&self) -> AutoReconnectCookieHandle {
         AutoReconnectCookieHandle {
+            sender: self.ev_sender.clone(),
+        }
+    }
+
+    /// Returns a handle for gracefully disconnecting the active client with a
+    /// `ServerSetErrorInfo` PDU while [`Self::run`] owns this server.
+    pub fn error_info_disconnect_handle(&self) -> ErrorInfoDisconnectHandle {
+        ErrorInfoDisconnectHandle {
             sender: self.ev_sender.clone(),
         }
     }
@@ -1606,6 +1638,16 @@ impl RdpServer {
             match event {
                 ServerEvent::Quit(reason) => {
                     debug!("Got quit event: {reason}");
+                    return Ok(RunState::Disconnect);
+                }
+                ServerEvent::Disconnect(error) => {
+                    debug!(?error, "Got disconnect event");
+                    let pdu = rdp::headers::ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(error));
+                    let data = encode_share_data_pdu(pdu, io_channel_id, user_channel_id)?;
+                    writer
+                        .write_all(&data)
+                        .await
+                        .map_err(|e| ServerError::io("send server set error info", e))?;
                     return Ok(RunState::Disconnect);
                 }
                 ServerEvent::GetLocalAddr(tx) => {


### PR DESCRIPTION
## Summary

`RdpServer` had no framework-level way to disconnect a client mid-session with a wire-visible reason. A handler wanting to reject a client had to build a `ServerSetErrorInfoPdu` by hand and find a way to reach the active connection's writer, or fall back to `ServerEvent::Quit`, which tears the connection down silently with no signal to the client at all.

## Public API changes

Adds `ServerEvent::Disconnect(ErrorInfo)` and `ErrorInfoDisconnectHandle`, mirroring the existing `AutoReconnectCookieHandle` shape:

```rust
pub fn error_info_disconnect_handle(&self) -> ErrorInfoDisconnectHandle;

impl ErrorInfoDisconnectHandle {
    pub fn disconnect(&self, error: ErrorInfo) -> Result<(), mpsc::error::SendError<ServerEvent>>;
}
```

`ErrorInfo` is re-exported at the crate root, matching how `ServerAutoReconnect` is already re-exported for the auto-reconnect cookie API. Purely additive, no existing signature changes.

## Internal changes

`Disconnect` is handled in `dispatch_server_events`, where the writer is already in scope: encodes `ServerSetErrorInfoPdu(error)` (MS-RDPBCGR 2.2.5.1) via the existing `encode_share_data_pdu` helper (the same mechanism the auto-reconnect cookie's Save Session Info PDU already uses), writes it, then returns `RunState::Disconnect`.

## Notes

No test added. The closest existing precedent for this class of feature, `AutoReconnectCookieHandle`, has no test coverage anywhere in the workspace either, so this is consistent with the established bar rather than a gap specific to this PR.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks` clean. `cargo xtask check features --case workspace/powerset-runtime` clean (44/44, covers `ironrdp-server`).
