### PR TITLE
fix(rdpsnd): stop blocking the real-time playback callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
  "ironrdp-rdpeai",
  "ironrdp-rdpsnd",
  "opus2",
+ "ringbuf",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4998,6 +4999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5527,17 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a158e09ede21a14b172ca6cdd6208386c6ae2cb6acef58d774368ef8c450dfa7"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]

--- a/crates/ironrdp-rdpsnd-native/Cargo.toml
+++ b/crates/ironrdp-rdpsnd-native/Cargo.toml
@@ -28,7 +28,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["std"]
 ironrdp-rdpeai = { path = "../ironrdp-rdpeai", version = "0.1", optional = true } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9" } # public
 opus2 = { version = "0.4", optional = true, features = ["bundled"] }
-ringbuf = "0.5"
+ringbuf = "0.5" # public
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]

--- a/crates/ironrdp-rdpsnd-native/Cargo.toml
+++ b/crates/ironrdp-rdpsnd-native/Cargo.toml
@@ -28,6 +28,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["std"]
 ironrdp-rdpeai = { path = "../ironrdp-rdpeai", version = "0.1", optional = true } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9" } # public
 opus2 = { version = "0.4", optional = true, features = ["bundled"] }
+ringbuf = "0.5"
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]

--- a/crates/ironrdp-rdpsnd-native/Cargo.toml
+++ b/crates/ironrdp-rdpsnd-native/Cargo.toml
@@ -28,7 +28,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["std"]
 ironrdp-rdpeai = { path = "../ironrdp-rdpeai", version = "0.1", optional = true } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9" } # public
 opus2 = { version = "0.4", optional = true, features = ["bundled"] }
-ringbuf = "0.5" # public
+ringbuf = "0.5"
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]

--- a/crates/ironrdp-rdpsnd-native/examples/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/examples/cpal.rs
@@ -6,11 +6,8 @@ use std::sync::Arc;
 use std::thread;
 
 use anyhow::Context as _;
-use cpal::traits::StreamTrait as _;
 use ironrdp_rdpsnd::pdu::{AudioFormat, WaveFormat};
 use ironrdp_rdpsnd_native::cpal::DecodeStream;
-use ringbuf::HeapRb;
-use ringbuf::traits::{Producer as _, Split as _};
 use tracing::debug;
 
 fn setup_logging() -> anyhow::Result<()> {
@@ -45,11 +42,9 @@ fn main() -> anyhow::Result<()> {
         bits_per_sample: 16,
         data: None,
     };
-    let rb = HeapRb::<u8>::new(4096);
-    let (mut producer, consumer) = rb.split();
     // Full volume on both channels (internal pack_volume layout: left high, right low).
     let volume = Arc::new(AtomicU32::new(0xFFFF_FFFF));
-    let stream = DecodeStream::new(&rx_format, consumer, volume)?;
+    let (_stream, mut producer) = DecodeStream::new(&rx_format, volume)?;
 
     let producer_thread = thread::spawn(move || {
         let data_chunks = vec![vec![1u8, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
@@ -61,7 +56,6 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
-    stream.stream().play()?;
     thread::sleep(Duration::from_secs(3));
     let _ = producer_thread.join();
 

--- a/crates/ironrdp-rdpsnd-native/examples/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/examples/cpal.rs
@@ -3,13 +3,14 @@
 use core::sync::atomic::AtomicU32;
 use core::time::Duration;
 use std::sync::Arc;
-use std::sync::mpsc;
 use std::thread;
 
 use anyhow::Context as _;
 use cpal::traits::StreamTrait as _;
 use ironrdp_rdpsnd::pdu::{AudioFormat, WaveFormat};
 use ironrdp_rdpsnd_native::cpal::DecodeStream;
+use ringbuf::HeapRb;
+use ringbuf::traits::{Producer as _, Split as _};
 use tracing::debug;
 
 fn setup_logging() -> anyhow::Result<()> {
@@ -44,15 +45,17 @@ fn main() -> anyhow::Result<()> {
         bits_per_sample: 16,
         data: None,
     };
-    let (tx, rx) = mpsc::channel();
+    let rb = HeapRb::<u8>::new(4096);
+    let (mut producer, consumer) = rb.split();
     // Full volume on both channels (internal pack_volume layout: left high, right low).
     let volume = Arc::new(AtomicU32::new(0xFFFF_FFFF));
-    let stream = DecodeStream::new(&rx_format, rx, volume)?;
+    let stream = DecodeStream::new(&rx_format, consumer, volume)?;
 
-    let producer = thread::spawn(move || {
+    let producer_thread = thread::spawn(move || {
         let data_chunks = vec![vec![1u8, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
         for chunk in data_chunks {
-            tx.send(chunk).expect("failed to send data chunk");
+            let written = producer.push_slice(&chunk);
+            debug_assert_eq!(written, chunk.len(), "ring buffer too small for this example chunk");
             debug!("Sent a chunk");
             thread::sleep(Duration::from_secs(1)); // Simulating work
         }
@@ -60,7 +63,7 @@ fn main() -> anyhow::Result<()> {
 
     stream.stream().play()?;
     thread::sleep(Duration::from_secs(3));
-    let _ = producer.join();
+    let _ = producer_thread.join();
 
     Ok(())
 }

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -1,8 +1,7 @@
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use core::time::Duration;
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::mpsc::{self, Sender};
 use std::thread::{self, JoinHandle};
 
 use cpal::traits::{DeviceTrait as _, HostTrait as _, StreamTrait as _};
@@ -10,6 +9,8 @@ use cpal::{SampleFormat, Stream, StreamConfig, SupportedStreamConfigRange};
 use ironrdp_error::bail;
 use ironrdp_rdpsnd::client::RdpsndClientHandler;
 use ironrdp_rdpsnd::pdu::{AudioFormat, AudioFormatFlags, PitchPdu, VolumePdu, WaveFormat};
+use ringbuf::traits::{Consumer as _, Producer as _, Split as _};
+use ringbuf::{HeapCons, HeapProd, HeapRb};
 use tracing::{debug, error, trace, warn};
 
 use crate::error::{RdpsndNativeError, RdpsndNativeErrorKind, RdpsndNativeResult};
@@ -101,12 +102,56 @@ pub fn apply_volume(
     }
 }
 
+/// Write silence for a PCM buffer of the given sample width.
+///
+/// 8-bit PCM is unsigned with midpoint 128; every other supported width here
+/// is signed, where zero is silence.
+fn fill_silence(buf: &mut [u8], bits_per_sample: u16) {
+    let silence = if bits_per_sample == 8 { 0x80 } else { 0x00 };
+    buf.fill(silence);
+}
+
+/// Capacity of the playback ring buffer between the producer (network/decode)
+/// and the real-time cpal consumer.
+///
+/// Sized to ~500 ms of audio at the negotiated format so ordinary pauses in
+/// the incoming Wave PDU stream (silence between sounds, scheduling jitter)
+/// don't starve the device, without adding much playback latency. Floored so
+/// odd/low-bitrate formats still get a workable buffer.
+fn ring_buffer_capacity(format: &AudioFormat) -> usize {
+    let bytes_per_sec = usize::try_from(format.n_avg_bytes_per_sec).unwrap_or(usize::MAX);
+    (bytes_per_sec / 2).max(4096)
+}
+
+/// Where PCM bytes go once a playback stream is open.
+///
+/// PCM Wave blocks are pushed straight into the ring buffer that feeds the
+/// cpal callback. Opus blocks go to a dedicated decode thread instead, which
+/// decodes and pushes the resulting PCM into that same ring buffer — decoding
+/// must never happen on whatever thread calls `wave()` (the RDPSND PDU
+/// processing path), and it must never happen on the real-time cpal thread.
+enum Ingest {
+    Pcm(HeapProd<u8>),
+    #[cfg(feature = "opus")]
+    Opus(Sender<Vec<u8>>),
+}
+
+impl core::fmt::Debug for Ingest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Pcm(_) => f.write_str("Ingest::Pcm(..)"),
+            #[cfg(feature = "opus")]
+            Self::Opus(_) => f.write_str("Ingest::Opus(..)"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct RdpsndBackend {
     // Unfortunately, Stream is not `Send`, so we move it to a separate thread.
     stream_handle: Option<JoinHandle<()>>,
     stream_ended: Arc<AtomicBool>,
-    tx: Option<Sender<Vec<u8>>>,
+    ingest: Option<Ingest>,
     active_format: Option<AudioFormat>,
     volume: Arc<AtomicU32>,
     /// Formats advertised during RDPSND negotiation (device-filtered PCM + optional Opus).
@@ -122,7 +167,7 @@ impl Default for RdpsndBackend {
 impl RdpsndBackend {
     pub fn new() -> Self {
         Self {
-            tx: None,
+            ingest: None,
             active_format: None,
             stream_handle: None,
             stream_ended: Arc::new(AtomicBool::new(false)),
@@ -274,6 +319,67 @@ impl Drop for RdpsndBackend {
     }
 }
 
+/// Spawn the Opus decode thread and return the sender that feeds it encoded packets.
+///
+/// Runs entirely off the real-time path: it consumes encoded packets from an
+/// ordinary blocking `mpsc` channel (fine — this thread isn't real-time) and
+/// pushes decoded PCM into `producer` with a non-blocking `push_slice`, so it
+/// can never stall the cpal callback either.
+#[cfg(feature = "opus")]
+fn spawn_opus_decode_thread(format: &AudioFormat, mut producer: HeapProd<u8>) -> RdpsndNativeResult<Sender<Vec<u8>>> {
+    let chan = match format.n_channels {
+        1 => opus2::Channels::Mono,
+        2 => opus2::Channels::Stereo,
+        _ => bail!(
+            "unsupported channel count for Opus",
+            RdpsndNativeErrorKind::UnsupportedFormat,
+        ),
+    };
+    let mut dec = opus2::Decoder::new(format.n_samples_per_sec, chan)
+        .map_err(|e| RdpsndNativeError::new("creating Opus decoder", RdpsndNativeErrorKind::OpusInit).with_source(e))?;
+
+    let (enc_tx, enc_rx) = mpsc::channel::<Vec<u8>>();
+    thread::spawn(move || {
+        while let Ok(pkt) = enc_rx.recv() {
+            let nb_samples = match dec.get_nb_samples(&pkt) {
+                Ok(nb_samples) => nb_samples,
+                Err(error) => {
+                    error!(?error, "Failed to get the number of samples of an Opus packet");
+                    continue;
+                }
+            };
+
+            #[expect(
+                clippy::as_conversions,
+                reason = "opus::Channels has no conversions to usize implemented"
+            )]
+            let mut pcm_i16 = vec![0i16; nb_samples * chan as usize];
+            if let Err(error) = dec.decode(&pkt, &mut pcm_i16, false) {
+                error!(?error, "Failed to decode an Opus packet");
+                continue;
+            }
+            // Reinterpreting Vec<i16> -> &[u8] via cast_slice is safe (smaller alignment).
+            // Allocating as Vec<i16> in the first place avoids the alignment hazard of
+            // `bytemuck::cast_slice_mut::<u8, i16>` panicking when the allocator hands
+            // back a u8 buffer that is not 2-byte aligned (which manifested as a hard
+            // crash in #1202 under the burst of malformed Opus packets generated by a
+            // server reboot).
+            let pcm = bytemuck::cast_slice(&pcm_i16);
+
+            let written = producer.push_slice(pcm);
+            if written < pcm.len() {
+                warn!(
+                    dropped = pcm.len() - written,
+                    "Playback ring buffer full; dropping decoded audio"
+                );
+            }
+        }
+        debug!("Opus decode thread exiting (sender dropped)");
+    });
+
+    Ok(enc_tx)
+}
+
 impl RdpsndClientHandler for RdpsndBackend {
     fn get_flags(&self) -> AudioFormatFlags {
         // VOLUME is implemented via sample scaling in the playback path.
@@ -303,8 +409,27 @@ impl RdpsndClientHandler for RdpsndBackend {
         }
 
         if self.stream_handle.is_none() {
-            let (tx, rx) = mpsc::channel();
-            self.tx = Some(tx);
+            let rb = HeapRb::<u8>::new(ring_buffer_capacity(format));
+            let (producer, consumer) = rb.split();
+
+            let ingest = match format.format {
+                WaveFormat::PCM => Ingest::Pcm(producer),
+                #[cfg(feature = "opus")]
+                WaveFormat::OPUS => match spawn_opus_decode_thread(format, producer) {
+                    Ok(enc_tx) => Ingest::Opus(enc_tx),
+                    Err(e) => {
+                        // Soft-fail: log and bail before anything is spawned. The next
+                        // wave block will retry (stream_handle/ingest are still None).
+                        error!(error = %e.report().with_locations());
+                        return;
+                    }
+                },
+                _ => {
+                    error!(?format, "Unsupported wave format");
+                    return;
+                }
+            };
+            self.ingest = Some(ingest);
 
             self.active_format = Some(format.clone());
             let format = format.clone();
@@ -312,7 +437,7 @@ impl RdpsndClientHandler for RdpsndBackend {
             let stream_ended = Arc::clone(&self.stream_ended);
             let volume = Arc::clone(&self.volume);
             self.stream_handle = Some(thread::spawn(move || {
-                let stream = match DecodeStream::new(&format, rx, volume) {
+                let stream = match DecodeStream::new(&format, consumer, volume) {
                     Ok(stream) => stream,
                     Err(e) => {
                         // Soft-fail: log and exit the stream thread. Further wave
@@ -330,11 +455,24 @@ impl RdpsndClientHandler for RdpsndBackend {
             }));
         }
 
-        if let Some(ref tx) = self.tx {
-            if let Err(error) = tx.send(data.to_vec()) {
-                error!(%error);
+        match self.ingest.as_mut() {
+            Some(Ingest::Pcm(producer)) => {
+                let written = producer.push_slice(&data);
+                if written < data.len() {
+                    warn!(
+                        dropped = data.len() - written,
+                        "Playback ring buffer full; dropping audio"
+                    );
+                }
             }
-        };
+            #[cfg(feature = "opus")]
+            Some(Ingest::Opus(tx)) => {
+                if let Err(error) = tx.send(data.to_vec()) {
+                    error!(%error);
+                }
+            }
+            None => {}
+        }
     }
 
     fn set_volume(&mut self, volume: VolumePdu) {
@@ -349,7 +487,9 @@ impl RdpsndClientHandler for RdpsndBackend {
     }
 
     fn close(&mut self) {
-        self.tx = None;
+        // Dropping the Opus sender (if any) makes the decode thread's blocking
+        // `recv()` return `Err` on its own — no explicit stop signal needed there.
+        self.ingest = None;
         self.active_format = None;
         if let Some(stream) = self.stream_handle.take() {
             self.stream_ended.store(true, Ordering::Relaxed);
@@ -363,73 +503,11 @@ impl RdpsndClientHandler for RdpsndBackend {
 
 #[doc(hidden)]
 pub struct DecodeStream {
-    _dec_thread: Option<JoinHandle<()>>,
     stream: Stream,
 }
 
 impl DecodeStream {
-    pub fn new(rx_format: &AudioFormat, mut rx: Receiver<Vec<u8>>, volume: Arc<AtomicU32>) -> RdpsndNativeResult<Self> {
-        let mut dec_thread = None;
-        match rx_format.format {
-            #[cfg(feature = "opus")]
-            WaveFormat::OPUS => {
-                let chan = match rx_format.n_channels {
-                    1 => opus2::Channels::Mono,
-                    2 => opus2::Channels::Stereo,
-                    _ => bail!(
-                        "unsupported channel count for Opus",
-                        RdpsndNativeErrorKind::UnsupportedFormat,
-                    ),
-                };
-                let (dec_tx, dec_rx) = mpsc::channel();
-                let mut dec = opus2::Decoder::new(rx_format.n_samples_per_sec, chan).map_err(|e| {
-                    RdpsndNativeError::new("creating Opus decoder", RdpsndNativeErrorKind::OpusInit).with_source(e)
-                })?;
-                dec_thread = Some(thread::spawn(move || {
-                    while let Ok(pkt) = rx.recv() {
-                        let nb_samples = match dec.get_nb_samples(&pkt) {
-                            Ok(nb_samples) => nb_samples,
-                            Err(error) => {
-                                error!(?error, "Failed to get the number of samples of an Opus packet");
-                                continue;
-                            }
-                        };
-
-                        #[expect(
-                            clippy::as_conversions,
-                            reason = "opus::Channels has no conversions to usize implemented"
-                        )]
-                        let mut pcm_i16 = vec![0i16; nb_samples * chan as usize];
-                        if let Err(error) = dec.decode(&pkt, &mut pcm_i16, false) {
-                            error!(?error, "Failed to decode an Opus packet");
-                            continue;
-                        }
-                        // Vec<u8> is what the channel carries downstream. Reinterpreting
-                        // Vec<i16> -> Vec<u8> via cast_slice is safe (smaller alignment).
-                        // Allocating as Vec<i16> in the first place avoids the alignment
-                        // hazard of `bytemuck::cast_slice_mut::<u8, i16>` panicking when
-                        // the allocator hands back a u8 buffer that is not 2-byte aligned
-                        // (which manifested as a hard crash in #1202 under the burst of
-                        // malformed Opus packets generated by a server reboot).
-                        let pcm = bytemuck::cast_slice(&pcm_i16).to_vec();
-
-                        if dec_tx.send(pcm).is_err() {
-                            error!("Failed to send the decoded Opus packet over the channel");
-                            // If send has failed, it means that the receiver has been dropped.
-                            // There is no point in continuing the loop in this case.
-                            break;
-                        }
-                    }
-                }));
-                rx = dec_rx;
-            }
-            WaveFormat::PCM => {}
-            _ => bail!(
-                "matching server-requested wave format",
-                RdpsndNativeErrorKind::UnsupportedFormat,
-            ),
-        }
-
+    pub fn new(rx_format: &AudioFormat, consumer: HeapCons<u8>, volume: Arc<AtomicU32>) -> RdpsndNativeResult<Self> {
         let sample_format = match rx_format.bits_per_sample {
             8 => SampleFormat::U8,
             16 => SampleFormat::I16,
@@ -453,7 +531,7 @@ impl DecodeStream {
 
         let bits_per_sample = rx_format.bits_per_sample;
         let channels = rx_format.n_channels;
-        let mut rx = RxBuffer::new(rx, volume, bits_per_sample, channels);
+        let mut rx = RxBuffer::new(consumer, volume, bits_per_sample, channels);
         // cpal 0.17: SampleRate is a u32 type alias (not a newtype).
         let config = StreamConfig {
             channels: rx_format.n_channels,
@@ -482,10 +560,7 @@ impl DecodeStream {
             RdpsndNativeError::new("starting cpal output stream", RdpsndNativeErrorKind::StreamBuild).with_source(e)
         })?;
 
-        Ok(Self {
-            _dec_thread: dec_thread,
-            stream,
-        })
+        Ok(Self { stream })
     }
 
     pub fn stream(&self) -> &Stream {
@@ -494,9 +569,7 @@ impl DecodeStream {
 }
 
 struct RxBuffer {
-    receiver: Receiver<Vec<u8>>,
-    last: Option<Vec<u8>>,
-    idx: usize,
+    consumer: HeapCons<u8>,
     volume: Arc<AtomicU32>,
     bits_per_sample: u16,
     channels: u16,
@@ -505,11 +578,9 @@ struct RxBuffer {
 }
 
 impl RxBuffer {
-    fn new(receiver: Receiver<Vec<u8>>, volume: Arc<AtomicU32>, bits_per_sample: u16, channels: u16) -> Self {
+    fn new(consumer: HeapCons<u8>, volume: Arc<AtomicU32>, bits_per_sample: u16, channels: u16) -> Self {
         Self {
-            receiver,
-            last: None,
-            idx: 0,
+            consumer,
             volume,
             bits_per_sample,
             channels,
@@ -517,50 +588,35 @@ impl RxBuffer {
         }
     }
 
+    /// Fill `data` for one cpal callback period.
+    ///
+    /// Runs on the real-time audio thread: it must never block. `pop_slice`
+    /// is lock-free and returns immediately with however many bytes were
+    /// available; anything still missing is filled with silence instead of
+    /// blocking (as the old `recv_timeout(4000ms)` did) or leaving stale
+    /// bytes in `data`.
     fn fill(&mut self, data: &mut [u8]) {
-        let mut filled = 0;
+        let filled = self.consumer.pop_slice(data);
 
-        while filled < data.len() {
-            if self.last.is_none() {
-                match self.receiver.recv_timeout(Duration::from_millis(4000)) {
-                    Ok(mut rx) => {
-                        debug!(rx.len = rx.len());
-                        let (left, right) = unpack_volume(self.volume.load(Ordering::Relaxed));
-                        apply_volume(
-                            &mut rx,
-                            self.bits_per_sample,
-                            self.channels,
-                            left,
-                            right,
-                            &mut self.volume_sample_phase,
-                        );
-                        self.last = Some(rx);
-                    }
-                    Err(error) => {
-                        warn!(%error);
-                    }
-                }
+        if filled > 0 {
+            let (left, right) = unpack_volume(self.volume.load(Ordering::Relaxed));
+            apply_volume(
+                &mut data[..filled],
+                self.bits_per_sample,
+                self.channels,
+                left,
+                right,
+                &mut self.volume_sample_phase,
+            );
+        }
+
+        if filled < data.len() {
+            if filled == 0 {
+                trace!("Playback ring buffer underrun");
+            } else {
+                trace!(filled, requested = data.len(), "Playback ring buffer partial underrun");
             }
-
-            let Some(ref last) = self.last else {
-                trace!("Playback rx underrun");
-                return;
-            };
-
-            #[expect(clippy::arithmetic_side_effects)]
-            while self.idx < last.len() && filled < data.len() {
-                data[filled] = last[self.idx];
-                assert!(filled < usize::MAX);
-                assert!(self.idx < usize::MAX);
-                filled += 1;
-                self.idx += 1;
-            }
-
-            // If all elements from last have been consumed, clear `self.last`
-            if self.idx >= last.len() {
-                self.last = None;
-                self.idx = 0;
-            }
+            fill_silence(&mut data[filled..], self.bits_per_sample);
         }
     }
 }

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -438,7 +438,7 @@ impl RdpsndClientHandler for RdpsndBackend {
             let stream_ended = Arc::clone(&self.stream_ended);
             let volume = Arc::clone(&self.volume);
             self.stream_handle = Some(thread::spawn(move || {
-                let stream = match DecodeStream::new(&format, consumer, volume) {
+                let stream = match DecodeStream::new_with_consumer(&format, consumer, volume) {
                     Ok(stream) => stream,
                     Err(e) => {
                         // Soft-fail: log and exit the stream thread. Further wave
@@ -508,13 +508,35 @@ impl RdpsndClientHandler for RdpsndBackend {
     }
 }
 
+pub struct PcmProducer {
+    producer: HeapProd<u8>,
+}
+
+impl PcmProducer {
+    pub fn push_slice(&mut self, data: &[u8]) -> usize {
+        self.producer.push_slice(data)
+    }
+}
+
 #[doc(hidden)]
 pub struct DecodeStream {
     stream: Stream,
 }
 
 impl DecodeStream {
-    pub fn new(rx_format: &AudioFormat, consumer: HeapCons<u8>, volume: Arc<AtomicU32>) -> RdpsndNativeResult<Self> {
+    pub fn new(rx_format: &AudioFormat, volume: Arc<AtomicU32>) -> RdpsndNativeResult<(Self, PcmProducer)> {
+        let rb = HeapRb::<u8>::new(ring_buffer_capacity(rx_format));
+        let (producer, consumer) = rb.split();
+        let stream = Self::new_with_consumer(rx_format, consumer, volume)?;
+
+        Ok((stream, PcmProducer { producer }))
+    }
+
+    fn new_with_consumer(
+        rx_format: &AudioFormat,
+        consumer: HeapCons<u8>,
+        volume: Arc<AtomicU32>,
+    ) -> RdpsndNativeResult<Self> {
         let sample_format = match rx_format.bits_per_sample {
             8 => SampleFormat::U8,
             16 => SampleFormat::I16,

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -1,6 +1,7 @@
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::borrow::Cow;
 use std::sync::Arc;
+#[cfg(feature = "opus")]
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, JoinHandle};
 
@@ -464,7 +465,7 @@ impl RdpsndClientHandler for RdpsndBackend {
                     // absorption between the server's audio timeline and the local
                     // device (no resampling here); only worth a WARN once it's large
                     // enough to suggest an actual scheduling stall on the audio thread.
-                    if dropped > format.n_avg_bytes_per_sec as usize / 100 {
+                    if dropped > usize::try_from(format.n_avg_bytes_per_sec).unwrap_or(usize::MAX) / 100 {
                         warn!(dropped, "Playback ring buffer full; dropping audio");
                     } else {
                         trace!(dropped, "Playback ring buffer full; dropping audio");

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -458,11 +458,17 @@ impl RdpsndClientHandler for RdpsndBackend {
         match self.ingest.as_mut() {
             Some(Ingest::Pcm(producer)) => {
                 let written = producer.push_slice(&data);
-                if written < data.len() {
-                    warn!(
-                        dropped = data.len() - written,
-                        "Playback ring buffer full; dropping audio"
-                    );
+                let dropped = data.len() - written;
+                if dropped > 0 {
+                    // A handful of dropped bytes every so often is normal clock-drift
+                    // absorption between the server's audio timeline and the local
+                    // device (no resampling here); only worth a WARN once it's large
+                    // enough to suggest an actual scheduling stall on the audio thread.
+                    if dropped > format.n_avg_bytes_per_sec as usize / 100 {
+                        warn!(dropped, "Playback ring buffer full; dropping audio");
+                    } else {
+                        trace!(dropped, "Playback ring buffer full; dropping audio");
+                    }
                 }
             }
             #[cfg(feature = "opus")]


### PR DESCRIPTION
`RxBuffer::fill()` ran on the cpal real-time audio thread and called `Receiver::recv_timeout(Duration::from_millis(4000))` whenever it ran out of buffered PCM. Any pause in incoming Wave PDUs longer than one callback period — completely normal whenever nothing is currently playing remotely — blocked the audio device's callback thread for up
to 4 seconds, starving its ring buffer and triggering a cpal "Buffer underrun/overrun occurred" error plus a "timed out waiting on channel" warning, repeating every ~4s for as long as playback stayed idle.

Replace the `mpsc::Receiver<Vec<u8>>` between the producer (network/decode) and the consumer (cpal callback) with a lock-free SPSC byte ring buffer (`ringbuf`). `RxBuffer::fill()` now calls `pop_slice`, which is non-blocking and returns immediately with whatever is available; any shortfall is filled with correct silence (0x80 for unsigned 8-bit PCM, 0x00 otherwise) instead of blocking or leaving stale bytes. Volume is still applied at pop time, right before playback, preserving the existing responsiveness of VolumePdu changes.

This also drops the old `last`/`idx` partial-block bookkeeping in `RxBuffer` (the ring buffer handles partial reads natively), and moves Opus decoding off the `stream_handle` thread into its own thread spawned directly from `wave()`, pushing decoded PCM into the same ring buffer non-blockingly.

Fixes for this kind of errors:
```
2026-08-26T04:19:43.004416Z ERROR ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:43.055013Z ERROR ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:43.104671Z ERROR ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:47.109771Z  WARN ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:540: error=timed out waiting on channel
2026-08-26T04:19:47.109844Z ERROR ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:48.950520Z  WARN ThreadId(54) crates/ironrdp-rdpsnd-native/src/cpal.rs:540: error=channel is empty and sending half is closed
2026-08-26T04:19:49.375421Z ERROR ThreadId(56) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:49.489871Z ERROR ThreadId(56) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:49.593537Z ERROR ThreadId(56) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
2026-08-26T04:19:49.679003Z ERROR ThreadId(56) crates/ironrdp-rdpsnd-native/src/cpal.rs:473: error=Buffer underrun/overrun occurred.
```