### PR TITLE
feat(mstsgu): authenticate gateway sessions

### DIFF
--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -7,14 +7,14 @@ This crate
 - supports HTTPS WebSocket transport and falls back to the legacy dual-channel HTTP transport,
 - honors `HTTPS_PROXY`/`https_proxy` and `NO_PROXY`/`no_proxy` for outbound HTTP(S) CONNECT and SOCKS5 gateway proxies,
 - provides internal raw RPCH HTTP framing codecs, but no live RPC-over-HTTP gateway transport,
-- decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
+- processes `HTTP_REAUTH_MESSAGE` by opening a short-lived reauthentication transport that retains the active data transport,
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,
 - accepts gateway consent messages by default,
 - lets applications inspect and accept or decline a consent message synchronously through [`GwClient::connect_with_consent`] or [`GwClient::connect_with_port_and_consent`],
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
-- authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
+- authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, Basic fallback, or MS-TSGU `SSPI_NTLM` extended authentication when negotiated,
 - can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,
-- does not implement `HTTP_EXTENDED_AUTH_SC`, PAA, or a credential-provider UI,
+- rejects unsupported `HTTP_EXTENDED_AUTH_SC` and PAA exchanges without a credential-provider UI,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,
 - encodes and decodes DCE/RPC common-header fragments and reassembles responses, without a live RPC-over-HTTP transport, and
 - finishes write-side shutdown by closing the outbound WebSocket or ending the dual HTTP IN request body.

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -51,6 +51,17 @@ pub struct GatewayHttpAuth {
 }
 
 impl GatewayHttpAuth {
+    /// Build SSPI state for the MS-TSGU NTLM extended-authentication exchange.
+    pub(crate) fn new_extended_auth_ntlm(username: &str, password: &str) -> Result<Self, Error> {
+        Self::new_ntlm(username, password, None)
+    }
+
+    /// Process one NTLM token from the MS-TSGU extended-authentication exchange.
+    pub(crate) fn step_extended_auth(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
+        let token = self.initialize(input)?;
+        Ok((token, self.complete))
+    }
+
     pub fn scheme(&self) -> &'static str {
         self.scheme
     }

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -120,6 +120,9 @@ pub struct GwTunnelPolicy {
 /// [HTTP_TUNNEL_RESPONSE_OPTIONAL][MS-TSGU 2.2.10.21] as an [HTTP_UNICODE_STRING][MS-TSGU 2.2.10.22].
 /// Returning `false` declines the gateway consent and stops tunnel setup.
 ///
+/// A consent message received during later background reauthentication is declined because this
+/// borrowed callback is no longer available.
+///
 /// [MS-TSGU 2.2.10.21]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=72
 /// [MS-TSGU 2.2.10.22]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=73
 pub type GwConsentCallback<'a> = dyn FnMut(&str) -> bool + Send + 'a;
@@ -233,6 +236,12 @@ type TransportFactory =
     Box<dyn FnMut() -> Pin<Box<dyn Future<Output = Result<GatewayTransport, Error>> + Send>> + Send>;
 type ReauthenticationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
 
+#[derive(Clone, Copy)]
+enum ConsentFallback {
+    Accept,
+    Reject,
+}
+
 fn network_transport_factory(
     target: GwConnectTarget,
     certificate_validation: CertificateValidation,
@@ -303,7 +312,7 @@ impl GwClient {
 
     /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
     ///
-    /// The callback is invoked once for each consent message returned while creating the tunnel.
+    /// The callback is invoked once for each consent message returned while creating the initial tunnel.
     /// Returning `false` stops tunnel setup with [`GwErrorKind::ConsentDeclined`].
     pub async fn connect_with_consent(
         target: &GwConnectTarget,
@@ -362,7 +371,7 @@ impl GwClient {
 
     /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
     ///
-    /// The callback is invoked once for each consent message returned while creating the tunnel.
+    /// The callback is invoked once for each consent message returned while creating the initial tunnel.
     /// Returning `false` stops tunnel setup with [`GwErrorKind::ConsentDeclined`].
     pub async fn connect_with_port_and_consent(
         target: &GwConnectTarget,
@@ -403,6 +412,7 @@ impl GwClient {
         .map(|x| (x, client_addr))
     }
 
+    #[cfg(feature = "test-support")]
     async fn connect_ws(
         target: GwConnectTarget,
         client_name: &str,
@@ -442,7 +452,12 @@ impl GwClient {
         };
 
         let session_authentication = gw.handshake(transport.session_authentication).await?;
-        gw.tunnel(None, consent_callback).await?;
+        let reauthentication_consent_fallback = if consent_callback.is_some() {
+            ConsentFallback::Reject
+        } else {
+            ConsentFallback::Accept
+        };
+        gw.tunnel(None, consent_callback, ConsentFallback::Accept).await?;
         let policy = gw.tunnel_auth().await?;
         gw.channel().await?;
 
@@ -465,9 +480,11 @@ impl GwClient {
                             None => core::future::pending().await,
                         }
                     } => {
-                        result.expect("reauthentication future is present")?;
                         reauthentication = None;
-                        warn!("RD Gateway reauthentication completed");
+                        match result.expect("reauthentication future is present") {
+                            Ok(()) => warn!("RD Gateway reauthentication completed"),
+                            Err(error) => warn!("RD Gateway reauthentication failed: {error}"),
+                        }
                     },
                     _ = keepalive_interval.tick() => {
                         let pos = {
@@ -526,7 +543,9 @@ impl GwClient {
                                         io: transport.io,
                                     };
                                     secondary.handshake(session_authentication).await?;
-                                    secondary.tunnel(Some(reauth_tunnel_context), None).await?;
+                                    secondary
+                                        .tunnel(Some(reauth_tunnel_context), None, reauthentication_consent_fallback)
+                                        .await?;
                                     secondary.tunnel_auth().await?;
                                     secondary.channel().await?;
 
@@ -744,10 +763,11 @@ impl GwConn {
         &mut self,
         reauth_tunnel_context: Option<u64>,
         consent_callback: Option<&mut GwConsentCallback<'_>>,
+        default_consent: ConsentFallback,
     ) -> Result<(), Error> {
         let req = TunnelReqPkt {
             // No observed server works without this capability.
-            caps: HttpCapsTy::MessagingConsentSign.as_u32(),
+            caps: HttpCapsTy::MessagingConsentSign.as_u32() | HttpCapsTy::Reauth.as_u32(),
             fields_present: 0,
             reauth_tunnel_context,
             ..TunnelReqPkt::default()
@@ -762,7 +782,7 @@ impl GwConn {
             return Err(Error::new("Tunnel", GwErrorKind::GatewayCode(resp.status_code)));
         }
         assert!(cur.eof());
-        evaluate_consent_message(&resp.consent_msg, consent_callback)?;
+        evaluate_consent_message(&resp.consent_msg, consent_callback, default_consent)?;
         Ok(())
     }
 
@@ -825,6 +845,7 @@ fn decode_consent_message(bytes: &[u8]) -> Result<String, Error> {
 fn evaluate_consent_message(
     consent_message: &[u8],
     consent_callback: Option<&mut GwConsentCallback<'_>>,
+    default_consent: ConsentFallback,
 ) -> Result<(), Error> {
     if consent_message.is_empty() {
         return Ok(());
@@ -832,11 +853,17 @@ fn evaluate_consent_message(
 
     let message = decode_consent_message(consent_message)?;
     if let Some(consent_callback) = consent_callback {
-        if !consent_callback(&message) {
-            return Err(Error::new("TunnelConsent", GwErrorKind::ConsentDeclined));
+        if consent_callback(&message) {
+            return Ok(());
         }
+        return Err(Error::new("TunnelConsent", GwErrorKind::ConsentDeclined));
     }
-    Ok(())
+
+    if matches!(default_consent, ConsentFallback::Reject) {
+        Err(Error::new("TunnelConsent", GwErrorKind::ConsentDeclined))
+    } else {
+        Ok(())
+    }
 }
 
 impl AsyncRead for GwClient {

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -39,9 +39,8 @@ use self::packet_io::{GatewayTransport, PacketIo, open_gateway_transport};
 #[doc(hidden)]
 pub use self::proto::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use self::proto::{
-    ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, ExtendedAuthPkt, HandshakeReqPkt, HandshakeRespPkt,
-    HttpCapsTy, HttpExtendedAuth, KeepalivePkt, PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt,
-    TunnelRespPkt,
+    ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, ExtendedAuthPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy,
+    HttpExtendedAuth, KeepalivePkt, PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
 };
 pub use self::udp::{
     AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
@@ -230,7 +229,8 @@ struct GwConn {
     io: PacketIo,
 }
 
-type TransportFactory = Box<dyn FnMut() -> Pin<Box<dyn Future<Output = Result<GatewayTransport, Error>> + Send>> + Send>;
+type TransportFactory =
+    Box<dyn FnMut() -> Pin<Box<dyn Future<Output = Result<GatewayTransport, Error>> + Send>> + Send>;
 type ReauthenticationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
 
 fn network_transport_factory(
@@ -399,8 +399,8 @@ impl GwClient {
             network_transport_factory(target.clone(), certificate_validation, certificate_validation_callback),
             consent_callback,
         )
-            .await
-            .map(|x| (x, client_addr))
+        .await
+        .map(|x| (x, client_addr))
     }
 
     async fn connect_ws(
@@ -635,7 +635,10 @@ impl GwConn {
         Ok((hdr, msg.split_off(cur.pos())))
     }
 
-    async fn handshake(&mut self, session_authentication: GwSessionAuthentication) -> Result<GwSessionAuthentication, Error> {
+    async fn handshake(
+        &mut self,
+        session_authentication: GwSessionAuthentication,
+    ) -> Result<GwSessionAuthentication, Error> {
         let hs = HandshakeReqPkt {
             ver_major: 1,
             ver_minor: 0,
@@ -703,7 +706,8 @@ impl GwConn {
             }
 
             let mut cur = ReadCursor::new(&bytes);
-            let response = ExtendedAuthPkt::decode(&mut cur).map_err(|_| Error::new("extended authentication", GwErrorKind::Decode))?;
+            let response = ExtendedAuthPkt::decode(&mut cur)
+                .map_err(|_| Error::new("extended authentication", GwErrorKind::Decode))?;
             if !cur.eof() {
                 return Err(Error::new("extended authentication", GwErrorKind::Decode));
             }

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -35,12 +35,13 @@ use log::warn;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::sync::PollSender;
 
-use self::packet_io::{PacketIo, open_gateway_transport};
+use self::packet_io::{GatewayTransport, PacketIo, open_gateway_transport};
 #[doc(hidden)]
 pub use self::proto::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use self::proto::{
-    ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt,
-    PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
+    ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, ExtendedAuthPkt, HandshakeReqPkt, HandshakeRespPkt,
+    HttpCapsTy, HttpExtendedAuth, KeepalivePkt, PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt,
+    TunnelRespPkt,
 };
 pub use self::udp::{
     AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
@@ -126,6 +127,26 @@ pub type GwConsentCallback<'a> = dyn FnMut(&str) -> bool + Send + 'a;
 
 type Error = ironrdp_error::Error<GwErrorKind>;
 
+/// Gateway authentication selected for the current HTTP connection.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GwSessionAuthentication {
+    /// Authentication completed during the HTTP or WebSocket setup.
+    #[default]
+    Http,
+    /// NTLM authentication completed with `HTTP_EXTENDED_AUTH_PACKET` messages.
+    NtlmSspi,
+}
+
+/// An extended authentication method advertised by the gateway.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GwExtendedAuthentication {
+    SmartCard,
+    PluggableAuthentication,
+    NtlmSspi,
+    Unknown(u16),
+}
+
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum GwErrorKind {
@@ -137,6 +158,7 @@ pub enum GwErrorKind {
     HttpStatus(u16),
     PacketEof,
     UnsupportedFeature,
+    UnsupportedExtendedAuthentication(GwExtendedAuthentication),
     ConsentDeclined,
     Custom,
     Encode,
@@ -172,6 +194,9 @@ impl Display for GwErrorKind {
             GwErrorKind::HttpStatus(status) => return write!(f, "unexpected http status {status}"),
             GwErrorKind::PacketEof => "PacketEOF",
             GwErrorKind::UnsupportedFeature => "unsupported feature",
+            GwErrorKind::UnsupportedExtendedAuthentication(method) => {
+                return write!(f, "unsupported extended authentication method {method:?}");
+            }
             GwErrorKind::ConsentDeclined => "gateway consent declined",
             GwErrorKind::Custom => "custom",
             GwErrorKind::Encode => "encode",
@@ -183,6 +208,18 @@ impl Display for GwErrorKind {
 
 impl core::error::Error for GwErrorKind {}
 
+fn extended_authentication_method(extended_auth: HttpExtendedAuth) -> GwExtendedAuthentication {
+    if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SC) {
+        GwExtendedAuthentication::SmartCard
+    } else if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_PAA) {
+        GwExtendedAuthentication::PluggableAuthentication
+    } else if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM) {
+        GwExtendedAuthentication::NtlmSspi
+    } else {
+        GwExtendedAuthentication::Unknown(extended_auth.bits())
+    }
+}
+
 struct GwConn {
     client_name: String,
     target: GwConnectTarget,
@@ -191,6 +228,25 @@ struct GwConn {
     /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
     server_port: u16,
     io: PacketIo,
+}
+
+type TransportFactory = Box<dyn FnMut() -> Pin<Box<dyn Future<Output = Result<GatewayTransport, Error>> + Send>> + Send>;
+type ReauthenticationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
+
+fn network_transport_factory(
+    target: GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> TransportFactory {
+    Box::new(move || {
+        let target = target.clone();
+        let certificate_validation_callback = certificate_validation_callback.clone();
+        Box::pin(async move {
+            open_gateway_transport(&target, certificate_validation, certificate_validation_callback)
+                .await
+                .map(|(transport, _)| transport)
+        })
+    })
 }
 
 pub struct GwClient {
@@ -202,6 +258,7 @@ pub struct GwClient {
     rx_bufs: Vec<Bytes>,
     tx: PollSender<Bytes>,
     policy: GwTunnelPolicy,
+    session_authentication: GwSessionAuthentication,
 }
 
 impl Drop for GwClient {
@@ -332,9 +389,16 @@ impl GwClient {
         certificate_validation_callback: Option<CertificateValidationCallback>,
         consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        let (io, client_addr) =
-            open_gateway_transport(target, certificate_validation, certificate_validation_callback).await?;
-        Self::connect_ws(target.clone(), client_name, server_port, io, consent_callback)
+        let (transport, client_addr) =
+            open_gateway_transport(target, certificate_validation, certificate_validation_callback.clone()).await?;
+        Self::connect_ws_with_reauth(
+            target.clone(),
+            client_name,
+            server_port,
+            transport,
+            network_transport_factory(target.clone(), certificate_validation, certificate_validation_callback),
+            consent_callback,
+        )
             .await
             .map(|x| (x, client_addr))
     }
@@ -343,18 +407,42 @@ impl GwClient {
         target: GwConnectTarget,
         client_name: &str,
         server_port: u16,
-        io: PacketIo,
+        transport: GatewayTransport,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
+    ) -> Result<GwClient, Error> {
+        Self::connect_ws_with_reauth(
+            target,
+            client_name,
+            server_port,
+            transport,
+            Box::new(|| {
+                Box::pin(core::future::ready(Err(Error::new(
+                    "gateway reauthentication requires a network transport",
+                    GwErrorKind::UnsupportedFeature,
+                ))))
+            }),
+            consent_callback,
+        )
+        .await
+    }
+
+    async fn connect_ws_with_reauth(
+        target: GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        transport: GatewayTransport,
+        mut open_transport: TransportFactory,
         consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<GwClient, Error> {
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
             target,
             server_port,
-            io,
+            io: transport.io,
         };
 
-        gw.handshake().await?;
-        gw.tunnel(consent_callback).await?;
+        let session_authentication = gw.handshake(transport.session_authentication).await?;
+        gw.tunnel(None, consent_callback).await?;
         let policy = gw.tunnel_auth().await?;
         gw.channel().await?;
 
@@ -365,11 +453,22 @@ impl GwClient {
             let iv = Duration::from_secs(15 * 60);
             let mut keepalive_interval = tokio::time::interval_at(tokio::time::Instant::now() + iv, iv);
             let mut inbound_open = true;
+            let mut reauthentication: Option<ReauthenticationFuture> = None;
 
             loop {
                 let mut wsbuf = [0u8; 8192];
 
                 tokio::select!(
+                    result = async {
+                        match &mut reauthentication {
+                            Some(reauthentication) => Some(reauthentication.await),
+                            None => core::future::pending().await,
+                        }
+                    } => {
+                        result.expect("reauthentication future is present")?;
+                        reauthentication = None;
+                        warn!("RD Gateway reauthentication completed");
+                    },
                     _ = keepalive_interval.tick() => {
                         let pos = {
                             let mut cur = WriteCursor::new(&mut wsbuf);
@@ -408,8 +507,35 @@ impl GwClient {
                             },
                             PktTy::ReauthMessage => {
                                 let msg = ReauthMessagePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
+                                if reauthentication.is_some() {
+                                    return Err(Error::new("gateway reauthentication already pending", GwErrorKind::Connect));
+                                }
+
+                                let client_name = gw.client_name.clone();
+                                let target = gw.target.clone();
+                                let server_port = gw.server_port;
+                                let reauth_tunnel_context = msg.reauth_tunnel_context;
+                                let transport = open_transport();
+                                reauthentication = Some(Box::pin(async move {
+                                    let transport = transport.await?;
+                                    let session_authentication = transport.session_authentication;
+                                    let mut secondary = GwConn {
+                                        client_name,
+                                        target,
+                                        server_port,
+                                        io: transport.io,
+                                    };
+                                    secondary.handshake(session_authentication).await?;
+                                    secondary.tunnel(Some(reauth_tunnel_context), None).await?;
+                                    secondary.tunnel_auth().await?;
+                                    secondary.channel().await?;
+
+                                    // A reauthentication channel only updates authorization state for the
+                                    // original connection and never carries application data.
+                                    Ok(())
+                                }));
                                 warn!(
-                                    "RD Gateway requested reauthentication (context 0x{:016x}); mid-session reauth is not performed",
+                                    "RD Gateway requested reauthentication (context 0x{:016x})",
                                     msg.reauth_tunnel_context
                                 );
                             },
@@ -462,6 +588,7 @@ impl GwClient {
             rx_bufs: vec![],
             tx: PollSender::new(out_tx),
             policy,
+            session_authentication,
         })
     }
 
@@ -469,11 +596,16 @@ impl GwClient {
     pub fn tunnel_policy(&self) -> &GwTunnelPolicy {
         &self.policy
     }
+
+    /// Authentication selected for the initial gateway connection.
+    pub fn session_authentication(&self) -> GwSessionAuthentication {
+        self.session_authentication
+    }
 }
 
 impl GwConn {
     async fn send_packet<E: Encode>(&mut self, payload: &E) -> Result<(), Error> {
-        let mut buf = [0u8; 4096];
+        let mut buf = vec![0; payload.size()];
         let pos = {
             let mut cur = WriteCursor::new(&mut buf);
             payload
@@ -503,15 +635,21 @@ impl GwConn {
         Ok((hdr, msg.split_off(cur.pos())))
     }
 
-    async fn handshake(&mut self) -> Result<(), Error> {
-        // For NTLM we would include extended_auth: NTLM_SSPI in this handshake req here.
+    async fn handshake(&mut self, session_authentication: GwSessionAuthentication) -> Result<GwSessionAuthentication, Error> {
         let hs = HandshakeReqPkt {
             ver_major: 1,
             ver_minor: 0,
+            extended_auth: match session_authentication {
+                GwSessionAuthentication::Http => HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE,
+                GwSessionAuthentication::NtlmSspi => HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM,
+            },
             ..HandshakeReqPkt::default()
         };
         self.send_packet(&hs).await?;
-        let (_hdr, bytes) = self.read_packet().await?;
+        let (hdr, bytes) = self.read_packet().await?;
+        if hdr.ty != PktTy::HandshakeResp {
+            return Err(Error::new("Handshake", GwErrorKind::Decode));
+        }
 
         let mut cur = ReadCursor::new(&bytes);
         let resp = HandshakeRespPkt::decode(&mut cur).map_err(|_| Error::new("Handshake", GwErrorKind::Decode))?;
@@ -521,14 +659,93 @@ impl GwConn {
         if resp.ver_major != 1 || resp.ver_minor != 0 || resp.server_version != 0 {
             return Err(Error::new("Handshake", GwErrorKind::Connect));
         }
-        Ok(())
+        if !cur.eof() {
+            return Err(Error::new("Handshake", GwErrorKind::Decode));
+        }
+
+        match session_authentication {
+            GwSessionAuthentication::Http if !resp.extended_auth.is_empty() => {
+                return Err(Error::new(
+                    "Handshake",
+                    GwErrorKind::UnsupportedExtendedAuthentication(extended_authentication_method(resp.extended_auth)),
+                ));
+            }
+            GwSessionAuthentication::NtlmSspi
+                if !resp
+                    .extended_auth
+                    .contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM) =>
+            {
+                return Err(Error::new(
+                    "Handshake",
+                    GwErrorKind::UnsupportedExtendedAuthentication(GwExtendedAuthentication::NtlmSspi),
+                ));
+            }
+            GwSessionAuthentication::NtlmSspi => self.extended_auth_sspi_ntlm().await?,
+            GwSessionAuthentication::Http => {}
+        }
+
+        Ok(session_authentication)
     }
 
-    async fn tunnel(&mut self, consent_callback: Option<&mut GwConsentCallback<'_>>) -> Result<(), Error> {
+    async fn extended_auth_sspi_ntlm(&mut self) -> Result<(), Error> {
+        let mut auth = http_auth::GatewayHttpAuth::new_extended_auth_ntlm(&self.target.gw_user, &self.target.gw_pass)?;
+        let (token, mut complete) = auth.step_extended_auth(None)?;
+        self.send_packet(&ExtendedAuthPkt {
+            error_code: 0,
+            auth_blob: token,
+        })
+        .await?;
+
+        loop {
+            let (hdr, bytes) = self.read_packet().await?;
+            if hdr.ty != PktTy::ExtendedAuth {
+                return Err(Error::new("extended authentication response", GwErrorKind::Decode));
+            }
+
+            let mut cur = ReadCursor::new(&bytes);
+            let response = ExtendedAuthPkt::decode(&mut cur).map_err(|_| Error::new("extended authentication", GwErrorKind::Decode))?;
+            if !cur.eof() {
+                return Err(Error::new("extended authentication", GwErrorKind::Decode));
+            }
+            if response.error_code != 0 {
+                return Err(Error::new(
+                    "extended authentication",
+                    GwErrorKind::GatewayCode(response.error_code),
+                ));
+            }
+            if complete {
+                if response.auth_blob.is_empty() {
+                    return Ok(());
+                }
+                return Err(Error::new("extended authentication", GwErrorKind::Connect));
+            }
+            if response.auth_blob.is_empty() {
+                return Err(Error::new("extended authentication", GwErrorKind::Connect));
+            }
+
+            let (token, is_complete) = auth.step_extended_auth(Some(&response.auth_blob))?;
+            if token.is_empty() {
+                return Err(Error::new("extended authentication", GwErrorKind::Connect));
+            }
+            self.send_packet(&ExtendedAuthPkt {
+                error_code: 0,
+                auth_blob: token,
+            })
+            .await?;
+            complete = is_complete;
+        }
+    }
+
+    async fn tunnel(
+        &mut self,
+        reauth_tunnel_context: Option<u64>,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
+    ) -> Result<(), Error> {
         let req = TunnelReqPkt {
-            // Havent seen any server working without this.
+            // No observed server works without this capability.
             caps: HttpCapsTy::MessagingConsentSign.as_u32(),
             fields_present: 0,
+            reauth_tunnel_context,
             ..TunnelReqPkt::default()
         };
         self.send_packet(&req).await?;

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -997,8 +997,8 @@ async fn authenticated_rdg_request(
 ) -> Result<AuthenticatedRdgResponse, Error> {
     let mut http_auth: Option<GatewayHttpAuth> = None;
     let mut session_authentication = requested_session_authentication.unwrap_or_default();
-    let mut authorization = (session_authentication == GwSessionAuthentication::NtlmSspi)
-        .then(|| "SSPI_NTLM".to_owned());
+    let mut authorization =
+        (session_authentication == GwSessionAuthentication::NtlmSspi).then(|| "SSPI_NTLM".to_owned());
     let mut use_basic = false;
     const MAX_AUTH_ROUNDS: usize = 8;
 

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -25,9 +25,9 @@ use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::protocol::Role;
 use tokio_tungstenite::tungstenite::{Message, http};
 
-use crate::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
+use crate::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, split_auth_challenge, www_authenticate_values};
 use crate::proto::PktHdr;
-use crate::{Error, GwConnectTarget, GwErrorKind};
+use crate::{Error, GwConnectTarget, GwErrorKind, GwSessionAuthentication};
 
 pub(crate) trait GatewayIo: AsyncRead + AsyncWrite + Unpin {}
 
@@ -190,6 +190,11 @@ pub(crate) enum PacketIo {
     },
 }
 
+pub(crate) struct GatewayTransport {
+    pub(crate) io: PacketIo,
+    pub(crate) session_authentication: GwSessionAuthentication,
+}
+
 impl PacketIo {
     pub(crate) async fn send_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
         self.check_in_response()?;
@@ -284,7 +289,7 @@ pub(crate) async fn open_gateway_transport(
     target: &GwConnectTarget,
     certificate_validation: CertificateValidation,
     certificate_validation_callback: Option<CertificateValidationCallback>,
-) -> Result<(PacketIo, core::net::SocketAddr), Error> {
+) -> Result<(GatewayTransport, core::net::SocketAddr), Error> {
     let gateway = parse_gateway_endpoint(&target.gw_endpoint)?;
     let gw_host = gateway.host.clone();
     let proxy = proxy_from_environment(&gateway)?;
@@ -791,7 +796,7 @@ async fn open_transport_with_out_stream<F, Fut>(
     gw_host: &str,
     target: &GwConnectTarget,
     open_in_stream: F,
-) -> Result<(PacketIo, core::net::SocketAddr), Error>
+) -> Result<(GatewayTransport, core::net::SocketAddr), Error>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<GatewayStream, Error>>,
@@ -827,7 +832,9 @@ where
         target,
         websocket_upgrade: true,
     };
-    let response = authenticated_rdg_request(&mut out_sender, &context, &spn, &mut cookies).await?;
+    let authenticated = authenticated_rdg_request(&mut out_sender, &context, &spn, &mut cookies, None).await?;
+    let session_authentication = authenticated.session_authentication;
+    let response = authenticated.response;
 
     match response.status() {
         http::StatusCode::SWITCHING_PROTOCOLS => {
@@ -837,7 +844,13 @@ where
                 .ok_or_else(|| Error::new("websocket upgrade connection lost", GwErrorKind::Connect))?;
             let stream = WebSocketStream::from_raw_socket(parts.io.into_inner(), Role::Client, None).await;
             let (sink, stream) = stream.split();
-            Ok((PacketIo::WebSocket { sink, stream }, client_addr))
+            Ok((
+                GatewayTransport {
+                    io: PacketIo::WebSocket { sink, stream },
+                    session_authentication,
+                },
+                client_addr,
+            ))
         }
         http::StatusCode::OK => {
             let mut out_body = response.into_body();
@@ -857,9 +870,16 @@ where
                 out_buf,
                 out_stop_tx,
                 out_conn,
+                session_authentication,
             )
             .await?;
-            Ok((io, client_addr))
+            Ok((
+                GatewayTransport {
+                    io,
+                    session_authentication,
+                },
+                client_addr,
+            ))
         }
         status => {
             drain_response_body(response.into_body(), "drain rdg out response body").await?;
@@ -872,7 +892,7 @@ where
 pub(crate) async fn open_test_transport(
     out_stream: tokio::io::DuplexStream,
     in_stream: tokio::io::DuplexStream,
-) -> Result<PacketIo, Error> {
+) -> Result<GatewayTransport, Error> {
     let target = GwConnectTarget {
         gw_endpoint: "gateway.test:443".to_owned(),
         gw_user: "user".to_owned(),
@@ -894,7 +914,7 @@ pub(crate) async fn open_test_transport(
         },
     )
     .await
-    .map(|(io, _)| io)
+    .map(|(transport, _)| transport)
 }
 
 #[expect(
@@ -912,6 +932,7 @@ async fn open_in_channel(
     out_buf: Vec<u8>,
     out_stop_tx: oneshot::Sender<()>,
     out_conn: tokio::task::JoinHandle<()>,
+    session_authentication: GwSessionAuthentication,
 ) -> Result<PacketIo, Error> {
     let in_io = hyper_util::rt::tokio::TokioIo::new(in_stream);
     let (mut in_sender, in_conn) = hyper::client::conn::http1::handshake(in_io)
@@ -930,7 +951,9 @@ async fn open_in_channel(
         target,
         websocket_upgrade: false,
     };
-    let response = authenticated_rdg_request(&mut in_sender, &context, spn, cookies).await?;
+    let authenticated =
+        authenticated_rdg_request(&mut in_sender, &context, spn, cookies, Some(session_authentication)).await?;
+    let response = authenticated.response;
     if response.status() != http::StatusCode::OK {
         let status = response.status();
         drain_response_body(response.into_body(), "drain rdg in response body").await?;
@@ -970,9 +993,12 @@ async fn authenticated_rdg_request(
     context: &RdgRequestContext<'_>,
     spn: &str,
     cookies: &mut GatewayCookies,
-) -> Result<http::Response<Incoming>, Error> {
+    requested_session_authentication: Option<GwSessionAuthentication>,
+) -> Result<AuthenticatedRdgResponse, Error> {
     let mut http_auth: Option<GatewayHttpAuth> = None;
-    let mut authorization: Option<String> = None;
+    let mut session_authentication = requested_session_authentication.unwrap_or_default();
+    let mut authorization = (session_authentication == GwSessionAuthentication::NtlmSspi)
+        .then(|| "SSPI_NTLM".to_owned());
     let mut use_basic = false;
     const MAX_AUTH_ROUNDS: usize = 8;
 
@@ -999,7 +1025,19 @@ async fn authenticated_rdg_request(
                     .collect();
                 run_http_auth(move || auth.finish_www_authenticate(challenges.iter().map(String::as_str))).await?;
             }
-            return Ok(response);
+            return Ok(AuthenticatedRdgResponse {
+                response,
+                session_authentication,
+            });
+        }
+
+        if requested_session_authentication == Some(GwSessionAuthentication::NtlmSspi) {
+            let status = response.status();
+            drain_response_body(response.into_body(), "drain rdg extended authentication body").await?;
+            return Err(Error::new(
+                "rdg extended authentication",
+                GwErrorKind::HttpStatus(status.as_u16()),
+            ));
         }
 
         if use_basic {
@@ -1021,7 +1059,16 @@ async fn authenticated_rdg_request(
         let pass = context.target.gw_pass.clone();
         let smart_card = context.target.smart_card.clone();
         let target_name = spn.to_owned();
-        let step = if let Some(mut auth) = http_auth.take() {
+        let step = if requested_session_authentication.is_none()
+            && http_auth.is_none()
+            && smart_card.is_none()
+            && challenges
+                .iter()
+                .any(|challenge| split_auth_challenge(challenge, "SSPI_NTLM").is_some())
+        {
+            session_authentication = GwSessionAuthentication::NtlmSspi;
+            AuthStep::Continue("SSPI_NTLM".to_owned())
+        } else if let Some(mut auth) = http_auth.take() {
             let (auth, step) = run_http_auth(move || {
                 let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
                 let step = auth.step_www_authenticate(refs)?;
@@ -1053,6 +1100,11 @@ async fn authenticated_rdg_request(
     }
 
     Err(Error::new("rdg authentication rounds exceeded", GwErrorKind::Connect))
+}
+
+struct AuthenticatedRdgResponse {
+    response: http::Response<Incoming>,
+    session_authentication: GwSessionAuthentication,
 }
 
 fn empty_rdg_body() -> RdgBody {

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -166,10 +166,6 @@ pub(crate) struct HandshakeRespPkt {
     pub ver_major: u8,
     pub ver_minor: u8,
     pub server_version: u16,
-    #[expect(
-        dead_code,
-        reason = "authentication flow does not negotiate extended authentication yet"
-    )]
     pub extended_auth: HttpExtendedAuth,
 }
 
@@ -347,13 +343,6 @@ impl Decode<'_> for TunnelRespPkt {
 }
 
 /// 2.2.10.7 HTTP_EXTENDED_AUTH_PACKET Structure
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "authentication flow does not process extended authentication yet"
-    )
-)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExtendedAuthPkt {
     pub(crate) error_code: u32,

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -6,8 +6,7 @@ use tokio::io::AsyncWriteExt as _;
 use crate::http_auth::basic_authorization;
 use crate::packet_io::{
     GatewayTransport as NetworkGatewayTransport, gateway_endpoint_is_valid as endpoint_is_valid,
-    open_gateway_transport, open_test_transport,
-    parse_proxy_url, proxy_from_values, read_http_connect_response,
+    open_gateway_transport, open_test_transport, parse_proxy_url, proxy_from_values, read_http_connect_response,
 };
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
@@ -96,11 +95,9 @@ impl GatewayTransport {
             server_port,
             self.0,
             Box::new(move || {
-                Box::pin(core::future::ready(
-                    reauthentication_transport
-                        .take()
-                        .ok_or_else(|| Error::new("mock reauthentication transport exhausted", crate::GwErrorKind::Connect)),
-                ))
+                Box::pin(core::future::ready(reauthentication_transport.take().ok_or_else(
+                    || Error::new("mock reauthentication transport exhausted", crate::GwErrorKind::Connect),
+                )))
             }),
             None,
         )

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -5,13 +5,14 @@ use tokio::io::AsyncWriteExt as _;
 
 use crate::http_auth::basic_authorization;
 use crate::packet_io::{
-    PacketIo, gateway_endpoint_is_valid as endpoint_is_valid, open_gateway_transport, open_test_transport,
+    GatewayTransport as NetworkGatewayTransport, gateway_endpoint_is_valid as endpoint_is_valid,
+    open_gateway_transport, open_test_transport,
     parse_proxy_url, proxy_from_values, read_http_connect_response,
 };
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
-pub struct GatewayTransport(PacketIo);
+pub struct GatewayTransport(NetworkGatewayTransport);
 
 impl GatewayTransport {
     /// Connect the client side of the mock OUT and IN HTTP connections.
@@ -36,19 +37,24 @@ impl GatewayTransport {
             .map(|(transport, _)| Self(transport))
     }
 
+    /// Return the authentication negotiated while opening this mock transport.
+    pub fn session_authentication(&self) -> crate::GwSessionAuthentication {
+        self.0.session_authentication
+    }
+
     /// Send one MS-TSGU packet to the mock gateway.
     pub async fn send_packet(&mut self, packet: &[u8]) -> Result<(), String> {
-        self.0.send_bytes(packet).await.map_err(|error| error.to_string())
+        self.0.io.send_bytes(packet).await.map_err(|error| error.to_string())
     }
 
     /// Read one MS-TSGU packet from the mock gateway.
     pub async fn read_packet(&mut self) -> Result<Option<Bytes>, String> {
-        self.0.read_packet_buf().await.map_err(|error| error.to_string())
+        self.0.io.read_packet_buf().await.map_err(|error| error.to_string())
     }
 
     /// Finish the mock gateway IN request body.
     pub async fn close(&mut self) -> Result<(), String> {
-        self.0.close().await.map_err(|error| error.to_string())
+        self.0.io.close().await.map_err(|error| error.to_string())
     }
 
     /// Establish a gateway tunnel through this test transport.
@@ -60,6 +66,45 @@ impl GatewayTransport {
         consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<GwClient, Error> {
         GwClient::connect_ws(target, client_name, server_port, self.0, consent_callback).await
+    }
+
+    /// Establish a mock tunnel with a selected session-authentication mode.
+    pub async fn connect_tunnel_with_session_authentication(
+        self,
+        target: GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        session_authentication: crate::GwSessionAuthentication,
+    ) -> Result<GwClient, Error> {
+        let mut transport = self.0;
+        transport.session_authentication = session_authentication;
+        GwClient::connect_ws(target, client_name, server_port, transport, None).await
+    }
+
+    /// Establish a mock tunnel with a second mock transport reserved for reauthentication.
+    pub async fn connect_tunnel_with_reauth(
+        self,
+        target: GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        reauthentication_transport: GatewayTransport,
+    ) -> Result<GwClient, Error> {
+        let mut reauthentication_transport = Some(reauthentication_transport.0);
+        GwClient::connect_ws_with_reauth(
+            target,
+            client_name,
+            server_port,
+            self.0,
+            Box::new(move || {
+                Box::pin(core::future::ready(
+                    reauthentication_transport
+                        .take()
+                        .ok_or_else(|| Error::new("mock reauthentication transport exhausted", crate::GwErrorKind::Connect)),
+                ))
+            }),
+            None,
+        )
+        .await
     }
 }
 

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -8,7 +8,7 @@ use crate::packet_io::{
     GatewayTransport as NetworkGatewayTransport, gateway_endpoint_is_valid as endpoint_is_valid,
     open_gateway_transport, open_test_transport, parse_proxy_url, proxy_from_values, read_http_connect_response,
 };
-use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
+use crate::{ConsentFallback, Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
 pub struct GatewayTransport(NetworkGatewayTransport);
@@ -88,6 +88,19 @@ impl GatewayTransport {
         server_port: u16,
         reauthentication_transport: GatewayTransport,
     ) -> Result<GwClient, Error> {
+        self.connect_tunnel_with_reauth_and_consent(target, client_name, server_port, reauthentication_transport, None)
+            .await
+    }
+
+    /// Establish a mock tunnel with a second mock transport and initial consent callback.
+    pub async fn connect_tunnel_with_reauth_and_consent(
+        self,
+        target: GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        reauthentication_transport: GatewayTransport,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
+    ) -> Result<GwClient, Error> {
         let mut reauthentication_transport = Some(reauthentication_transport.0);
         GwClient::connect_ws_with_reauth(
             target,
@@ -99,7 +112,7 @@ impl GatewayTransport {
                     || Error::new("mock reauthentication transport exhausted", crate::GwErrorKind::Connect),
                 )))
             }),
-            None,
+            consent_callback,
         )
         .await
     }
@@ -110,7 +123,7 @@ pub fn evaluate_consent_message(
     consent_message: &[u8],
     consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
-    crate::evaluate_consent_message(consent_message, consent_callback)
+    crate::evaluate_consent_message(consent_message, consent_callback, ConsentFallback::Accept)
 }
 
 /// Select a proxy from explicit environment variable values without changing process state.

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -3,15 +3,17 @@
 use std::sync::{Arc, Mutex};
 
 use core::convert::Infallible;
+use futures_util::stream;
 use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt as _, Full};
-use hyper::body::Bytes;
+use http_body_util::{BodyExt as _, Full, StreamBody};
+use hyper::body::{Bytes, Frame};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use ironrdp_mstsgu::test_support::{GatewayTransport, evaluate_consent_message};
 use ironrdp_mstsgu::{GwConnectTarget, GwErrorKind, GwExtendedAuthentication, GwSessionAuthentication};
+use tokio::io::AsyncReadExt as _;
 
 type TestBody = BoxBody<Bytes, Infallible>;
 
@@ -455,17 +457,19 @@ async fn reauthentication_uses_a_fresh_tunnel_and_preserves_the_data_transport()
     let (reauth_out_client, reauth_out_server) = tokio::io::duplex(4096);
     let (reauth_in_client, reauth_in_server) = tokio::io::duplex(4096);
     let (reauth_complete_tx, reauth_complete_rx) = tokio::sync::oneshot::channel();
+    let (initial_out_tx, initial_out_rx) = tokio::sync::mpsc::channel(2);
 
-    let initial_out_server = tokio::spawn(mock_out_server(
-        initial_out_server,
-        vec![
+    initial_out_tx
+        .send(Bytes::from(out_response([
             packet(2, &handshake_response(0)),
             packet(5, &tunnel_response(0, &[])),
             packet(7, &control_response(0)),
             packet(9, &control_response(0)),
             packet(12, &reauth_message(reauth_tunnel_context)),
-        ],
-    ));
+        ])))
+        .await
+        .expect("send initial response");
+    let initial_out_server = tokio::spawn(mock_streaming_out_server(initial_out_server, initial_out_rx));
     let initial_in_server = tokio::spawn(mock_in_server(initial_in_server, None, None));
     let reauth_out_server = tokio::spawn(mock_out_server(
         reauth_out_server,
@@ -488,7 +492,7 @@ async fn reauthentication_uses_a_fresh_tunnel_and_preserves_the_data_transport()
     let reauth_transport = GatewayTransport::connect(reauth_out_client, reauth_in_client)
         .await
         .expect("connect reauthentication transport");
-    let client = initial_transport
+    let mut client = initial_transport
         .connect_tunnel_with_reauth(test_target(), "client.test", 3389, reauth_transport)
         .await
         .expect("connect tunnel");
@@ -497,11 +501,165 @@ async fn reauthentication_uses_a_fresh_tunnel_and_preserves_the_data_transport()
         .await
         .expect("reauthentication completed")
         .expect("reauthentication completion signal");
+    reauth_out_server.await.expect("serve reauthentication OUT");
+    initial_out_tx
+        .send(Bytes::from(data_packet(b"after reauthentication")))
+        .await
+        .expect("send application data");
+    let mut received = [0; 22];
+    tokio::time::timeout(core::time::Duration::from_secs(1), client.read_exact(&mut received))
+        .await
+        .expect("read application data")
+        .expect("application data");
+    assert_eq!(&received, b"after reauthentication");
+
+    drop(initial_out_tx);
     drop(client);
 
     initial_out_server.await.expect("serve initial OUT");
     initial_in_server.await.expect("serve initial IN");
+    reauth_in_server.await.expect("serve reauthentication IN");
+}
+
+#[tokio::test]
+async fn failed_reauthentication_preserves_the_data_transport() {
+    let reauth_tunnel_context = 0x8877_6655_4433_2211;
+    let (initial_out_client, initial_out_server) = tokio::io::duplex(4096);
+    let (initial_in_client, initial_in_server) = tokio::io::duplex(4096);
+    let (reauth_out_client, reauth_out_server) = tokio::io::duplex(4096);
+    let (reauth_in_client, reauth_in_server) = tokio::io::duplex(4096);
+    let (reauth_attempt_tx, reauth_attempt_rx) = tokio::sync::oneshot::channel();
+    let (initial_out_tx, initial_out_rx) = tokio::sync::mpsc::channel(2);
+
+    initial_out_tx
+        .send(Bytes::from(out_response([
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0, &[])),
+            packet(7, &control_response(0)),
+            packet(9, &control_response(0)),
+            packet(12, &reauth_message(reauth_tunnel_context)),
+        ])))
+        .await
+        .expect("send initial response");
+    let initial_out_server = tokio::spawn(mock_streaming_out_server(initial_out_server, initial_out_rx));
+    let initial_in_server = tokio::spawn(mock_in_server(initial_in_server, None, None));
+    let reauth_out_server = tokio::spawn(mock_out_server(
+        reauth_out_server,
+        vec![
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0x8007_59DD, &[])),
+        ],
+    ));
+    let reauth_in_server = tokio::spawn(mock_reauth_failure_in_server(
+        reauth_in_server,
+        reauth_tunnel_context,
+        reauth_attempt_tx,
+    ));
+
+    let initial_transport = GatewayTransport::connect(initial_out_client, initial_in_client)
+        .await
+        .expect("connect initial transport");
+    let reauth_transport = GatewayTransport::connect(reauth_out_client, reauth_in_client)
+        .await
+        .expect("connect reauthentication transport");
+    let mut client = initial_transport
+        .connect_tunnel_with_reauth(test_target(), "client.test", 3389, reauth_transport)
+        .await
+        .expect("connect tunnel");
+
+    tokio::time::timeout(core::time::Duration::from_secs(1), reauth_attempt_rx)
+        .await
+        .expect("reauthentication attempt")
+        .expect("reauthentication attempt signal");
     reauth_out_server.await.expect("serve reauthentication OUT");
+    initial_out_tx
+        .send(Bytes::from(data_packet(b"after reauthentication failure")))
+        .await
+        .expect("send application data");
+    let mut received = [0; 30];
+    tokio::time::timeout(core::time::Duration::from_secs(1), client.read_exact(&mut received))
+        .await
+        .expect("read application data")
+        .expect("application data");
+    assert_eq!(&received, b"after reauthentication failure");
+
+    drop(initial_out_tx);
+    drop(client);
+    initial_out_server.await.expect("serve initial OUT");
+    initial_in_server.await.expect("serve initial IN");
+    reauth_in_server.await.expect("serve reauthentication IN");
+}
+
+#[tokio::test]
+async fn reauthentication_consent_requires_an_owned_callback() {
+    let reauth_tunnel_context = 0x0102_0304_0506_0708;
+    let consent = consent_message("Accept");
+    let callback_count = Arc::new(Mutex::new(0));
+    let callback_count_for_callback = Arc::clone(&callback_count);
+    let (initial_out_client, initial_out_server) = tokio::io::duplex(4096);
+    let (initial_in_client, initial_in_server) = tokio::io::duplex(4096);
+    let (reauth_out_client, reauth_out_server) = tokio::io::duplex(4096);
+    let (reauth_in_client, reauth_in_server) = tokio::io::duplex(4096);
+    let (reauth_attempt_tx, reauth_attempt_rx) = tokio::sync::oneshot::channel();
+    let (initial_out_tx, initial_out_rx) = tokio::sync::mpsc::channel(2);
+
+    initial_out_tx
+        .send(Bytes::from(out_response([
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0, &consent)),
+            packet(7, &control_response(0)),
+            packet(9, &control_response(0)),
+            packet(12, &reauth_message(reauth_tunnel_context)),
+        ])))
+        .await
+        .expect("send initial response");
+    let initial_out_server = tokio::spawn(mock_streaming_out_server(initial_out_server, initial_out_rx));
+    let initial_in_server = tokio::spawn(mock_in_server(initial_in_server, None, None));
+    let reauth_out_server = tokio::spawn(mock_out_server(
+        reauth_out_server,
+        vec![
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0, &consent)),
+        ],
+    ));
+    let reauth_in_server = tokio::spawn(mock_reauth_failure_in_server(
+        reauth_in_server,
+        reauth_tunnel_context,
+        reauth_attempt_tx,
+    ));
+
+    let initial_transport = GatewayTransport::connect(initial_out_client, initial_in_client)
+        .await
+        .expect("connect initial transport");
+    let reauth_transport = GatewayTransport::connect(reauth_out_client, reauth_in_client)
+        .await
+        .expect("connect reauthentication transport");
+    let mut callback = move |_message: &str| {
+        *callback_count_for_callback.lock().expect("callback count lock") += 1;
+        true
+    };
+    let client = initial_transport
+        .connect_tunnel_with_reauth_and_consent(
+            test_target(),
+            "client.test",
+            3389,
+            reauth_transport,
+            Some(&mut callback),
+        )
+        .await
+        .expect("connect tunnel");
+
+    tokio::time::timeout(core::time::Duration::from_secs(1), reauth_attempt_rx)
+        .await
+        .expect("reauthentication attempt")
+        .expect("reauthentication attempt signal");
+    reauth_out_server.await.expect("serve reauthentication OUT");
+    assert_eq!(*callback_count.lock().expect("callback count lock"), 1);
+
+    drop(initial_out_tx);
+    drop(client);
+    initial_out_server.await.expect("serve initial OUT");
+    initial_in_server.await.expect("serve initial IN");
     reauth_in_server.await.expect("serve reauthentication IN");
 }
 
@@ -590,11 +748,23 @@ fn reauth_message(reauth_tunnel_context: u64) -> [u8; 8] {
     reauth_tunnel_context.to_le_bytes()
 }
 
-async fn mock_out_server(stream: tokio::io::DuplexStream, packets: Vec<Vec<u8>>) {
+fn data_packet(data: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(2 + data.len());
+    payload.extend(u16::try_from(data.len()).expect("data length").to_le_bytes());
+    payload.extend(data);
+    packet(10, &payload)
+}
+
+fn out_response(packets: impl IntoIterator<Item = Vec<u8>>) -> Vec<u8> {
     let mut response_body = Vec::from([0; 10]);
     for packet in packets {
         response_body.extend(packet);
     }
+    response_body
+}
+
+async fn mock_out_server(stream: tokio::io::DuplexStream, packets: Vec<Vec<u8>>) {
+    let response_body = out_response(packets);
     let service = service_fn(move |request: Request<hyper::body::Incoming>| {
         let response_body = response_body.clone();
         async move {
@@ -606,6 +776,76 @@ async fn mock_out_server(stream: tokio::io::DuplexStream, packets: Vec<Vec<u8>>)
         .serve_connection(TokioIo::new(stream), service)
         .await
         .expect("serve OUT");
+}
+
+async fn mock_streaming_out_server(stream: tokio::io::DuplexStream, response_body: tokio::sync::mpsc::Receiver<Bytes>) {
+    let response_body = Arc::new(Mutex::new(Some(response_body)));
+    let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+        let response_body = response_body
+            .lock()
+            .expect("response body lock")
+            .take()
+            .expect("single OUT request");
+        async move {
+            assert_eq!(request.method(), "RDG_OUT_DATA");
+            Ok::<_, Infallible>(streaming_response(StatusCode::OK, response_body))
+        }
+    });
+    http1::Builder::new()
+        .serve_connection(TokioIo::new(stream), service)
+        .await
+        .expect("serve streaming OUT");
+}
+
+async fn mock_reauth_failure_in_server(
+    stream: tokio::io::DuplexStream,
+    reauth_tunnel_context: u64,
+    attempt: tokio::sync::oneshot::Sender<()>,
+) {
+    let attempt = Arc::new(Mutex::new(Some(attempt)));
+    let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+        let attempt = Arc::clone(&attempt);
+        async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+
+            for expected_packet_type in [1, 4] {
+                let frame = request
+                    .body_mut()
+                    .frame()
+                    .await
+                    .expect("IN request frame")
+                    .expect("IN request frame result")
+                    .into_data()
+                    .expect("IN request data frame");
+                assert_eq!(packet_type(&frame), expected_packet_type);
+                if expected_packet_type == 4 {
+                    assert_eq!(&frame[12..14], &0x2u16.to_le_bytes());
+                    assert_eq!(&frame[16..24], &reauth_tunnel_context.to_le_bytes());
+                }
+            }
+            attempt
+                .lock()
+                .expect("reauthentication attempt lock")
+                .take()
+                .expect("single reauthentication attempt")
+                .send(())
+                .expect("send reauthentication attempt");
+
+            let next = tokio::time::timeout(core::time::Duration::from_millis(100), request.body_mut().frame()).await;
+            assert!(
+                !matches!(next, Ok(Some(Ok(_)))),
+                "reauthentication consent rejection or tunnel failure must not authorize or create a channel"
+            );
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        }
+    });
+    http1::Builder::new()
+        .serve_connection(TokioIo::new(stream), service)
+        .await
+        .expect("serve reauthentication IN");
 }
 
 async fn mock_in_server(
@@ -635,10 +875,14 @@ async fn mock_in_server(
                 if expected_packet_type == 4 {
                     match reauth_tunnel_context {
                         Some(reauth_tunnel_context) => {
+                            assert_eq!(&frame[8..12], &0x14u32.to_le_bytes());
                             assert_eq!(&frame[12..14], &0x2u16.to_le_bytes());
                             assert_eq!(&frame[16..24], &reauth_tunnel_context.to_le_bytes());
                         }
-                        None => assert_eq!(&frame[12..14], &0u16.to_le_bytes()),
+                        None => {
+                            assert_eq!(&frame[8..12], &0x14u32.to_le_bytes());
+                            assert_eq!(&frame[12..14], &0u16.to_le_bytes());
+                        }
                     }
                 }
             }
@@ -657,6 +901,17 @@ async fn mock_in_server(
 
 fn response(status: StatusCode, body: Bytes) -> Response<TestBody> {
     let mut response = Response::new(Full::new(body).boxed());
+    *response.status_mut() = status;
+    response
+}
+
+fn streaming_response(status: StatusCode, mut body: tokio::sync::mpsc::Receiver<Bytes>) -> Response<TestBody> {
+    let body = StreamBody::new(stream::poll_fn(move |cx| {
+        body.poll_recv(cx)
+            .map(|data| data.map(|data| Ok::<_, Infallible>(Frame::data(data))))
+    }))
+    .boxed();
+    let mut response = Response::new(body);
     *response.status_mut() = status;
     response
 }

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -10,8 +10,8 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use ironrdp_mstsgu::{GwConnectTarget, GwErrorKind, GwExtendedAuthentication, GwSessionAuthentication};
 use ironrdp_mstsgu::test_support::{GatewayTransport, evaluate_consent_message};
+use ironrdp_mstsgu::{GwConnectTarget, GwErrorKind, GwExtendedAuthentication, GwSessionAuthentication};
 
 type TestBody = BoxBody<Bytes, Infallible>;
 
@@ -171,7 +171,10 @@ async fn http_sspi_ntlm_is_selected_and_reused_for_the_in_channel() {
                         Ok::<_, Infallible>(response)
                     }
                     1 => {
-                        assert_eq!(request.headers().get("authorization").expect("SSPI_NTLM authorization"), "SSPI_NTLM");
+                        assert_eq!(
+                            request.headers().get("authorization").expect("SSPI_NTLM authorization"),
+                            "SSPI_NTLM"
+                        );
                         Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from(vec![0; 10])))
                     }
                     _ => panic!("unexpected OUT request"),
@@ -574,7 +577,11 @@ fn control_response(error_code: u32) -> [u8; 8] {
 fn extended_auth_response(error_code: u32, auth_blob: &[u8]) -> Vec<u8> {
     let mut response = Vec::with_capacity(6 + auth_blob.len());
     response.extend(error_code.to_le_bytes());
-    response.extend(u16::try_from(auth_blob.len()).expect("extended authentication blob length").to_le_bytes());
+    response.extend(
+        u16::try_from(auth_blob.len())
+            .expect("extended authentication blob length")
+            .to_le_bytes(),
+    );
     response.extend(auth_blob);
     response
 }
@@ -583,10 +590,7 @@ fn reauth_message(reauth_tunnel_context: u64) -> [u8; 8] {
     reauth_tunnel_context.to_le_bytes()
 }
 
-async fn mock_out_server(
-    stream: tokio::io::DuplexStream,
-    packets: Vec<Vec<u8>>,
-) {
+async fn mock_out_server(stream: tokio::io::DuplexStream, packets: Vec<Vec<u8>>) {
     let mut response_body = Vec::from([0; 10]);
     for packet in packets {
         response_body.extend(packet);

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -10,8 +10,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use ironrdp_mstsgu::GwConnectTarget;
-use ironrdp_mstsgu::GwErrorKind;
+use ironrdp_mstsgu::{GwConnectTarget, GwErrorKind, GwExtendedAuthentication, GwSessionAuthentication};
 use ironrdp_mstsgu::test_support::{GatewayTransport, evaluate_consent_message};
 
 type TestBody = BoxBody<Bytes, Infallible>;
@@ -145,6 +144,199 @@ async fn callback_rejection_stops_before_tunnel_authorization() {
 }
 
 #[tokio::test]
+async fn http_sspi_ntlm_is_selected_and_reused_for_the_in_channel() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let out_requests = Arc::new(Mutex::new(0));
+    let out_requests_for_service = Arc::clone(&out_requests);
+
+    let out_server = tokio::spawn(async move {
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let out_requests = Arc::clone(&out_requests_for_service);
+            async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                let request_number = {
+                    let mut out_requests = out_requests.lock().expect("OUT request count lock");
+                    let request_number = *out_requests;
+                    *out_requests += 1;
+                    request_number
+                };
+                match request_number {
+                    0 => {
+                        assert!(request.headers().get("authorization").is_none());
+                        let mut response = response(StatusCode::UNAUTHORIZED, Bytes::new());
+                        response
+                            .headers_mut()
+                            .insert("www-authenticate", "SSPI_NTLM".parse().expect("SSPI_NTLM header"));
+                        Ok::<_, Infallible>(response)
+                    }
+                    1 => {
+                        assert_eq!(request.headers().get("authorization").expect("SSPI_NTLM authorization"), "SSPI_NTLM");
+                        Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from(vec![0; 10])))
+                    }
+                    _ => panic!("unexpected OUT request"),
+                }
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(out_server), service)
+            .await
+            .expect("serve OUT");
+    });
+
+    let in_authorizations = Arc::new(Mutex::new(Vec::new()));
+    let in_authorizations_for_service = Arc::clone(&in_authorizations);
+    let in_server = tokio::spawn(async move {
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let in_authorizations = Arc::clone(&in_authorizations_for_service);
+            async move {
+                assert_eq!(request.method(), "RDG_IN_DATA");
+                in_authorizations.lock().expect("IN authorization lock").push(
+                    request
+                        .headers()
+                        .get("authorization")
+                        .map(|authorization| authorization.to_str().expect("valid authorization").to_owned()),
+                );
+                Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let transport = GatewayTransport::connect(out_client, in_client)
+        .await
+        .expect("connect SSPI_NTLM transport");
+    assert_eq!(transport.session_authentication(), GwSessionAuthentication::NtlmSspi);
+    drop(transport);
+
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+    assert_eq!(*out_requests.lock().expect("OUT request count lock"), 2);
+    assert!(
+        in_authorizations
+            .lock()
+            .expect("IN authorization lock")
+            .contains(&Some("SSPI_NTLM".to_owned()))
+    );
+}
+
+#[tokio::test]
+async fn extended_sspi_ntlm_sends_an_initial_token_and_rejects_an_empty_challenge() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let mut out_response = Vec::from([0; 10]);
+    out_response.extend(packet(2, &handshake_response_with_extended_auth(0, 0x0004)));
+    out_response.extend(packet(3, &extended_auth_response(0, &[])));
+
+    let out_server = tokio::spawn(mock_out_server(out_server, vec![out_response.split_off(10)]));
+    let in_server = tokio::spawn(async move {
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+
+            let handshake = request
+                .body_mut()
+                .frame()
+                .await
+                .expect("handshake frame")
+                .expect("handshake frame result")
+                .into_data()
+                .expect("handshake data frame");
+            assert_eq!(packet_type(&handshake), 1);
+            assert_eq!(&handshake[12..14], &0x0004u16.to_le_bytes());
+
+            let extended_auth = request
+                .body_mut()
+                .frame()
+                .await
+                .expect("extended authentication frame")
+                .expect("extended authentication frame result")
+                .into_data()
+                .expect("extended authentication data frame");
+            assert_eq!(packet_type(&extended_auth), 3);
+            assert_ne!(&extended_auth[12..14], &0u16.to_le_bytes());
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let transport = GatewayTransport::connect(out_client, in_client)
+        .await
+        .expect("connect transport");
+    let error = match transport
+        .connect_tunnel_with_session_authentication(
+            test_target(),
+            "client.test",
+            3389,
+            GwSessionAuthentication::NtlmSspi,
+        )
+        .await
+    {
+        Ok(_) => panic!("empty extended authentication challenge"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error.kind(), GwErrorKind::Connect));
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
+#[tokio::test]
+async fn unsupported_extended_authentication_is_reported_precisely() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let out_server = tokio::spawn(mock_out_server(
+        out_server,
+        vec![packet(2, &handshake_response_with_extended_auth(0, 0x0001))],
+    ));
+    let in_server = tokio::spawn(async move {
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| async move {
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+            let handshake = request
+                .body_mut()
+                .frame()
+                .await
+                .expect("handshake frame")
+                .expect("handshake frame result")
+                .into_data()
+                .expect("handshake data frame");
+            assert_eq!(packet_type(&handshake), 1);
+            assert_eq!(&handshake[12..14], &0u16.to_le_bytes());
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let transport = GatewayTransport::connect(out_client, in_client)
+        .await
+        .expect("connect transport");
+    let error = match transport.connect_tunnel(test_target(), "client.test", 3389, None).await {
+        Ok(_) => panic!("unsupported extended authentication"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error.kind(),
+        GwErrorKind::UnsupportedExtendedAuthentication(GwExtendedAuthentication::SmartCard)
+    ));
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
+#[tokio::test]
 async fn control_errors_preserve_gateway_hresult() {
     for (expected_packet_types, error_code, context, label) in [
         (&[1][..], 0x8007_59DA, "Handshake", "E_PROXY_RAP_ACCESSDENIED"),
@@ -252,6 +444,64 @@ async fn control_errors_preserve_gateway_hresult() {
     }
 }
 
+#[tokio::test]
+async fn reauthentication_uses_a_fresh_tunnel_and_preserves_the_data_transport() {
+    let reauth_tunnel_context = 0x1122_3344_5566_7788;
+    let (initial_out_client, initial_out_server) = tokio::io::duplex(4096);
+    let (initial_in_client, initial_in_server) = tokio::io::duplex(4096);
+    let (reauth_out_client, reauth_out_server) = tokio::io::duplex(4096);
+    let (reauth_in_client, reauth_in_server) = tokio::io::duplex(4096);
+    let (reauth_complete_tx, reauth_complete_rx) = tokio::sync::oneshot::channel();
+
+    let initial_out_server = tokio::spawn(mock_out_server(
+        initial_out_server,
+        vec![
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0, &[])),
+            packet(7, &control_response(0)),
+            packet(9, &control_response(0)),
+            packet(12, &reauth_message(reauth_tunnel_context)),
+        ],
+    ));
+    let initial_in_server = tokio::spawn(mock_in_server(initial_in_server, None, None));
+    let reauth_out_server = tokio::spawn(mock_out_server(
+        reauth_out_server,
+        vec![
+            packet(2, &handshake_response(0)),
+            packet(5, &tunnel_response(0, &[])),
+            packet(7, &control_response(0)),
+            packet(9, &control_response(0)),
+        ],
+    ));
+    let reauth_in_server = tokio::spawn(mock_in_server(
+        reauth_in_server,
+        Some(reauth_tunnel_context),
+        Some(reauth_complete_tx),
+    ));
+
+    let initial_transport = GatewayTransport::connect(initial_out_client, initial_in_client)
+        .await
+        .expect("connect initial transport");
+    let reauth_transport = GatewayTransport::connect(reauth_out_client, reauth_in_client)
+        .await
+        .expect("connect reauthentication transport");
+    let client = initial_transport
+        .connect_tunnel_with_reauth(test_target(), "client.test", 3389, reauth_transport)
+        .await
+        .expect("connect tunnel");
+
+    tokio::time::timeout(core::time::Duration::from_secs(1), reauth_complete_rx)
+        .await
+        .expect("reauthentication completed")
+        .expect("reauthentication completion signal");
+    drop(client);
+
+    initial_out_server.await.expect("serve initial OUT");
+    initial_in_server.await.expect("serve initial IN");
+    reauth_out_server.await.expect("serve reauthentication OUT");
+    reauth_in_server.await.expect("serve reauthentication IN");
+}
+
 #[test]
 fn malformed_consent_payload_is_rejected_before_callback() {
     let callback_count = Arc::new(Mutex::new(0));
@@ -291,8 +541,13 @@ fn packet_type(packet: &[u8]) -> u16 {
 }
 
 fn handshake_response(error_code: u32) -> [u8; 10] {
-    let mut response = [0, 0, 0, 0, 1, 0, 0, 0, 1, 0];
+    handshake_response_with_extended_auth(error_code, 0)
+}
+
+fn handshake_response_with_extended_auth(error_code: u32, extended_auth: u16) -> [u8; 10] {
+    let mut response = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0];
     response[..4].copy_from_slice(&error_code.to_le_bytes());
+    response[8..].copy_from_slice(&extended_auth.to_le_bytes());
     response
 }
 
@@ -314,6 +569,86 @@ fn control_response(error_code: u32) -> [u8; 8] {
     let mut response = [0; 8];
     response[..4].copy_from_slice(&error_code.to_le_bytes());
     response
+}
+
+fn extended_auth_response(error_code: u32, auth_blob: &[u8]) -> Vec<u8> {
+    let mut response = Vec::with_capacity(6 + auth_blob.len());
+    response.extend(error_code.to_le_bytes());
+    response.extend(u16::try_from(auth_blob.len()).expect("extended authentication blob length").to_le_bytes());
+    response.extend(auth_blob);
+    response
+}
+
+fn reauth_message(reauth_tunnel_context: u64) -> [u8; 8] {
+    reauth_tunnel_context.to_le_bytes()
+}
+
+async fn mock_out_server(
+    stream: tokio::io::DuplexStream,
+    packets: Vec<Vec<u8>>,
+) {
+    let mut response_body = Vec::from([0; 10]);
+    for packet in packets {
+        response_body.extend(packet);
+    }
+    let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+        let response_body = response_body.clone();
+        async move {
+            assert_eq!(request.method(), "RDG_OUT_DATA");
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from(response_body)))
+        }
+    });
+    http1::Builder::new()
+        .serve_connection(TokioIo::new(stream), service)
+        .await
+        .expect("serve OUT");
+}
+
+async fn mock_in_server(
+    stream: tokio::io::DuplexStream,
+    reauth_tunnel_context: Option<u64>,
+    complete: Option<tokio::sync::oneshot::Sender<()>>,
+) {
+    let complete = Arc::new(Mutex::new(complete));
+    let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+        let complete = Arc::clone(&complete);
+        async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+
+            for expected_packet_type in [1, 4, 6, 8] {
+                let frame = request
+                    .body_mut()
+                    .frame()
+                    .await
+                    .expect("IN request frame")
+                    .expect("IN request frame result")
+                    .into_data()
+                    .expect("IN request data frame");
+                assert_eq!(packet_type(&frame), expected_packet_type);
+                if expected_packet_type == 4 {
+                    match reauth_tunnel_context {
+                        Some(reauth_tunnel_context) => {
+                            assert_eq!(&frame[12..14], &0x2u16.to_le_bytes());
+                            assert_eq!(&frame[16..24], &reauth_tunnel_context.to_le_bytes());
+                        }
+                        None => assert_eq!(&frame[12..14], &0u16.to_le_bytes()),
+                    }
+                }
+            }
+
+            if let Some(complete) = complete.lock().expect("completion lock").take() {
+                complete.send(()).expect("send reauthentication completion");
+            }
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        }
+    });
+    http1::Builder::new()
+        .serve_connection(TokioIo::new(stream), service)
+        .await
+        .expect("serve IN");
 }
 
 fn response(status: StatusCode, body: Bytes) -> Response<TestBody> {


### PR DESCRIPTION
Negotiate MS-TSGU SSPI NTLM authentication and reauthenticate the
original session on a short-lived transport without interrupting
application data.

Reject unsupported smart-card and pluggable exchanges explicitly.