### PR TITLE
fix(egfx): do not track frames a suspended client cannot acknowledge

### DIFF
--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -525,15 +525,20 @@ impl FrameTracker {
         let frame_id = self.next_frame_id;
         self.next_frame_id = self.next_frame_id.wrapping_add(1);
 
-        self.unacknowledged.insert(
-            frame_id,
-            FrameInfo {
+        // A suspended client sends no acknowledgement until it opts back in
+        // ([MS-RDPEGFX] 2.2.2.13), so nothing would take this frame back out.
+        // Backpressure is off while suspended, so the entry has no work to do.
+        if !self.ack_suspended {
+            self.unacknowledged.insert(
                 frame_id,
-                timestamp,
-                sent_at: Instant::now(),
-                size_bytes: 0,
-            },
-        );
+                FrameInfo {
+                    frame_id,
+                    timestamp,
+                    sent_at: Instant::now(),
+                    size_bytes: 0,
+                },
+            );
+        }
 
         self.total_sent += 1;
         frame_id
@@ -548,7 +553,8 @@ impl FrameTracker {
 
     /// Handle frame acknowledgment from client
     pub fn acknowledge(&mut self, frame_id: u32, queue_depth: u32) -> Option<FrameInfo> {
-        if queue_depth == SUSPEND_FRAME_ACK_QUEUE_DEPTH {
+        let suspending = queue_depth == SUSPEND_FRAME_ACK_QUEUE_DEPTH;
+        if suspending {
             self.ack_suspended = true;
             self.client_queue_depth = 0;
         } else {
@@ -556,10 +562,21 @@ impl FrameTracker {
             self.client_queue_depth = queue_depth;
         }
 
+        // A suspending Frame Acknowledge still acknowledges: take the frame
+        // out before the clear below, since it carries the round-trip sample
+        // and byte count the QoE report is built from.
         let info = self.unacknowledged.remove(&frame_id);
         if info.is_some() {
             self.total_acked += 1;
         }
+
+        if suspending {
+            // [MS-RDPEGFX] 3.2.5.13: "the server MUST clear the Unacknowledged
+            // Frames ADM element and MUST NOT expect any further
+            // RDPGFX_FRAME_ACKNOWLEDGE_PDU messages from the client".
+            self.unacknowledged.clear();
+        }
+
         info
     }
 

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -2,7 +2,7 @@ use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor, encode_vec};
 use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_egfx::pdu::{
     Avc420Region, CapabilitiesAdvertisePdu, CapabilitiesV8Flags, CapabilitiesV10Flags, CapabilitiesV81Flags,
-    CapabilitySet, Codec1Type, GfxPdu, PixelFormat,
+    CapabilitySet, Codec1Type, FrameAcknowledgePdu, GfxPdu, PixelFormat, QueueDepth,
 };
 use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer, QoeMetrics, Surface};
 use ironrdp_graphics::zgfx::Decompressor;
@@ -512,4 +512,151 @@ fn test_send_uncompressed_frame_backpressure() {
     // Second frame blocked by backpressure
     let frame2 = server.send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 16);
     assert!(frame2.is_none());
+}
+
+#[test]
+fn test_frames_sent_while_acknowledgement_is_suspended_do_not_hold_backpressure() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    server.set_max_frames_in_flight(1);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    let frame1 = server
+        .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 0)
+        .expect("first frame");
+
+    // [MS-RDPEGFX] 2.2.2.13: a queue depth of SUSPEND_FRAME_ACKNOWLEDGEMENT
+    // means the client stops sending Frame Acknowledge until it says otherwise.
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id: frame1,
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    // The pause outlasts the in-flight window by a wide margin, and none of
+    // these frames will be acknowledged.
+    let mut last_frame = frame1;
+    for index in 1..=5 {
+        last_frame = server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, index * 16)
+            .expect("a suspended client must not throttle the encoder");
+    }
+    server.drain_output();
+
+    // The client comes back and acknowledges normally.
+    let resume = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::AvailableBytes(8),
+        frame_id: last_frame,
+        total_frames_decoded: 6,
+    });
+    let _output = server.process(0, &encode_pdu(&resume)).expect("resume ack");
+
+    assert!(
+        server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 96)
+            .is_some(),
+        "frames counted during the pause hold backpressure on for good: with no \
+         frame going out there is no End Frame left for the client to acknowledge"
+    );
+}
+
+#[test]
+fn test_suspension_does_not_shrink_the_window_for_the_rest_of_the_connection() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    server.set_max_frames_in_flight(3);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    // Fill the window, then suspend. The frames already in flight will not be
+    // acknowledged either -- the suspension covers them as much as the ones
+    // that follow.
+    let mut first = None;
+    for index in 0..3 {
+        let id = server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, index * 16)
+            .expect("window not yet full");
+        first.get_or_insert(id);
+    }
+
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id: first.expect("a frame went out"),
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    let resume = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::AvailableBytes(8),
+        frame_id: u32::MAX,
+        total_frames_decoded: 2,
+    });
+    let _output = server.process(0, &encode_pdu(&resume)).expect("resume ack");
+    server.drain_output();
+
+    // The whole window has to be available again. Frames stranded by the
+    // suspension are never acknowledged, so leaving them tracked shrinks the
+    // window permanently -- here to one frame instead of three.
+    for index in 0..3 {
+        assert!(
+            server
+                .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 100 + index * 16)
+                .is_some(),
+            "frame {index} after resume was held back by a frame stranded in the pause"
+        );
+    }
+}
+
+#[test]
+fn test_a_suspending_acknowledgement_still_acknowledges_its_frame() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    let frame_id = server
+        .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 0)
+        .expect("first frame");
+
+    // The PDU that suspends also acknowledges a frame, and that frame carries
+    // the round-trip sample the QoE report is built from. Dropping it because
+    // the same PDU happens to suspend loses the measurement.
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id,
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    assert!(
+        server.qoe_snapshot().is_some(),
+        "the suspending acknowledgement was not counted, so no round-trip sample exists"
+    );
 }


### PR DESCRIPTION
A client that sets queueDepth to SUSPEND_FRAME_ACKNOWLEDGEMENT stops
sending Frame Acknowledge until it opts back in ([MS-RDPEGFX] 2.2.2.13),
so nothing is coming to take a frame sent during that pause back out of
`unacknowledged`. `begin_frame` inserted every one of them regardless.

On resume the map therefore stood above `max_in_flight` with no way
down: `should_backpressure` holds every frame back, and with no frame
going out there is no End Frame left for the client to acknowledge. The
resuming PDU removes exactly one entry, which is not enough to break
out, and 3.3.5.13 has the client report only its most recently processed
frame -- there is no backlog of acknowledgements to catch up on. The
session stays frozen until it is torn down.

Backpressure is switched off while the client is suspended, so the entry
has no work to do there in the first place -- the fix is to stop making
it.

Frames already in flight when the suspension arrives are dropped because
3.2.5.13 requires it: "the server MUST clear the Unacknowledged Frames
ADM element and MUST NOT expect any further RDPGFX_FRAME_ACKNOWLEDGE_PDU
messages from the client. In this mode, the server MUST NOT wait or
block on unacknowledged frames". That happens after the acknowledgement
this PDU carries has been taken out, not before -- a suspending Frame
Acknowledge is still an acknowledgement, and the frame it names carries
the round-trip sample and byte count the QoE report is built from.

What the accounting does lose while suspended: `in_flight` reads zero,
and frames sent during the pause never reach `total_acked`,
`total_bytes_sent` or the round-trip series, since their
acknowledgements never arrive. Any consumer of those counters sees the
divergence, and it does not close on resume.

Three tests: frames keep flowing after a resume, the whole window is
available again afterwards, and a suspending acknowledgement still
counts. The suspend path had no coverage at all before.

