### PR TITLE
test(extra): cover signed RPCH send requests

### DIFF
--- a/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
@@ -64,6 +64,19 @@ fn authenticated_response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
     pdu
 }
 
+fn authenticated_request_pdu(call_id: u32, opnum: u16, stub: &[u8]) -> Vec<u8> {
+    let mut pdu = request_pdu(call_id, opnum, stub);
+    let auth_pad_length =
+        u8::try_from((16 - (pdu.len() - COMMON_HEADER) % 16) % 16).expect("authentication padding fits u8");
+    pdu.resize(pdu.len() + usize::from(auth_pad_length), 0); // Authentication padding.
+    pdu.extend_from_slice(&[0x0a, 0x05, auth_pad_length, 0, 0, 0, 0, 0]); // NTLM integrity security trailer.
+    pdu.extend_from_slice(&[0; 16]); // NTLM message-integrity verifier.
+    let fragment_length = u16::try_from(pdu.len()).expect("fragment length fits u16");
+    pdu[8..10].copy_from_slice(&fragment_length.to_le_bytes());
+    pdu[10..12].copy_from_slice(&16u16.to_le_bytes());
+    pdu
+}
+
 fn encode_u32(value: usize, big_endian: bool) -> [u8; 4] {
     let value = u32::try_from(value).expect("length fits u32");
     if big_endian {
@@ -132,6 +145,22 @@ fn handles_dce_rpc_authentication_trailers() {
     let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
 
     assert_eq!(inner.server, vec![(2, cc.to_vec())]);
+}
+
+#[test]
+fn extracts_first_authenticated_send_to_server_payload() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let input = in_channel(authenticated_request_pdu(
+        7,
+        SEND_TO_SERVER_OPNUM,
+        &send_to_server_stub(&[&rdp]),
+    ));
+    let output = out_channel(response_pdu(6, &cc));
+
+    let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
 }
 
 #[test]


### PR DESCRIPTION
Cover authenticated, padded TsProxySendToServer framing so the replay extractor preserves inner RDP payloads.