### PR TITLE
fix(rdpdr): consume query information body

### DIFF
--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -2557,10 +2557,10 @@ impl Information {
 
 /// [2.2.3.3.8] Server Drive Query Information Request (DR_DRIVE_QUERY_INFORMATION_REQ)
 ///
-/// Note that Length, Padding, and QueryBuffer fields are all ignored in keeping with the [analogous code in FreeRDP].
+/// `Length` bounds the consumed `QueryBuffer`; the padding and buffer contents are ignored like the [analogous FreeRDP code].
 ///
 /// [2.2.3.3.8]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/e43dcd68-2980-40a9-9238-344b6cf94946
-/// [analogous code in FreeRDP]: https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L384
+/// [analogous FreeRDP code]: https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L384
 #[derive(Debug, PartialEq, Clone)]
 pub struct ServerDriveQueryInformationRequest {
     pub device_io_request: DeviceIoRequest,
@@ -2569,11 +2569,16 @@ pub struct ServerDriveQueryInformationRequest {
 
 impl ServerDriveQueryInformationRequest {
     const NAME: &'static str = "ServerDriveQueryInformationRequest";
-    const FIXED_PART_SIZE: usize = 4; // FsInformationClass
+    const PADDING_SIZE: usize = 24;
+    const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 4 /* Length */ + Self::PADDING_SIZE /* Padding */;
 
     pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::FIXED_PART_SIZE);
         let file_info_class_lvl = FileInformationClassLevel::from(src.read_u32());
+        let query_buffer_length = cast_length!(Self::NAME, "Length", src.read_u32(), in: src)?;
+        read_padding!(src, Self::PADDING_SIZE);
+        ensure_size!(ctx: Self::NAME, in: src, size: query_buffer_length);
+        src.advance(query_buffer_length);
 
         Ok(Self {
             device_io_request: dev_io_req,
@@ -2581,10 +2586,13 @@ impl ServerDriveQueryInformationRequest {
         })
     }
 
+    /// Encodes an empty `QueryBuffer` because this representation retains only the information class.
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(ctx: Self::NAME, in: dst, size: self.size());
         self.device_io_request.encode(dst)?;
         dst.write_u32(self.file_info_class_lvl.clone().into());
+        dst.write_u32(0); // Length
+        write_padding!(dst, Self::PADDING_SIZE);
         Ok(())
     }
 

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -1030,17 +1030,70 @@ fn device_create_request_round_trips() {
 
 #[test]
 fn server_drive_query_information_request_round_trips() {
+    const WIRE: [u8; 52] = [
+        1, 0, 0, 0, // DeviceId
+        2, 0, 0, 0, // FileId
+        3, 0, 0, 0, // CompletionId
+        5, 0, 0, 0, // MajorFunction
+        0, 0, 0, 0, // MinorFunction
+        4, 0, 0, 0, // FsInformationClass
+        0, 0, 0, 0, // Length
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Padding
+    ];
     let original = ServerDriveQueryInformationRequest {
         device_io_request: some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
         file_info_class_lvl: FileInformationClassLevel::FILE_BASIC_INFORMATION,
     };
     let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    assert_eq!(encoded, WIRE);
+    let mut src = ReadCursor::new(&encoded[20..]);
     let decoded = ServerDriveQueryInformationRequest::decode(
         some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
-        &mut ReadCursor::new(&encoded[20..]),
+        &mut src,
     )
     .unwrap();
     assert_eq!(decoded.file_info_class_lvl, original.file_info_class_lvl);
+    assert!(src.is_empty());
+}
+
+#[test]
+fn server_drive_query_information_request_consumes_query_buffer() {
+    let original = ServerDriveQueryInformationRequest {
+        device_io_request: some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
+        file_info_class_lvl: FileInformationClassLevel::FILE_BASIC_INFORMATION,
+    };
+    let mut encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    encoded[24..28].copy_from_slice(&3u32.to_le_bytes());
+    encoded.extend_from_slice(&[1, 2, 3]);
+
+    let mut src = ReadCursor::new(&encoded[20..]);
+    let decoded = ServerDriveQueryInformationRequest::decode(
+        some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
+        &mut src,
+    )
+    .unwrap();
+    assert_eq!(decoded.file_info_class_lvl, original.file_info_class_lvl);
+    assert!(src.is_empty());
+}
+
+#[test]
+fn server_drive_query_information_request_rejects_truncated_fields() {
+    let original = ServerDriveQueryInformationRequest {
+        device_io_request: some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
+        file_info_class_lvl: FileInformationClassLevel::FILE_BASIC_INFORMATION,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let request = some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0));
+
+    assert!(
+        ServerDriveQueryInformationRequest::decode(request.clone(), &mut ReadCursor::new(&encoded[20..51])).is_err()
+    );
+
+    let mut missing_query_buffer = encoded;
+    missing_query_buffer[24..28].copy_from_slice(&1u32.to_le_bytes());
+    assert!(
+        ServerDriveQueryInformationRequest::decode(request, &mut ReadCursor::new(&missing_query_buffer[20..])).is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
DR_DRIVE_QUERY_INFORMATION_REQ previously decoded only the
FsInformationClass field and ignored Length, Padding, and QueryBuffer,
leaving those bytes unconsumed on the wire cursor. Servers that send a
non-empty QueryBuffer (per MS-RDPEFS 2.2.3.3.8) desynchronized
subsequent PDU parsing.

Decode and encode the full fixed part (FsInformationClass, Length,
24-byte Padding) and advance the cursor past the Length-bounded
QueryBuffer on decode. Encode continues to emit an empty QueryBuffer
since this representation only retains the information class.