### PR TITLE
refactor(server): deliver USB completions through shared per-device state

### DIFF
--- a/crates/ironrdp-rdpeusb/src/server.rs
+++ b/crates/ironrdp-rdpeusb/src/server.rs
@@ -455,6 +455,14 @@ impl UrbdrcDeviceServer {
         })
     }
 
+    /// Cancel Request Message ([MS-RDPEUSB] section 2.2.6.1):
+    ///
+    /// Asks the client to stop processing `request_id`. This does not release
+    /// the request: a transmitted request is always answered by a completion,
+    /// and a cancelled one completes with a failure `HRESULT` ([MS-RDPEUSB]
+    /// sections 3.3.5.3.1 and 3.3.5.3.6). That completion is what releases the
+    /// tracking state, so releasing it here would make the completion look
+    /// unsolicited.
     pub fn cancel_request(&mut self, request_id: RequestId) -> PduResult<DvcMessage> {
         let udev_iface = self.usb_device_iface()?;
         Ok(Box::new(CancelRequest {
@@ -462,6 +470,26 @@ impl UrbdrcDeviceServer {
             udev_iface,
             req_id: request_id,
         }))
+    }
+
+    /// Releases a request that was built but never handed to the DVC transport.
+    ///
+    /// Every transmitted request is eventually answered by a completion, and
+    /// handling that completion is what releases the request's tracking state.
+    /// A request that never reached the transport is never answered, so without
+    /// this its state would be held until the channel closes.
+    ///
+    /// `request` MUST NOT have been transmitted. Passing it by value keeps the
+    /// normal path honest, since writing a request moves
+    /// [`ServerIoRequest::message`] out of it. That is a convention rather than
+    /// enforcement: encoding the message through a shared borrow leaves the
+    /// request intact, and abandoning it afterwards makes the completion that
+    /// does arrive look unsolicited.
+    ///
+    /// Use [`Self::cancel_request`] instead to stop a request already in flight.
+    pub fn abandon_unsent(&mut self, request: ServerIoRequest) {
+        // Vacant for a no-ack request, which is tracked nowhere to begin with.
+        self.pending_io.remove(&request.request_id);
     }
 
     pub fn retract_device(&mut self, reason: UsbRetractReason) -> PduResult<DvcMessage> {

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -55,7 +55,7 @@ pub use server::{
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 #[cfg(feature = "usb")]
 pub use urbdrc::{
-    CompletionFut, DeviceFactory, PendingHandle, PendingRequest, RawPending, RdpUsbDeviceAnnounceInfo, UsbDeviceHandle,
+    CompletionFut, DeviceFactory, PendingHandle, PendingIo, PendingRequest, RdpUsbDeviceAnnounceInfo, UsbDeviceHandle,
     UsbRedirDevice, UsbRequestCompletion,
 };
 #[cfg(feature = "__bench")]

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -55,7 +55,7 @@ pub use server::{
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 #[cfg(feature = "usb")]
 pub use urbdrc::{
-    CompletionFut, DeviceFactory, PendingHandle, PendingIo, PendingRequest, RdpUsbDeviceAnnounceInfo, UsbDeviceHandle,
+    CompletionFut, DeviceFactory, PendingHandle, PendingRequest, RdpUsbDeviceAnnounceInfo, UsbDeviceHandle,
     UsbRedirDevice, UsbRequestCompletion,
 };
 #[cfg(feature = "__bench")]

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -35,8 +35,6 @@ use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, Se
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{Action, PduResult, decode_err, mcs, nego, rdp};
 use ironrdp_rdpdr as rdpdr;
-#[cfg(feature = "usb")]
-use ironrdp_rdpeusb::io::RequestId;
 use ironrdp_rdpsnd as rdpsnd;
 use ironrdp_svc::{ChannelFlags, StaticChannelId, StaticChannelSet, SvcProcessor, server_encode_svc_messages};
 use ironrdp_tokio::{FramedRead, FramedWrite, TokioFramed, split_tokio_framed, unsplit_tokio_framed};
@@ -1950,10 +1948,6 @@ impl RdpServer {
                                     .map_err_kind("query USB device text", ServerErrorKind::Pdu)?;
                                 (vec![text], false)
                             }
-                            UrbdrcDeviceServerMessage::IoComp { request_id, completion } => {
-                                device.complete_pending(request_id, completion);
-                                continue;
-                            }
                             UrbdrcDeviceServerMessage::IoReq { data, tx } => {
                                 if tx.is_closed() {
                                     continue;
@@ -1976,11 +1970,14 @@ impl RdpServer {
                                 // Reply before the write so the caller owns cancel-on-drop as early
                                 // as possible. A CANCEL_REQUEST it enqueues in response lands in a
                                 // later batch, so it cannot overtake this request on the wire.
-                                if tx.send(pending).is_err() {
+                                if tx.send(pending).is_err() && request.expects_completion {
                                     trace!(dvc_id, "USB I/O request receiver dropped");
+                                    device.forget_pending(request.request_id);
+                                    processor.abandon_unsent(request);
+                                    (Vec::new(), false)
+                                } else {
+                                    (vec![request.message], false)
                                 }
-
-                                (vec![request.message], false)
                             }
                             UrbdrcDeviceServerMessage::Retract(reason) => {
                                 let request = processor
@@ -1990,16 +1987,14 @@ impl RdpServer {
                                 (vec![request], true)
                             }
                             UrbdrcDeviceServerMessage::CancelRequest(request_id) => {
-                                let request = processor
-                                    .cancel_request(request_id)
-                                    .map_err_kind("cancel USB I/O request", ServerErrorKind::Pdu)?;
-
-                                // A completion may have won the race with PendingRequest::drop.
-                                // Only emit CANCEL_REQUEST while the request is still pending.
                                 if !device.is_pending(request_id) {
                                     trace!(dvc_id, request_id, "USB I/O request is no longer pending");
                                     continue;
                                 }
+
+                                let request = processor
+                                    .cancel_request(request_id)
+                                    .map_err_kind("cancel USB I/O request", ServerErrorKind::Pdu)?;
 
                                 (vec![request], false)
                             }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -62,12 +62,12 @@ use crate::handler::RdpServerInputHandler;
 use crate::rdpei::RdpeiServerFactory;
 #[cfg(feature = "usb")]
 use crate::urbdrc::{
-    DeviceFactory, RawPending, ServerDeviceIoReq, UrbdrcDeviceServerMessage, UrbdrcServerMessage, UsbControlHandle,
-    UsbDeviceHandle, UsbDeviceLifecycle,
+    DeviceFactory, ServerDeviceIoReq, ServerUsbDevice, UrbdrcDeviceServerMessage, UrbdrcServerMessage,
+    UsbControlHandle, UsbDeviceHandle,
 };
 use crate::{RdpdrServerFactory, SoundServerFactory, builder, capabilities};
 #[cfg(feature = "usb")]
-use ironrdp_rdpeusb::{InterfaceAlloc, io::CompletionData, server::UrbdrcControlServer, server::UrbdrcDeviceServer};
+use ironrdp_rdpeusb::{InterfaceAlloc, server::UrbdrcControlServer, server::UrbdrcDeviceServer};
 
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
@@ -483,16 +483,7 @@ impl DisplayControlHandler for DisplayControlBackend {
 struct ServerUsbManager {
     factory: Box<dyn DeviceFactory>,
     comp_iface_alloc: InterfaceAlloc,
-    router: HashMap<DynamicChannelId, ServerUsbDevice>,
-}
-
-#[cfg(feature = "usb")]
-struct ServerUsbDevice {
-    lifecycle: Arc<UsbDeviceLifecycle>,
-    /// Handle attached to a submitted request, so dropping the request cancels
-    /// it. Kept per device rather than per message to keep [`ServerEvent`] small.
-    handle: UsbDeviceHandle,
-    pending: HashMap<RequestId, oneshot::Sender<CompletionData>>,
+    router: HashMap<DynamicChannelId, Arc<ServerUsbDevice>>,
 }
 
 #[cfg(feature = "usb")]
@@ -1049,18 +1040,20 @@ impl RdpServer {
             return;
         };
 
-        if let Some(device) = usb_man.router.remove(&dvc_id) {
-            // Set the terminal state before dropping completion senders. A woken
-            // PendingRequest must not enqueue CANCEL_REQUEST for a removed DVC.
-            device.lifecycle.mark_closed();
-            debug!(
-                dvc_id,
-                pending_requests = device.pending.len(),
-                "Removed closed USB device from request router"
-            );
-        } else {
+        let Some(device) = usb_man.router.remove(&dvc_id) else {
             trace!(dvc_id, "Closed USB device is absent from request router");
-        }
+            return;
+        };
+
+        // Set the terminal state before failing waiters: a woken PendingRequest
+        // must not enqueue CANCEL_REQUEST for a removed DVC. The pending map is
+        // shared, so dropping the router entry no longer drops it.
+        device.mark_closed();
+        let pending_requests = device.drain_pending();
+        debug!(
+            dvc_id,
+            pending_requests, "Removed closed USB device from request router"
+        );
     }
 
     /// Returns the shared "display suppressed" flag — `true` while the
@@ -1893,15 +1886,8 @@ impl RdpServer {
 
                             drdynvc
                                 .create_channel_with(|dvc_id| {
-                                    let lifecycle = Arc::new(UsbDeviceLifecycle::new());
-                                    let handle =
-                                        UsbDeviceHandle::new(self.ev_sender.clone(), dvc_id, Arc::clone(&lifecycle));
-                                    let device = ServerUsbDevice {
-                                        lifecycle,
-                                        handle: handle.clone(),
-                                        pending: HashMap::new(),
-                                    };
-                                    if usb_man.router.insert(dvc_id, device).is_some() {
+                                    let handle = UsbDeviceHandle::new(self.ev_sender.clone(), dvc_id);
+                                    if usb_man.router.insert(dvc_id, handle.device()).is_some() {
                                         warn!(dvc_id = dvc_id, "Replacing USB device pending-request map");
                                     }
                                     Ok::<_, PduError>(
@@ -1928,11 +1914,11 @@ impl RdpServer {
                             .map_err(|e| ServerError::io("write_all", e))?;
                     }
                     UrbdrcServerMessage::Device { dvc_id, dev_msg } => {
-                        let Some(lifecycle) = self
+                        let Some(device) = self
                             .usb_man
                             .as_ref()
                             .and_then(|usb_man| usb_man.router.get(&dvc_id))
-                            .map(|device| Arc::clone(&device.lifecycle))
+                            .map(Arc::clone)
                         else {
                             warn!(dvc_id, "Missing USB device state");
                             continue;
@@ -1941,123 +1927,81 @@ impl RdpServer {
                         // Handle checks are an early rejection for callers. This event-loop check
                         // is authoritative because a request may already be queued when retract or
                         // channel close changes the shared lifecycle state.
-                        if !lifecycle.is_open() {
+                        if !device.is_open() {
                             trace!(dvc_id, "Dropping request for closing or closed USB device");
                             continue;
                         }
 
-                        let (dvc_msgs, io_reply, close_dev) = {
-                            let Some(drdynvc) = self.get_svc_processor::<dvc::DrdynvcServer>() else {
-                                warn!("No drdynvc channel, dropping URBDRC request");
+                        let Some(drdynvc) = self.get_svc_processor::<dvc::DrdynvcServer>() else {
+                            warn!("No drdynvc channel, dropping URBDRC request");
+                            continue;
+                        };
+
+                        let Some(mut dvc) = drdynvc.dvc_by_id_mut::<UrbdrcDeviceServer>(dvc_id) else {
+                            warn!(dvc_id, "USB dynamic channel ID mismatch");
+                            continue;
+                        };
+                        let processor = dvc.processor_mut();
+
+                        let (dvc_msgs, close_dev) = match dev_msg {
+                            UrbdrcDeviceServerMessage::QueryDeviceText { text_type, locale_id } => {
+                                let text = processor
+                                    .query_device_text(text_type, locale_id)
+                                    .map_err_kind("query USB device text", ServerErrorKind::Pdu)?;
+                                (vec![text], false)
+                            }
+                            UrbdrcDeviceServerMessage::IoComp { request_id, completion } => {
+                                device.complete_pending(request_id, completion);
                                 continue;
-                            };
-
-                            let Some(mut dvc) = drdynvc.dvc_by_id_mut::<UrbdrcDeviceServer>(dvc_id) else {
-                                warn!(dvc_id, "USB dynamic channel ID mismatch");
-                                continue;
-                            };
-                            let processor = dvc.processor_mut();
-
-                            match dev_msg {
-                                UrbdrcDeviceServerMessage::QueryDeviceText { text_type, locale_id } => {
-                                    let text = processor
-                                        .query_device_text(text_type, locale_id)
-                                        .map_err_kind("query USB device text", ServerErrorKind::Pdu)?;
-                                    (vec![text], None, false)
+                            }
+                            UrbdrcDeviceServerMessage::IoReq { data, tx } => {
+                                if tx.is_closed() {
+                                    continue;
                                 }
-                                UrbdrcDeviceServerMessage::IoComp { request_id, completion } => {
-                                    let Some(usb_man) = self.usb_man.as_mut() else {
-                                        warn!("Missing USB device factory");
-                                        continue;
-                                    };
-                                    let Some(device) = usb_man.router.get_mut(&dvc_id) else {
-                                        warn!(dvc_id, "Missing USB device state");
-                                        continue;
-                                    };
-                                    let Some(sender) = device.pending.remove(&request_id) else {
-                                        warn!(dvc_id, request_id, "Missing pending USB I/O request");
-                                        continue;
-                                    };
 
-                                    if sender.send(completion).is_err() {
-                                        trace!(dvc_id, request_id, "USB I/O completion receiver dropped");
+                                let request = match data {
+                                    ServerDeviceIoReq::IoControl(packet) => processor.io_control(packet),
+                                    ServerDeviceIoReq::InternalIoControl(packet) => {
+                                        processor.internal_io_control(packet)
                                     }
-                                    (Vec::new(), None, false)
+                                    ServerDeviceIoReq::TransferOut(packet) => processor.transfer_out(packet),
+                                    ServerDeviceIoReq::TransferIn(packet) => processor.transfer_in(packet),
                                 }
-                                UrbdrcDeviceServerMessage::IoReq { data, tx } => {
-                                    if tx.is_closed() {
-                                        continue;
-                                    }
+                                .map_err_kind("USB I/O request", ServerErrorKind::Pdu)?;
 
-                                    let request = match data {
-                                        ServerDeviceIoReq::IoControl(packet) => processor.io_control(packet),
-                                        ServerDeviceIoReq::InternalIoControl(packet) => {
-                                            processor.internal_io_control(packet)
-                                        }
-                                        ServerDeviceIoReq::TransferOut(packet) => processor.transfer_out(packet),
-                                        ServerDeviceIoReq::TransferIn(packet) => processor.transfer_in(packet),
-                                    }
-                                    .map_err_kind("USB I/O request", ServerErrorKind::Pdu)?;
+                                let pending = request
+                                    .expects_completion
+                                    .then(|| device.register_pending(request.request_id));
 
-                                    let pending = if request.expects_completion {
-                                        let Some(usb_man) = self.usb_man.as_mut() else {
-                                            warn!("Missing USB device factory");
-                                            continue;
-                                        };
-                                        let Some(device) = usb_man.router.get_mut(&dvc_id) else {
-                                            error!(dvc_id, "Missing USB device state");
-                                            continue;
-                                        };
-
-                                        let (comp_tx, comp_rx) = oneshot::channel();
-                                        if device.pending.insert(request.request_id, comp_tx).is_some() {
-                                            warn!(
-                                                dvc_id,
-                                                request_id = request.request_id,
-                                                "Replacing pending USB I/O request"
-                                            );
-                                        }
-
-                                        Some(RawPending {
-                                            rx: comp_rx,
-                                            id: request.request_id,
-                                            handle: device.handle.clone(),
-                                        })
-                                    } else {
-                                        None
-                                    };
-
-                                    (vec![request.message], Some((tx, pending)), false)
+                                // Reply before the write so the caller owns cancel-on-drop as early
+                                // as possible. A CANCEL_REQUEST it enqueues in response lands in a
+                                // later batch, so it cannot overtake this request on the wire.
+                                if tx.send(pending).is_err() {
+                                    trace!(dvc_id, "USB I/O request receiver dropped");
                                 }
-                                UrbdrcDeviceServerMessage::Retract(reason) => {
-                                    let request = processor
-                                        .retract_device(reason)
-                                        .map_err_kind("retract USB device", ServerErrorKind::Pdu)?;
-                                    lifecycle.mark_retracting();
-                                    (vec![request], None, true)
-                                }
-                                UrbdrcDeviceServerMessage::CancelRequest(request_id) => {
-                                    let request = processor
-                                        .cancel_request(request_id)
-                                        .map_err_kind("cancel USB I/O request", ServerErrorKind::Pdu)?;
-                                    let Some(usb_man) = self.usb_man.as_mut() else {
-                                        warn!("Missing USB device factory");
-                                        continue;
-                                    };
-                                    let Some(device) = usb_man.router.get_mut(&dvc_id) else {
-                                        warn!(dvc_id, "Missing USB device state");
-                                        continue;
-                                    };
 
-                                    // A completion may have won the race with PendingRequest::drop.
-                                    // Only emit CANCEL_REQUEST while the request is still pending.
-                                    if !device.pending.contains_key(&request_id) {
-                                        trace!(dvc_id, request_id, "USB I/O request is no longer pending");
-                                        continue;
-                                    }
+                                (vec![request.message], false)
+                            }
+                            UrbdrcDeviceServerMessage::Retract(reason) => {
+                                let request = processor
+                                    .retract_device(reason)
+                                    .map_err_kind("retract USB device", ServerErrorKind::Pdu)?;
+                                device.mark_retracting();
+                                (vec![request], true)
+                            }
+                            UrbdrcDeviceServerMessage::CancelRequest(request_id) => {
+                                let request = processor
+                                    .cancel_request(request_id)
+                                    .map_err_kind("cancel USB I/O request", ServerErrorKind::Pdu)?;
 
-                                    (vec![request], None, false)
+                                // A completion may have won the race with PendingRequest::drop.
+                                // Only emit CANCEL_REQUEST while the request is still pending.
+                                if !device.is_pending(request_id) {
+                                    trace!(dvc_id, request_id, "USB I/O request is no longer pending");
+                                    continue;
                                 }
+
+                                (vec![request], false)
                             }
                         };
 
@@ -2085,13 +2029,6 @@ impl RdpServer {
                             .write_all(&data)
                             .await
                             .map_err(|e| ServerError::io("write_all", e))?;
-
-                        if let Some((tx, pending)) = io_reply {
-                            if let Err(pending) = tx.send(pending) {
-                                trace!(dvc_id, "USB I/O request receiver dropped");
-                                drop(pending);
-                            }
-                        }
                     }
                     UrbdrcServerMessage::DeviceClosed { dvc_id } => {
                         self.remove_usb_device(dvc_id);

--- a/crates/ironrdp-server/src/urbdrc.rs
+++ b/crates/ironrdp-server/src/urbdrc.rs
@@ -1414,7 +1414,7 @@ struct RawPending {
 
 /// Identity and completion channel of one in-flight I/O request.
 #[derive(Debug)]
-pub struct PendingIo {
+pub(crate) struct PendingIo {
     pub(super) rx: oneshot::Receiver<CompletionData>,
     pub(super) id: RequestId,
 }

--- a/crates/ironrdp-server/src/urbdrc.rs
+++ b/crates/ironrdp-server/src/urbdrc.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::ServerEvent;
 use crate::error::{ServerError, ServerErrorExt as _, ServerResult};
 use ironrdp_dvc::DynamicChannelId;
-use ironrdp_pdu::{PduResult, pdu_other_err};
+use ironrdp_pdu::PduResult;
 use ironrdp_rdpeusb::{
     io::{
         CompletionData, DeviceAnnounce, DeviceText, InternalIoControlPacket, IoControlCompletionResult,
@@ -61,10 +61,6 @@ pub enum UrbdrcDeviceServerMessage {
         /// completion.
         tx: oneshot::Sender<Option<PendingIo>>,
     },
-    IoComp {
-        request_id: RequestId,
-        completion: CompletionData,
-    },
     CancelRequest(RequestId),
     Retract(UsbRetractReason),
 }
@@ -106,7 +102,6 @@ impl UrbdrcControlServerBackend for UsbControlHandle {
 #[derive(Debug, Clone)]
 pub struct UsbDeviceHandle {
     sender: UnboundedSender<ServerEvent>,
-    channel_id: DynamicChannelId,
     device: Arc<ServerUsbDevice>,
 }
 
@@ -114,8 +109,7 @@ impl UsbDeviceHandle {
     pub(crate) fn new(sender: UnboundedSender<ServerEvent>, channel_id: DynamicChannelId) -> Self {
         Self {
             sender,
-            channel_id,
-            device: Arc::new(ServerUsbDevice::new()),
+            device: Arc::new(ServerUsbDevice::new(channel_id)),
         }
     }
 
@@ -127,7 +121,7 @@ impl UsbDeviceHandle {
     fn send_device_message(&self, dev_msg: UrbdrcDeviceServerMessage) -> ServerResult<()> {
         self.sender
             .send(ServerEvent::Usb(UrbdrcServerMessage::Device {
-                dvc_id: self.channel_id,
+                dvc_id: self.device.channel_id,
                 dev_msg,
             }))
             .map_err(|_error| ServerError::reason("usb device message", "usb device channel is closing or closed"))
@@ -519,6 +513,7 @@ impl UsbDeviceHandle {
 /// commits binding state under `usb_state`.
 #[derive(Debug)]
 pub(crate) struct ServerUsbDevice {
+    channel_id: DynamicChannelId,
     /// Kept outside a lock: submission paths check it constantly and
     /// [`RawPending::drop`] reads it, so it must never require one.
     lifecycle: UsbDeviceLifecycle,
@@ -527,8 +522,9 @@ pub(crate) struct ServerUsbDevice {
 }
 
 impl ServerUsbDevice {
-    fn new() -> Self {
+    fn new(channel_id: DynamicChannelId) -> Self {
         Self {
+            channel_id,
             lifecycle: UsbDeviceLifecycle::new(),
             pending: Mutex::new(HashMap::new()),
             usb_state: Mutex::new(UsbSharedState::default()),
@@ -556,14 +552,33 @@ impl ServerUsbDevice {
             .insert(request_id, tx)
             .is_some()
         {
-            tracing::warn!(request_id, "Replacing pending USB I/O request");
+            tracing::warn!(
+                dvc_id = self.channel_id,
+                request_id,
+                "Replacing pending USB I/O request"
+            );
         }
 
         PendingIo { rx, id: request_id }
     }
 
     /// Delivers a completion to the caller waiting on `request_id`.
+    ///
+    /// Completions are refused once the device is retracting or closed, matching
+    /// the check the event loop applies to every other device message. The
+    /// RDPEUSB processor already stops reporting completions after
+    /// RETRACT_DEVICE, so this only keeps the guarantee local rather than
+    /// resting on that behavior.
     pub(crate) fn complete_pending(&self, request_id: RequestId, completion: CompletionData) {
+        if !self.is_open() {
+            tracing::trace!(
+                dvc_id = self.channel_id,
+                request_id,
+                "Dropping completion for closing or closed USB device"
+            );
+            return;
+        }
+
         // Bind the removal so the guard is released before the caller is woken:
         // it commits binding state under `usb_state`, and the two locks are
         // never held together.
@@ -574,13 +589,28 @@ impl ServerUsbDevice {
             .remove(&request_id);
 
         let Some(sender) = sender else {
-            tracing::warn!(request_id, "Missing pending USB I/O request");
+            tracing::warn!(dvc_id = self.channel_id, request_id, "Missing pending USB I/O request");
             return;
         };
 
         if sender.send(completion).is_err() {
-            tracing::trace!(request_id, "USB I/O completion receiver dropped");
+            tracing::trace!(
+                dvc_id = self.channel_id,
+                request_id,
+                "USB I/O completion receiver dropped"
+            );
         }
+    }
+
+    /// Drops the tracking for a request that was never written to the channel.
+    ///
+    /// Pairs with `UrbdrcDeviceServer::abandon_unsent`: no completion will
+    /// arrive for such a request, so nothing else would ever remove it.
+    pub(crate) fn forget_pending(&self, request_id: RequestId) {
+        self.pending
+            .lock()
+            .expect("USB pending requests mutex poisoned")
+            .remove(&request_id);
     }
 
     pub(crate) fn is_pending(&self, request_id: RequestId) -> bool {
@@ -1500,10 +1530,9 @@ impl UsbRedirServer {
         Self { handle, device }
     }
 
-    fn send_io_completion(&self, request_id: RequestId, completion: CompletionData) -> PduResult<()> {
-        self.handle
-            .send_device_message(UrbdrcDeviceServerMessage::IoComp { request_id, completion })
-            .map_err(|_| pdu_other_err!("failed to send usb I/O completion"))
+    fn io_completed(&self, request_id: RequestId, completion: CompletionData) -> PduResult<()> {
+        self.handle.device.complete_pending(request_id, completion);
+        Ok(())
     }
 }
 
@@ -1528,7 +1557,7 @@ impl UrbdrcDeviceServerBackend for UsbRedirServer {
         request_id: RequestId,
         completion: IoControlCompletionResult,
     ) -> PduResult<()> {
-        self.send_io_completion(request_id, CompletionData::IoControl(completion))
+        self.io_completed(request_id, CompletionData::IoControl(completion))
     }
 
     fn internal_io_control_completed(
@@ -1537,7 +1566,7 @@ impl UrbdrcDeviceServerBackend for UsbRedirServer {
         request_id: RequestId,
         completion: IoControlCompletionResult,
     ) -> PduResult<()> {
-        self.send_io_completion(request_id, CompletionData::InternalIoControl(completion))
+        self.io_completed(request_id, CompletionData::InternalIoControl(completion))
     }
 
     fn transfer_in_completed(
@@ -1546,7 +1575,7 @@ impl UrbdrcDeviceServerBackend for UsbRedirServer {
         request_id: RequestId,
         completion: TransferInCompletionResult,
     ) -> PduResult<()> {
-        self.send_io_completion(request_id, CompletionData::TransferIn(completion))
+        self.io_completed(request_id, CompletionData::TransferIn(completion))
     }
 
     fn transfer_out_completed(
@@ -1555,7 +1584,7 @@ impl UrbdrcDeviceServerBackend for UsbRedirServer {
         request_id: RequestId,
         completion: TransferOutCompletionResult,
     ) -> PduResult<()> {
-        self.send_io_completion(request_id, CompletionData::TransferOut(completion))
+        self.io_completed(request_id, CompletionData::TransferOut(completion))
     }
 
     fn close(&mut self, channel_id: u32) {

--- a/crates/ironrdp-server/src/urbdrc.rs
+++ b/crates/ironrdp-server/src/urbdrc.rs
@@ -2,8 +2,8 @@ use core::pin::Pin;
 use core::sync::atomic::{AtomicU8, Ordering};
 use core::task::{Context, Poll};
 use std::{
-    collections::BTreeMap,
-    sync::{Arc, Mutex, MutexGuard},
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
 };
 
 use crate::ServerEvent;
@@ -56,9 +56,10 @@ pub enum UrbdrcDeviceServerMessage {
     },
     IoReq {
         data: ServerDeviceIoReq,
-        /// Sender used to return the pending request after the request is
-        /// written. `None` when the request expects no completion.
-        tx: oneshot::Sender<Option<RawPending>>,
+        /// Sender used to return the pending request once it is registered,
+        /// before the request is written. `None` when the request expects no
+        /// completion.
+        tx: oneshot::Sender<Option<PendingIo>>,
     },
     IoComp {
         request_id: RequestId,
@@ -106,22 +107,21 @@ impl UrbdrcControlServerBackend for UsbControlHandle {
 pub struct UsbDeviceHandle {
     sender: UnboundedSender<ServerEvent>,
     channel_id: DynamicChannelId,
-    lifecycle: Arc<UsbDeviceLifecycle>,
-    usb_state: Arc<Mutex<UsbSharedState>>,
+    device: Arc<ServerUsbDevice>,
 }
 
 impl UsbDeviceHandle {
-    pub(crate) fn new(
-        sender: UnboundedSender<ServerEvent>,
-        channel_id: DynamicChannelId,
-        lifecycle: Arc<UsbDeviceLifecycle>,
-    ) -> Self {
+    pub(crate) fn new(sender: UnboundedSender<ServerEvent>, channel_id: DynamicChannelId) -> Self {
         Self {
             sender,
             channel_id,
-            lifecycle,
-            usb_state: Arc::new(Mutex::new(UsbSharedState::default())),
+            device: Arc::new(ServerUsbDevice::new()),
         }
+    }
+
+    /// Per-device state, shared with the server event loop's request router.
+    pub(crate) fn device(&self) -> Arc<ServerUsbDevice> {
+        Arc::clone(&self.device)
     }
 
     fn send_device_message(&self, dev_msg: UrbdrcDeviceServerMessage) -> ServerResult<()> {
@@ -133,7 +133,7 @@ impl UsbDeviceHandle {
             .map_err(|_error| ServerError::reason("usb device message", "usb device channel is closing or closed"))
     }
 
-    fn enqueue_io_message(&self, data: ServerDeviceIoReq) -> ServerResult<oneshot::Receiver<Option<RawPending>>> {
+    fn enqueue_io_message(&self, data: ServerDeviceIoReq) -> ServerResult<oneshot::Receiver<Option<PendingIo>>> {
         self.ensure_open()?;
 
         let (tx, rx) = oneshot::channel();
@@ -142,24 +142,41 @@ impl UsbDeviceHandle {
         Ok(rx)
     }
 
-    async fn send_io_message(&self, data: ServerDeviceIoReq) -> ServerResult<RawPending> {
-        let rx = self.enqueue_io_message(data)?;
-        resolve_pending(rx).await
+    /// Resolves the server's submission reply into pending-request metadata.
+    async fn resolve_pending(&self, rx: oneshot::Receiver<Option<PendingIo>>) -> ServerResult<RawPending> {
+        match rx.await {
+            Ok(Some(pending)) => Ok(RawPending::new(self.clone(), pending)),
+            // The public facade only submits acknowledged requests, so a
+            // completion-less (NoAck) reply is an internal contract violation.
+            Ok(None) => Err(ServerError::reason(
+                "usb pending request",
+                "usb request unexpectedly has no pending completion",
+            )),
+            Err(_) => Err(ServerError::reason(
+                "usb pending request",
+                "usb device channel is closing or closed",
+            )),
+        }
     }
 
-    /// Sends a transfer-in request and returns its request metadata once written.
+    async fn send_io_message(&self, data: ServerDeviceIoReq) -> ServerResult<RawPending> {
+        let rx = self.enqueue_io_message(data)?;
+        self.resolve_pending(rx).await
+    }
+
+    /// Sends a transfer-in request and returns its request metadata once registered.
     async fn transfer_in_request(&self, packet: TransferInPacket) -> ServerResult<RawPending> {
         self.send_io_message(ServerDeviceIoReq::TransferIn(packet)).await
     }
 
-    /// Sends a transfer-out request and returns its request metadata once written.
+    /// Sends a transfer-out request and returns its request metadata once registered.
     async fn transfer_out_request(&self, packet: TransferOutPacket) -> ServerResult<RawPending> {
         self.send_io_message(ServerDeviceIoReq::TransferOut(packet)).await
     }
 
     /// Sends a cancel request for a pending I/O request.
     pub(crate) fn cancel_request(&self, request_id: RequestId) -> ServerResult<()> {
-        if !self.lifecycle.is_open() {
+        if !self.device.is_open() {
             return Ok(());
         }
 
@@ -179,7 +196,7 @@ impl UsbDeviceHandle {
     }
 
     fn ensure_open(&self) -> ServerResult<()> {
-        if self.lifecycle.is_open() {
+        if self.device.is_open() {
             Ok(())
         } else {
             Err(ServerError::reason(
@@ -242,7 +259,7 @@ impl UsbDeviceHandle {
             };
             self.enqueue_io_message(data)?
         };
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
 
         Ok(PendingRequest::new(
             inner,
@@ -323,7 +340,7 @@ impl UsbDeviceHandle {
         };
 
         let mut submission = TransitionGuard::poison_on_drop(self, transition);
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
             inner,
@@ -383,7 +400,7 @@ impl UsbDeviceHandle {
         };
 
         let mut submission = TransitionGuard::poison_on_drop(self, transition);
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
             inner,
@@ -404,7 +421,7 @@ impl UsbDeviceHandle {
             let packet = ironrdp_rdpeusb::usb::reset_pipe_and_clear_stall(pipe.handle);
             self.enqueue_io_message(ServerDeviceIoReq::TransferIn(packet))?
         };
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
         Ok(PendingRequest::new(inner, PendingOperation::ClearHalt))
     }
 
@@ -429,7 +446,7 @@ impl UsbDeviceHandle {
         };
 
         let mut submission = TransitionGuard::poison_on_drop(self, transition);
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
             inner,
@@ -476,7 +493,7 @@ impl UsbDeviceHandle {
             };
             self.enqueue_io_message(data)?
         };
-        let inner = resolve_pending(rx).await?;
+        let inner = self.resolve_pending(rx).await?;
         Ok(PendingRequest::new(inner, PendingOperation::Transfer))
     }
 
@@ -493,10 +510,96 @@ impl UsbDeviceHandle {
     }
 
     fn lock_usb_state(&self) -> MutexGuard<'_, UsbSharedState> {
-        match self.usb_state.lock() {
-            Ok(state) => state,
-            Err(poisoned) => poisoned.into_inner(),
+        self.device.usb_state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// INVARIANT: `pending` and `usb_state` are never locked at the same time.
+/// Completion delivery releases the `pending` guard before the woken caller
+/// commits binding state under `usb_state`.
+#[derive(Debug)]
+pub(crate) struct ServerUsbDevice {
+    /// Kept outside a lock: submission paths check it constantly and
+    /// [`RawPending::drop`] reads it, so it must never require one.
+    lifecycle: UsbDeviceLifecycle,
+    pending: Mutex<HashMap<RequestId, oneshot::Sender<CompletionData>>>,
+    usb_state: Mutex<UsbSharedState>,
+}
+
+impl ServerUsbDevice {
+    fn new() -> Self {
+        Self {
+            lifecycle: UsbDeviceLifecycle::new(),
+            pending: Mutex::new(HashMap::new()),
+            usb_state: Mutex::new(UsbSharedState::default()),
         }
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        self.lifecycle.is_open()
+    }
+
+    pub(crate) fn mark_retracting(&self) {
+        self.lifecycle.mark_retracting();
+    }
+
+    pub(crate) fn mark_closed(&self) {
+        self.lifecycle.mark_closed();
+    }
+
+    pub(crate) fn register_pending(&self, request_id: RequestId) -> PendingIo {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .pending
+            .lock()
+            .expect("USB pending requests mutex poisoned")
+            .insert(request_id, tx)
+            .is_some()
+        {
+            tracing::warn!(request_id, "Replacing pending USB I/O request");
+        }
+
+        PendingIo { rx, id: request_id }
+    }
+
+    /// Delivers a completion to the caller waiting on `request_id`.
+    pub(crate) fn complete_pending(&self, request_id: RequestId, completion: CompletionData) {
+        // Bind the removal so the guard is released before the caller is woken:
+        // it commits binding state under `usb_state`, and the two locks are
+        // never held together.
+        let sender = self
+            .pending
+            .lock()
+            .expect("USB pending requests mutex poisoned")
+            .remove(&request_id);
+
+        let Some(sender) = sender else {
+            tracing::warn!(request_id, "Missing pending USB I/O request");
+            return;
+        };
+
+        if sender.send(completion).is_err() {
+            tracing::trace!(request_id, "USB I/O completion receiver dropped");
+        }
+    }
+
+    pub(crate) fn is_pending(&self, request_id: RequestId) -> bool {
+        self.pending
+            .lock()
+            .expect("USB pending requests mutex poisoned")
+            .contains_key(&request_id)
+    }
+
+    /// Fails every request still awaiting a completion, returning how many there
+    /// were. Dropping the senders wakes each caller with a channel error.
+    ///
+    /// The pending map outlives the router entry that used to own it, so every
+    /// teardown path MUST call this or its callers wait forever.
+    pub(crate) fn drain_pending(&self) -> usize {
+        let mut pending = self.pending.lock().unwrap_or_else(PoisonError::into_inner);
+        let count = pending.len();
+        pending.clear();
+        count
     }
 }
 
@@ -879,23 +982,6 @@ impl Drop for TransitionGuard<'_> {
     }
 }
 
-/// Resolves the server's submission reply into pending-request metadata.
-async fn resolve_pending(rx: oneshot::Receiver<Option<RawPending>>) -> ServerResult<RawPending> {
-    match rx.await {
-        Ok(Some(pending)) => Ok(pending),
-        // The public facade only submits acknowledged requests, so a
-        // completion-less (NoAck) reply is an internal contract violation.
-        Ok(None) => Err(ServerError::reason(
-            "usb pending request",
-            "usb request unexpectedly has no pending completion",
-        )),
-        Err(_) => Err(ServerError::reason(
-            "usb pending request",
-            "usb device channel is closing or closed",
-        )),
-    }
-}
-
 fn configuration_binding_from_result(
     plan: &ConfigurationSelectionPlan,
     result: TsUrbSelectConfigResult,
@@ -1108,7 +1194,7 @@ impl PendingRequest {
     pub fn pending_handle(&self) -> PendingHandle {
         PendingHandle {
             usb_handle: self.inner.handle.clone(),
-            req_id: self.inner.id,
+            req_id: self.inner.io.id,
         }
     }
 
@@ -1276,7 +1362,7 @@ impl Future for CompletionFut {
                 "usb pending request already completed",
             )));
         };
-        match Pin::new(&mut this.pending.inner.rx).poll(cx) {
+        match Pin::new(&mut this.pending.inner.io.rx).poll(cx) {
             Poll::Pending => {
                 this.pending.operation = Some(operation);
                 Poll::Pending
@@ -1293,21 +1379,31 @@ impl Future for CompletionFut {
 }
 
 #[derive(Debug)]
-pub struct RawPending {
+struct RawPending {
+    handle: UsbDeviceHandle,
+    io: PendingIo,
+}
+
+/// Identity and completion channel of one in-flight I/O request.
+#[derive(Debug)]
+pub struct PendingIo {
     pub(super) rx: oneshot::Receiver<CompletionData>,
     pub(super) id: RequestId,
-    pub(super) handle: UsbDeviceHandle,
 }
 
 impl Drop for RawPending {
     fn drop(&mut self) {
-        if matches!(self.rx.try_recv(), Err(TryRecvError::Empty)) && self.handle.lifecycle.is_open() {
-            let _ = self.handle.cancel_request(self.id);
+        if matches!(self.io.rx.try_recv(), Err(TryRecvError::Empty)) && self.handle.device.is_open() {
+            let _ = self.handle.cancel_request(self.io.id);
         }
     }
 }
 
 impl RawPending {
+    pub(crate) fn new(handle: UsbDeviceHandle, io: PendingIo) -> Self {
+        Self { handle, io }
+    }
+
     /// Explains a completion channel that ended without delivering a value.
     ///
     /// The sender was dropped without a completion: either a local cancel won
@@ -1315,22 +1411,11 @@ impl RawPending {
     /// distinction is currently observable only through the message text; a
     /// typed server error is planned to restore it.
     fn channel_error(&self) -> ServerError {
-        if self.handle.lifecycle.is_open() {
+        if self.handle.device.is_open() {
             ServerError::reason("usb pending request", "usb request was cancelled before a completion")
         } else {
             ServerError::reason("usb pending request", "usb device channel is closing or closed")
         }
-    }
-
-    pub async fn wait(mut self) -> ServerResult<CompletionData> {
-        match (&mut self.rx).await {
-            Ok(completion) => Ok(completion),
-            Err(_) => Err(self.channel_error()),
-        }
-    }
-
-    pub fn cancel(self) {
-        drop(self);
     }
 }
 
@@ -1474,7 +1559,14 @@ impl UrbdrcDeviceServerBackend for UsbRedirServer {
     }
 
     fn close(&mut self, channel_id: u32) {
-        self.handle.lifecycle.mark_closed();
+        // Mark first: the event loop's authoritative check then rejects every
+        // queued request, so the drain below cannot race a late insert.
+        self.handle.device.mark_closed();
+        let pending_requests = self.handle.device.drain_pending();
+        if pending_requests != 0 {
+            tracing::debug!(channel_id, pending_requests, "Failed pending USB requests on close");
+        }
+
         let _ = self
             .handle
             .sender

--- a/crates/ironrdp-server/src/urbdrc.rs
+++ b/crates/ironrdp-server/src/urbdrc.rs
@@ -333,7 +333,7 @@ impl UsbDeviceHandle {
             (rx, transition)
         };
 
-        let mut submission = TransitionGuard::poison_on_drop(self, transition);
+        let submission = TransitionGuard::poison_on_drop(self, transition);
         let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
@@ -393,7 +393,7 @@ impl UsbDeviceHandle {
             descriptor: descriptor.as_set().as_bytes().to_vec(),
         };
 
-        let mut submission = TransitionGuard::poison_on_drop(self, transition);
+        let submission = TransitionGuard::poison_on_drop(self, transition);
         let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
@@ -439,7 +439,7 @@ impl UsbDeviceHandle {
             (rx, transition, previous_binding)
         };
 
-        let mut submission = TransitionGuard::poison_on_drop(self, transition);
+        let submission = TransitionGuard::poison_on_drop(self, transition);
         let inner = self.resolve_pending(rx).await?;
         submission.disarm();
         Ok(PendingRequest::new(
@@ -970,7 +970,6 @@ struct TransitionGuard<'a> {
     handle: &'a UsbDeviceHandle,
     transition: StatefulTransition,
     poison: bool,
-    armed: bool,
 }
 
 impl<'a> TransitionGuard<'a> {
@@ -979,7 +978,6 @@ impl<'a> TransitionGuard<'a> {
             handle,
             transition,
             poison: true,
-            armed: true,
         }
     }
 
@@ -988,21 +986,21 @@ impl<'a> TransitionGuard<'a> {
             handle,
             transition,
             poison: false,
-            armed: true,
         }
     }
 
     /// Hands transition bookkeeping over to the caller.
-    fn disarm(&mut self) {
-        self.armed = false;
+    #[expect(
+        clippy::mem_forget,
+        reason = "the guard owns nothing to leak; skipping its drop glue is the hand-off"
+    )]
+    fn disarm(self) {
+        core::mem::forget(self);
     }
 }
 
 impl Drop for TransitionGuard<'_> {
     fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
         let mut state = self.handle.lock_usb_state();
         if self.poison {
             state.poison_transition(self.transition);
@@ -1273,7 +1271,7 @@ impl PendingOperation {
                     .map_err(|e| ServerError::custom("malformed usb get interface completion", e))?,
             )),
             Self::SelectConfiguration { transition, plan } => {
-                let mut finish = TransitionGuard::finish_on_drop(handle, transition);
+                let finish = TransitionGuard::finish_on_drop(handle, transition);
                 let completion = ironrdp_rdpeusb::usb::select_configuration_completion(completion)
                     .map_err(|e| ServerError::custom("malformed usb select configuration completion", e))?;
                 let result = match completion {
@@ -1286,7 +1284,7 @@ impl PendingOperation {
                 Ok(UsbRequestCompletion::Unit(Ok(())))
             }
             Self::SelectInterface { transition, plan } => {
-                let mut finish = TransitionGuard::finish_on_drop(handle, transition);
+                let finish = TransitionGuard::finish_on_drop(handle, transition);
                 let completion = ironrdp_rdpeusb::usb::select_interface_completion(completion)
                     .map_err(|e| ServerError::custom("malformed usb select interface completion", e))?;
                 let result = match completion {
@@ -1308,7 +1306,7 @@ impl PendingOperation {
                 transition,
                 previous_binding,
             } => {
-                let mut finish = TransitionGuard::finish_on_drop(handle, transition);
+                let finish = TransitionGuard::finish_on_drop(handle, transition);
                 let completion = ironrdp_rdpeusb::usb::reset_device_completion(completion)
                     .map_err(|e| ServerError::custom("malformed usb reset device completion", e))?;
                 if let Err(usb_error) = completion {


### PR DESCRIPTION
Reworks how `ironrdp-server` tracks a redirected USB device, so that completions no longer round-trip through `ServerEvent`.

Per-device state (lifecycle, pending-request map, USB shared state) moves into a single `Arc<ServerUsbDevice>` held by `UsbDeviceHandle`. The event loop's router shares that state instead of owning a separate record.

The RDPEUSB backend now resolves a pending request directly through that shared state, and `UrbdrcDeviceServerMessage::IoComp` is gone. A completion is already fully decoded when the backend receives it, and delivering it needed nothing the event loop owns; previously it was re-queued and could sit behind requests waiting on a socket write. An I/O submission is also answered before its write, so the caller owns cancel-on-drop as early as possible.

`UrbdrcDeviceServer::abandon_unsent` releases a request that was built but never handed to the transport. Such a request is never answered by a completion, so nothing else would ever release its tracking state. This is deliberately separate from `cancel_request`: a cancelled request is still answered, with a failure HRESULT per [MS-RDPEUSB] sections 3.3.5.3.1 and 3.3.5.3.6, so cancelling must not release anything.

Two notes for review. `RawPending` and `PendingIo` are not re-exported from `ironrdp-server`; neither had a public constructor or producer, so no downstream could obtain one, and this removes unreachable exports rather than a usable API. Teardown now drains pending requests explicitly, because the pending map outlives the router entry that used to own it and dropping that entry no longer fails the waiting callers on its own.