### PR TITLE
fix(rdpeudp): harden TLS sideband setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "ironrdp-pdu",
  "ironrdp-rdpemt",
  "ironrdp-rdpeudp",
+ "ironrdp-tls",
  "sha2 0.10.9",
  "tokio",
  "tokio-rustls",

--- a/crates/ironrdp-rdpeudp-tokio/Cargo.toml
+++ b/crates/ironrdp-rdpeudp-tokio/Cargo.toml
@@ -16,11 +16,9 @@ categories.workspace = true
 doctest = false
 
 [features]
-# No default: matches `ironrdp-tls`'s own stance. Neither feature changes
-# behavior for a consumer that already installs a process-default
-# CryptoProvider itself (for example by depending on `ironrdp-tls` in the
-# same process); they exist for a consumer using this crate standalone, so
-# `ClientConfig::builder()` doesn't panic for lack of one.
+# No default: matches `ironrdp-tls`'s own stance. Consumers must select one
+# of these features or install a process-default CryptoProvider before
+# `ClientConfig::builder()` is called.
 rustls-aws-lc-rs = ["tokio-rustls/aws_lc_rs"]
 rustls-ring = ["tokio-rustls/ring"]
 
@@ -31,6 +29,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.2" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } # public
 ironrdp-rdpemt = { path = "../ironrdp-rdpemt", version = "0.1", features = ["std"] } # public
 ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", version = "0.1", features = ["std"] } # public
+ironrdp-tls = { path = "../ironrdp-tls", version = "0.2.2", default-features = false, features = ["rustls-verifier"] } # public
 bytes = "1"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] } # public
 sha2 = "0.10"

--- a/crates/ironrdp-rdpeudp-tokio/README.md
+++ b/crates/ironrdp-rdpeudp-tokio/README.md
@@ -3,6 +3,9 @@
 Tokio driver wiring the RDP-UDP transport, TLS and the multitransport tunnel
 into a usable async transport.
 
+The client path implements reliable RDP-UDP2 only.
+Legacy RDP-UDP v1/v2 data transfer, lossy RDP-UDP-L, FEC, and DTLS are not implemented.
+
 This crate is the I/O layer for three sans-I/O pieces:
 
 - [`ironrdp-rdpeudp`](../ironrdp-rdpeudp): reliable UDP with congestion control
@@ -34,12 +37,14 @@ state machine stays testable and free of ambient time.
 ```rust,ignore
 use ironrdp_rdpemt::TunnelConfig;
 use ironrdp_rdpeudp_tokio::{UdpTransportConfig, connect_udp};
+use ironrdp_tls::CertificateValidation;
 
-let config = UdpTransportConfig::new(
+let mut config = UdpTransportConfig::new(
     server_addr,
     "rdp-server.example.com".into(),
     TunnelConfig { request_id, security_cookie },
 );
+config.tls.certificate_validation = CertificateValidation::Strict;
 
 let mut transport = connect_udp(config).await?;
 

--- a/crates/ironrdp-rdpeudp-tokio/src/driver.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/driver.rs
@@ -64,6 +64,7 @@ pub(crate) struct Driver {
     /// here to retry once the send queue has room again instead of being
     /// dropped or treated as a fatal error.
     pending_write: Option<Vec<u8>>,
+    stream_released: bool,
 }
 
 impl Driver {
@@ -82,6 +83,7 @@ impl Driver {
             recv_buf: vec![0u8; RECV_BUF_SIZE],
             clock: Clock::new(),
             pending_write: None,
+            stream_released: false,
         }
     }
 
@@ -99,7 +101,7 @@ impl Driver {
     }
 
     /// Mark the shared state closed and wake everything waiting on it.
-    fn release_stream(&self, error: Option<&DriverError>) {
+    fn release_stream(&mut self, error: Option<&DriverError>) {
         let Ok(mut shared) = self.shared.lock() else {
             // A poisoned lock means the stream side already panicked, and
             // there is nothing left to wake.
@@ -116,6 +118,7 @@ impl Driver {
         }
 
         shared.close();
+        self.stream_released = true;
     }
 
     async fn run_to_completion(&mut self) -> Result<(), DriverError> {
@@ -162,6 +165,7 @@ impl Driver {
                         Err(error) if is_droppable(&error) => {
                             tracing::debug!(%error, "dropping an unusable datagram");
                         }
+
                         Err(error) => return Err(DriverError::rdpeudp("handle datagram", error)),
                     }
 
@@ -329,6 +333,19 @@ impl Driver {
                     }
                 }
             }
+        }
+    }
+}
+
+impl Drop for Driver {
+    fn drop(&mut self) {
+        if self.stream_released {
+            return;
+        }
+
+        if let Ok(mut shared) = self.shared.lock() {
+            shared.error.get_or_insert(io::ErrorKind::ConnectionAborted);
+            shared.close();
         }
     }
 }
@@ -623,7 +640,7 @@ mod tests {
             guard.read_waker = Some(futures_waker(Arc::clone(&woken)));
         }
 
-        let driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::new(Notify::new()));
+        let mut driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::new(Notify::new()));
         driver.release_stream(Some(&DriverError::connection_closed("test")));
 
         assert!(
@@ -631,6 +648,29 @@ mod tests {
             "the reader was left parked"
         );
 
+        let guard = shared.lock().expect("lock");
+        assert!(guard.closed);
+        assert_eq!(guard.error, Some(io::ErrorKind::ConnectionAborted));
+    }
+
+    #[tokio::test]
+    async fn dropping_driver_wakes_a_parked_reader() {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let conn = RdpeudpConnection::connect(test_connection_config(), Clock::new().now()).expect("connect");
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let woken = Arc::new(core::sync::atomic::AtomicBool::new(false));
+
+        {
+            let mut guard = shared.lock().expect("lock");
+            guard.read_waker = Some(futures_waker(Arc::clone(&woken)));
+        }
+
+        drop(Driver::new(socket, conn, Arc::clone(&shared), Arc::new(Notify::new())));
+
+        assert!(
+            woken.load(core::sync::atomic::Ordering::SeqCst),
+            "the reader was left parked"
+        );
         let guard = shared.lock().expect("lock");
         assert!(guard.closed);
         assert_eq!(guard.error, Some(io::ErrorKind::ConnectionAborted));

--- a/crates/ironrdp-rdpeudp-tokio/src/error.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/error.rs
@@ -89,8 +89,14 @@ pub enum UdpTransportErrorKind {
     /// The TLS handshake failed.
     Tls(io::Error),
 
+    /// The TLS handshake did not complete within the configured budget.
+    TlsTimeout,
+
     /// The tunnel state machine rejected an operation.
     Rdpemt(RdpemtError),
+
+    /// The RDPEMT tunnel handshake did not complete within the configured budget.
+    TunnelTimeout,
 
     /// The peer rejected the tunnel creation request.
     TunnelRejected { hr_response: u32 },
@@ -117,7 +123,9 @@ impl fmt::Display for UdpTransportErrorKind {
             Self::Handshake(_) => write!(f, "RDP-UDP handshake failed"),
             Self::HandshakeTimeout => write!(f, "RDP-UDP handshake timed out"),
             Self::Tls(_) => write!(f, "TLS error"),
+            Self::TlsTimeout => write!(f, "TLS handshake timed out"),
             Self::Rdpemt(_) => write!(f, "multitransport tunnel error"),
+            Self::TunnelTimeout => write!(f, "multitransport tunnel handshake timed out"),
             Self::TunnelRejected { hr_response } => {
                 write!(f, "tunnel creation rejected: HRESULT {hr_response:#010x}")
             }
@@ -144,7 +152,11 @@ impl core::error::Error for UdpTransportErrorKind {
             Self::Handshake(error) => Some(error),
             Self::Driver(error) => Some(error),
             Self::Rdpemt(error) => Some(error),
-            Self::HandshakeTimeout | Self::TunnelRejected { .. } | Self::DriverPanic => None,
+            Self::HandshakeTimeout
+            | Self::TlsTimeout
+            | Self::TunnelTimeout
+            | Self::TunnelRejected { .. }
+            | Self::DriverPanic => None,
             Self::UnsupportedProtocol { .. } | Self::PayloadTooLarge { .. } => None,
         }
     }
@@ -155,7 +167,9 @@ pub trait UdpTransportErrorExt {
     fn handshake(context: &'static str, error: DriverError) -> Self;
     fn handshake_timeout(context: &'static str) -> Self;
     fn tls(context: &'static str, error: io::Error) -> Self;
+    fn tls_timeout(context: &'static str) -> Self;
     fn rdpemt(context: &'static str, error: RdpemtError) -> Self;
+    fn tunnel_timeout(context: &'static str) -> Self;
     fn tunnel_rejected(context: &'static str, hr_response: u32) -> Self;
     fn driver_panic(context: &'static str) -> Self;
     fn driver(context: &'static str, error: DriverError) -> Self;
@@ -185,8 +199,18 @@ impl UdpTransportErrorExt for UdpTransportError {
     }
 
     #[track_caller]
+    fn tls_timeout(context: &'static str) -> Self {
+        Self::new(context, UdpTransportErrorKind::TlsTimeout)
+    }
+
+    #[track_caller]
     fn rdpemt(context: &'static str, error: RdpemtError) -> Self {
         Self::new(context, UdpTransportErrorKind::Rdpemt(error))
+    }
+
+    #[track_caller]
+    fn tunnel_timeout(context: &'static str) -> Self {
+        Self::new(context, UdpTransportErrorKind::TunnelTimeout)
     }
 
     #[track_caller]

--- a/crates/ironrdp-rdpeudp-tokio/src/lib.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/lib.rs
@@ -14,4 +14,4 @@ pub(crate) mod tunnel;
 
 pub use self::error::{DriverError, DriverErrorKind, UdpTransportError, UdpTransportErrorKind};
 pub use self::multitransport::MultitransportBootstrap;
-pub use self::transport::{UdpAcceptConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp};
+pub use self::transport::{UdpAcceptConfig, UdpTlsConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp};

--- a/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
@@ -5,30 +5,27 @@
 //!
 //! 1. Parse the request (requestId + requestedProtocol + securityCookie)
 //! 2. Establish a UDP transport using `connect_udp()`
-//! 3. Send an Initiate Multitransport Response PDU (S_OK or E_ABORT)
-//!    back on the TCP connection
+//! 3. Send an Initiate Multitransport Response PDU back on the TCP connection
+//!    when the negotiated mode or connection outcome requires one
 //!
-//! `MultitransportBootstrap` orchestrates this sequence. The upstream
-//! `ironrdp-connector` doesn't implement multitransport yet, so this
-//! acts as a standalone shim that an application wires into its
-//! connection flow.
+//! `ironrdp-connector` surfaces each request and frames the matching response.
+//! `MultitransportBootstrap` owns the sideband connection attempt between those connector steps.
 
 use core::net::SocketAddr;
-use std::sync::Arc;
-
 use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
 use ironrdp_rdpemt::{RdpemtError, RdpemtErrorExt as _, TunnelConfig};
 use ironrdp_rdpeudp::ConnectionConfig;
 
 use crate::error::{UdpTransportError, UdpTransportErrorExt as _};
-use crate::transport::{UdpTransport, UdpTransportConfig, connect_udp};
+use crate::transport::{UdpTlsConfig, UdpTransport, UdpTransportConfig, connect_udp};
 
 /// Orchestrates the multitransport connection sequence.
 ///
 /// Created from the raw Initiate Multitransport Request PDU payload
 /// received on the TCP MCS message channel. Call [`connect()`] to
 /// establish the UDP transport, then [`response_pdu()`] to get the
-/// bytes to send back on TCP.
+/// response selected by that attempt.
+/// The caller decides whether the negotiated mode requires sending it.
 ///
 /// [`connect()`]: MultitransportBootstrap::connect
 /// [`response_pdu()`]: MultitransportBootstrap::response_pdu
@@ -40,13 +37,16 @@ use crate::transport::{UdpTransport, UdpTransportConfig, connect_udp};
 /// let mut bootstrap = MultitransportBootstrap::new(request);
 ///
 /// // Attempt the UDP connection
+/// let tls = UdpTlsConfig::new(server_addr.to_string());
 /// let _ = bootstrap
-///     .connect(server_addr, "server.example.com".into(), Default::default(), None)
+///     .connect(server_addr, "server.example.com".into(), Default::default(), tls)
 ///     .await;
 ///
-/// // Always send the response back on TCP (S_OK or E_ABORT)
+/// // Send E_ABORT after failure, or S_OK when Soft-Sync was negotiated.
 /// let response_bytes = bootstrap.response_pdu().expect("response available after connect");
-/// tcp_writer.write_all(&response_bytes).await?;
+/// if !bootstrap.is_connected() || soft_sync_negotiated {
+///     tcp_writer.write_all(&response_bytes).await?;
+/// }
 ///
 /// // If successful, use the transport
 /// if let Some(transport) = bootstrap.take_transport() {
@@ -88,12 +88,7 @@ impl MultitransportBootstrap {
     /// On success, stores the transport and prepares an `S_OK` response.
     /// On failure, prepares an `E_ABORT` response and returns the error.
     ///
-    /// `server_cert_verifier` is forwarded to the underlying [`connect_udp`]
-    /// call the same way `connection_config` is: `None` preserves the
-    /// historic no-verification behavior, `Some(verifier)` opts into real
-    /// TLS certificate validation. Without threading it through here, a
-    /// caller going through this orchestrator had no way to reach the
-    /// verification `connect_udp` itself already supports.
+    /// `tls_config` is forwarded to [`connect_udp`] so the sideband uses the same certificate policy and callback as the primary transport.
     ///
     /// After calling this, use [`response_pdu()`] to get the bytes to
     /// send back to the server on the TCP connection.
@@ -104,7 +99,7 @@ impl MultitransportBootstrap {
         server_addr: SocketAddr,
         server_name: String,
         connection_config: ConnectionConfig,
-        server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
+        tls_config: UdpTlsConfig,
     ) -> Result<(), UdpTransportError> {
         // This driver only implements the reliable transport (RDPEUDP2 + TLS).
         // UdpFecL (lossy RDPEUDP + DTLS) is a distinct wire protocol this crate
@@ -125,7 +120,7 @@ impl MultitransportBootstrap {
         };
         let mut config = UdpTransportConfig::new(server_addr, server_name, tunnel_config);
         config.connection_config = connection_config;
-        config.server_cert_verifier = server_cert_verifier;
+        config.tls = tls_config;
 
         match connect_udp(config).await {
             Ok(transport) => {
@@ -238,7 +233,12 @@ mod tests {
         let unreachable_addr: SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
 
         let result = bootstrap
-            .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default(), None)
+            .connect(
+                unreachable_addr,
+                "localhost".into(),
+                ConnectionConfig::default(),
+                UdpTlsConfig::new(unreachable_addr.to_string()),
+            )
             .await;
 
         // Checking the specific error kind (not just is_err()) is the point:

--- a/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
@@ -178,6 +178,8 @@ impl MultitransportBootstrap {
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
 
     use super::*;
@@ -203,6 +205,21 @@ mod tests {
         assert_eq!(bootstrap.request().request_id, 42);
         assert!(!bootstrap.is_connected());
         assert!(bootstrap.response_pdu().is_none());
+    }
+
+    #[test]
+    fn default_tls_timeout_covers_interactive_certificate_decision() {
+        let server_addr = "127.0.0.1:3389".parse().expect("valid server address");
+        let config = UdpTransportConfig::new(
+            server_addr,
+            "localhost".into(),
+            TunnelConfig {
+                request_id: 42,
+                security_cookie: [0xAB; 16],
+            },
+        );
+
+        assert!(config.tls_timeout > Duration::from_secs(120));
     }
 
     #[test]

--- a/crates/ironrdp-rdpeudp-tokio/src/tls.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/tls.rs
@@ -1,8 +1,6 @@
 //! TLS upgrade over an RDPEUDP2 stream.
 //!
-//! Mirrors the rustls configuration from `ironrdp-tls`: no certificate
-//! verification (RDP uses self-signed certs), disabled TLS resumption
-//! (CredSSP compatibility), and SSLKEYLOGFILE support for Wireshark.
+//! Reuses the `ironrdp-tls` client configuration.
 //!
 //! The caller passes an `RdpeudpStream` which provides `AsyncRead +
 //! AsyncWrite` over the RDPEUDP2 connection. tokio-rustls wraps it
@@ -14,47 +12,75 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio_rustls::rustls::pki_types::ServerName;
 
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
+
 pub(crate) type TlsStream<S> = tokio_rustls::client::TlsStream<S>;
 pub(crate) type ServerTlsStream<S> = tokio_rustls::server::TlsStream<S>;
 
 /// Perform TLS handshake over an established RDPEUDP2 stream.
 ///
-/// `server_cert_verifier` selects how the peer certificate is validated.
-/// `None` preserves the historic behavior (no verification: RDP servers
-/// commonly present self-signed certificates). `Some(verifier)` lets a
-/// caller opt into real validation, for example a
-/// `rustls::client::WebPkiServerVerifier` built against the platform root
-/// store, mirroring the choice `ironrdp-tls` already exposes on the TCP
-/// path without this crate taking on that crate's certificate-store
-/// dependencies itself.
+/// The policy, callback, and endpoint use the same semantics as `ironrdp-tls` on the primary TCP transport.
 ///
-/// Returns the encrypted stream. The driver task continues running
-/// in the background, transparently shuttling encrypted bytes between
-/// the UDP socket and this TLS stream via `SharedIo`.
+/// A synchronous validation callback runs on a dedicated blocking thread so it cannot starve the RDPEUDP driver on a current-thread runtime.
+///
+/// Returns the encrypted stream.
+/// The driver task continues running in the background, transparently shuttling encrypted bytes between the UDP socket and this TLS stream via `SharedIo`.
 pub(crate) async fn tls_upgrade<S>(
     stream: S,
     server_name: &str,
-    server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+    certificate_validation_endpoint: &str,
+) -> io::Result<TlsStream<S>>
+where
+    S: Unpin + Send + AsyncRead + AsyncWrite + 'static,
+{
+    if certificate_validation_callback.is_none() {
+        return tls_upgrade_inner(
+            stream,
+            server_name,
+            certificate_validation,
+            None,
+            certificate_validation_endpoint,
+        )
+        .await;
+    }
+
+    let server_name = server_name.to_owned();
+    let certificate_validation_endpoint = certificate_validation_endpoint.to_owned();
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(tls_upgrade_inner(
+                stream,
+                &server_name,
+                certificate_validation,
+                certificate_validation_callback,
+                &certificate_validation_endpoint,
+            ))
+    })
+    .await
+    .map_err(io::Error::other)?
+}
+
+async fn tls_upgrade_inner<S>(
+    stream: S,
+    server_name: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+    certificate_validation_endpoint: &str,
 ) -> io::Result<TlsStream<S>>
 where
     S: Unpin + AsyncRead + AsyncWrite,
 {
-    let verifier: Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier> =
-        server_cert_verifier.unwrap_or_else(|| Arc::new(danger::NoCertificateVerification));
+    let config = ironrdp_tls::rustls_client_config(
+        certificate_validation,
+        certificate_validation_endpoint,
+        certificate_validation_callback,
+    )?;
 
     let mut tls_stream = {
-        let mut config = tokio_rustls::rustls::client::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(verifier)
-            .with_no_client_auth();
-
-        // SSLKEYLOGFILE support for debugging with Wireshark
-        config.key_log = Arc::new(tokio_rustls::rustls::KeyLogFile::new());
-
-        // Disable TLS resumption: not supported by CredSSP and some
-        // RDP server configurations.
-        config.resumption = tokio_rustls::rustls::client::Resumption::disabled();
-
         let config = Arc::new(config);
 
         let domain = ServerName::try_from(server_name.to_owned()).map_err(io::Error::other)?;
@@ -82,61 +108,4 @@ where
     let mut tls_stream = acceptor.accept(stream).await?;
     tls_stream.flush().await?;
     Ok(tls_stream)
-}
-
-mod danger {
-    use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    use tokio_rustls::rustls::{DigitallySignedStruct, Error, SignatureScheme, pki_types};
-
-    #[derive(Debug)]
-    pub(super) struct NoCertificateVerification;
-
-    impl ServerCertVerifier for NoCertificateVerification {
-        fn verify_server_cert(
-            &self,
-            _: &pki_types::CertificateDer<'_>,
-            _: &[pki_types::CertificateDer<'_>],
-            _: &pki_types::ServerName<'_>,
-            _: &[u8],
-            _: pki_types::UnixTime,
-        ) -> Result<ServerCertVerified, Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _: &[u8],
-            _: &pki_types::CertificateDer<'_>,
-            _: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            _: &[u8],
-            _: &pki_types::CertificateDer<'_>,
-            _: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            vec![
-                SignatureScheme::RSA_PKCS1_SHA1,
-                SignatureScheme::ECDSA_SHA1_Legacy,
-                SignatureScheme::RSA_PKCS1_SHA256,
-                SignatureScheme::ECDSA_NISTP256_SHA256,
-                SignatureScheme::RSA_PKCS1_SHA384,
-                SignatureScheme::ECDSA_NISTP384_SHA384,
-                SignatureScheme::RSA_PKCS1_SHA512,
-                SignatureScheme::ECDSA_NISTP521_SHA512,
-                SignatureScheme::RSA_PSS_SHA256,
-                SignatureScheme::RSA_PSS_SHA384,
-                SignatureScheme::RSA_PSS_SHA512,
-                SignatureScheme::ED25519,
-                SignatureScheme::ED448,
-            ]
-        }
-    }
 }

--- a/crates/ironrdp-rdpeudp-tokio/src/tls.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/tls.rs
@@ -36,14 +36,13 @@ where
     S: Unpin + Send + AsyncRead + AsyncWrite + 'static,
 {
     if certificate_validation_callback.is_none() {
-        return tls_upgrade_inner(
-            stream,
-            server_name,
-            certificate_validation,
-            None,
-            certificate_validation_endpoint,
-        )
-        .await;
+        let certificate_validation_endpoint = certificate_validation_endpoint.to_owned();
+        let config = spawn_blocking_io(move || {
+            ironrdp_tls::rustls_client_config(certificate_validation, &certificate_validation_endpoint, None)
+        })
+        .await?;
+
+        return tls_connect_with_config(stream, server_name, config).await;
     }
 
     let server_name = server_name.to_owned();
@@ -52,34 +51,36 @@ where
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?
-            .block_on(tls_upgrade_inner(
-                stream,
-                &server_name,
-                certificate_validation,
-                certificate_validation_callback,
-                &certificate_validation_endpoint,
-            ))
+            .block_on(async {
+                let config = ironrdp_tls::rustls_client_config(
+                    certificate_validation,
+                    &certificate_validation_endpoint,
+                    certificate_validation_callback,
+                )?;
+
+                tls_connect_with_config(stream, &server_name, config).await
+            })
     })
     .await
     .map_err(io::Error::other)?
 }
 
-async fn tls_upgrade_inner<S>(
+async fn spawn_blocking_io<T, F>(action: F) -> io::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(action).await.map_err(io::Error::other)?
+}
+
+async fn tls_connect_with_config<S>(
     stream: S,
     server_name: &str,
-    certificate_validation: CertificateValidation,
-    certificate_validation_callback: Option<CertificateValidationCallback>,
-    certificate_validation_endpoint: &str,
+    config: tokio_rustls::rustls::ClientConfig,
 ) -> io::Result<TlsStream<S>>
 where
     S: Unpin + AsyncRead + AsyncWrite,
 {
-    let config = ironrdp_tls::rustls_client_config(
-        certificate_validation,
-        certificate_validation_endpoint,
-        certificate_validation_callback,
-    )?;
-
     let mut tls_stream = {
         let config = Arc::new(config);
 
@@ -108,4 +109,44 @@ where
     let mut tls_stream = acceptor.accept(stream).await?;
     tls_stream.flush().await?;
     Ok(tls_stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use core::time::Duration;
+    use std::sync::mpsc;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_io_does_not_stall_the_current_thread_runtime() {
+        let active = Arc::new(AtomicBool::new(false));
+        let action_active = Arc::clone(&active);
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let release_thread = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(250));
+            release_tx.send(()).expect("release blocking action");
+        });
+
+        let action = tokio::spawn(spawn_blocking_io(move || {
+            action_active.store(true, Ordering::SeqCst);
+            started_tx.send(()).expect("signal action started");
+            release_rx.recv().expect("wait for release");
+            action_active.store(false, Ordering::SeqCst);
+            Ok(())
+        }));
+
+        started_rx.await.expect("blocking action started");
+        assert!(
+            active.load(Ordering::SeqCst),
+            "the runtime must resume while the blocking action is still active"
+        );
+
+        action.await.expect("join blocking action").expect("blocking action");
+        release_thread.join().expect("join release thread");
+    }
 }

--- a/crates/ironrdp-rdpeudp-tokio/src/transport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/transport.rs
@@ -58,6 +58,8 @@ pub struct UdpTransportConfig {
     pub handshake_timeout: Duration,
     /// Maximum time to wait for the TLS handshake to complete.
     /// Default: 130 seconds to allow a 120-second interactive certificate decision plus handshake overhead.
+    ///
+    /// The timeout cancels the connection attempt, but a synchronous certificate callback already running on a blocking thread continues until it returns.
     pub tls_timeout: Duration,
     /// Maximum time to wait for the RDPEMT tunnel handshake to complete.
     /// Default: 10 seconds.

--- a/crates/ironrdp-rdpeudp-tokio/src/transport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/transport.rs
@@ -57,7 +57,7 @@ pub struct UdpTransportConfig {
     /// Default: 10 seconds (matching FreeRDP).
     pub handshake_timeout: Duration,
     /// Maximum time to wait for the TLS handshake to complete.
-    /// Default: 60 seconds to allow an interactive certificate decision.
+    /// Default: 130 seconds to allow a 120-second interactive certificate decision plus handshake overhead.
     pub tls_timeout: Duration,
     /// Maximum time to wait for the RDPEMT tunnel handshake to complete.
     /// Default: 10 seconds.
@@ -76,7 +76,7 @@ impl UdpTransportConfig {
             tunnel_config,
             connection_config: ConnectionConfig::default(),
             handshake_timeout: Duration::from_secs(10),
-            tls_timeout: Duration::from_secs(60),
+            tls_timeout: Duration::from_secs(130),
             tunnel_timeout: Duration::from_secs(10),
             tls: UdpTlsConfig::new(server_addr.to_string()),
         }

--- a/crates/ironrdp-rdpeudp-tokio/src/transport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/transport.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex};
 use ironrdp_rdpemt::{RdpemtErrorExt as _, TunnelConfig};
 use ironrdp_rdpeudp::pdu::V1Datagram;
 use ironrdp_rdpeudp::{ConnectionConfig, RdpeudpConnection, RdpeudpErrorExt as _};
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use sha2::{Digest as _, Sha256};
 use tokio::io::AsyncWriteExt as _;
 use tokio::net::UdpSocket;
@@ -55,13 +56,14 @@ pub struct UdpTransportConfig {
     /// Maximum time to wait for the RDPEUDP2 handshake to complete.
     /// Default: 10 seconds (matching FreeRDP).
     pub handshake_timeout: Duration,
-    /// How the server's TLS certificate is validated.
-    ///
-    /// `None` (the default) preserves the historic behavior: no
-    /// verification, since RDP servers commonly present self-signed
-    /// certificates. `Some(verifier)` opts into real validation, mirroring
-    /// the choice `ironrdp-tls` exposes on the TCP path.
-    pub server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
+    /// Maximum time to wait for the TLS handshake to complete.
+    /// Default: 60 seconds to allow an interactive certificate decision.
+    pub tls_timeout: Duration,
+    /// Maximum time to wait for the RDPEMT tunnel handshake to complete.
+    /// Default: 10 seconds.
+    pub tunnel_timeout: Duration,
+    /// TLS certificate-validation settings for the sideband connection.
+    pub tls: UdpTlsConfig,
 }
 
 impl UdpTransportConfig {
@@ -74,7 +76,9 @@ impl UdpTransportConfig {
             tunnel_config,
             connection_config: ConnectionConfig::default(),
             handshake_timeout: Duration::from_secs(10),
-            server_cert_verifier: None,
+            tls_timeout: Duration::from_secs(60),
+            tunnel_timeout: Duration::from_secs(10),
+            tls: UdpTlsConfig::new(server_addr.to_string()),
         }
     }
 }
@@ -87,10 +91,48 @@ impl core::fmt::Debug for UdpTransportConfig {
             .field("tunnel_config", &self.tunnel_config)
             .field("connection_config", &self.connection_config)
             .field("handshake_timeout", &self.handshake_timeout)
+            .field("tls_timeout", &self.tls_timeout)
+            .field("tunnel_timeout", &self.tunnel_timeout)
+            .field("tls", &self.tls)
+            .finish()
+    }
+}
+
+/// TLS validation settings for an RDP-UDP sideband connection.
+#[derive(Clone)]
+pub struct UdpTlsConfig {
+    /// Certificate-validation policy.
+    pub certificate_validation: CertificateValidation,
+    /// Optional callback that can accept a certificate rejected by strict validation.
+    pub certificate_validation_callback: Option<CertificateValidationCallback>,
+    /// Endpoint passed to the validation callback.
+    pub certificate_validation_endpoint: String,
+}
+
+impl UdpTlsConfig {
+    /// Creates settings that preserve the historical permissive certificate policy.
+    pub fn new(certificate_validation_endpoint: String) -> Self {
+        Self {
+            certificate_validation: CertificateValidation::default(),
+            certificate_validation_callback: None,
+            certificate_validation_endpoint,
+        }
+    }
+}
+
+impl core::fmt::Debug for UdpTlsConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UdpTlsConfig")
+            .field("certificate_validation", &self.certificate_validation)
             .field(
-                "server_cert_verifier",
-                &self.server_cert_verifier.as_ref().map(|_| "Some(..)").unwrap_or("None"),
+                "certificate_validation_callback",
+                &self
+                    .certificate_validation_callback
+                    .as_ref()
+                    .map(|_| "Some(..)")
+                    .unwrap_or("None"),
             )
+            .field("certificate_validation_endpoint", &self.certificate_validation_endpoint)
             .finish()
     }
 }
@@ -408,9 +450,19 @@ pub async fn connect_udp(config: UdpTransportConfig) -> Result<UdpTransport, Udp
 
     // Phase 3: TLS handshake over the RDPEUDP2 stream
     let rdpeudp_stream = RdpeudpStream::new(Arc::clone(&shared));
-    let tls_stream = tls_upgrade(rdpeudp_stream, &config.server_name, config.server_cert_verifier)
-        .await
-        .map_err(|error| UdpTransportError::tls("connect udp", error))?;
+    let tls_stream = tokio::time::timeout(
+        config.tls_timeout,
+        tls_upgrade(
+            rdpeudp_stream,
+            &config.server_name,
+            config.tls.certificate_validation,
+            config.tls.certificate_validation_callback,
+            &config.tls.certificate_validation_endpoint,
+        ),
+    )
+    .await
+    .map_err(|_| UdpTransportError::tls_timeout("connect udp"))?
+    .map_err(|error| UdpTransportError::tls("connect udp", error))?;
 
     tracing::debug!("TLS handshake complete, starting RDPEMT tunnel negotiation");
 
@@ -420,7 +472,12 @@ pub async fn connect_udp(config: UdpTransportConfig) -> Result<UdpTransport, Udp
     // tokio::io::split gives us independent read/write halves.
     let (mut tls_read, mut tls_write) = tokio::io::split(tls_stream);
 
-    let mut tunnel = establish_tunnel_split(&mut tls_read, &mut tls_write, config.tunnel_config).await?;
+    let mut tunnel = tokio::time::timeout(
+        config.tunnel_timeout,
+        establish_tunnel_split(&mut tls_read, &mut tls_write, config.tunnel_config),
+    )
+    .await
+    .map_err(|_| UdpTransportError::tunnel_timeout("connect udp"))??;
 
     tracing::debug!("RDPEMT tunnel established, starting data pump");
 

--- a/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
+++ b/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
@@ -104,6 +104,42 @@ async fn full_stack_current_thread_runtime() {
     server.shutdown().await.expect("server shutdown");
 }
 
+/// Verify strict validation without a callback is safe on the current-thread runtime.
+#[tokio::test(flavor = "current_thread")]
+async fn strict_validation_without_callback_on_current_thread_runtime() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind server");
+    let server_addr = server_sock.local_addr().expect("server addr");
+    let tunnel_config = test_tunnel_config();
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config: ConnectionConfig::default(),
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    let mut config = UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config);
+    config.tls.certificate_validation = CertificateValidation::Strict;
+
+    let result = connect_udp(config).await;
+    assert!(
+        result.is_err(),
+        "strict validation must reject the self-signed test certificate"
+    );
+
+    // The server side also errors, since the client aborts mid-handshake.
+    let _ = server_handle.await;
+}
+
 /// Verify a blocking certificate prompt cannot starve RDPEUDP timers on the ActiveX runtime.
 #[tokio::test(flavor = "current_thread")]
 async fn delayed_certificate_callback_does_not_starve_udp_driver() {

--- a/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
+++ b/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
@@ -4,17 +4,19 @@
 //! between a client (`connect_udp`) and server (`accept_udp`) on
 //! localhost, then exercises bidirectional data transfer.
 //!
-//! These tests use `multi_thread` flavor because they perform real
-//! UDP I/O, which conflicts with tokio's mock clock (test-util).
+//! Most tests use a multithreaded runtime.
+//! A dedicated test also covers the current-thread runtime used by ActiveX workers.
 
+use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
 use std::sync::Arc;
 
 use ironrdp_rdpemt::TunnelConfig;
 use ironrdp_rdpeudp::ConnectionConfig;
 use ironrdp_rdpeudp_tokio::{
-    MultitransportBootstrap, UdpAcceptConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp,
+    MultitransportBootstrap, UdpAcceptConfig, UdpTlsConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp,
 };
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use tokio::net::UdpSocket;
 
 /// Generate a self-signed TLS server config for testing.
@@ -88,6 +90,65 @@ async fn full_stack_loopback_handshake() {
     let (client, server) = establish_loopback_pair_on("127.0.0.1:0").await;
     assert!(client.is_alive());
     assert!(server.is_alive());
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// Verify the full stack works on the current-thread runtime used by ActiveX workers.
+#[tokio::test(flavor = "current_thread")]
+async fn full_stack_current_thread_runtime() {
+    let (client, mut server) = establish_loopback_pair_on("127.0.0.1:0").await;
+    client.send(vec![0x01, 0x02, 0x03]).await.expect("client send");
+    assert_eq!(server.recv().await.expect("server recv"), vec![0x01, 0x02, 0x03]);
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// Verify a blocking certificate prompt cannot starve RDPEUDP timers on the ActiveX runtime.
+#[tokio::test(flavor = "current_thread")]
+async fn delayed_certificate_callback_does_not_starve_udp_driver() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind server");
+    let server_addr = server_sock.local_addr().expect("server addr");
+    let tunnel_config = test_tunnel_config();
+    let connection_config = ConnectionConfig {
+        idle_timeout: Duration::from_millis(100),
+        keep_alive_interval: Duration::from_millis(20),
+        ..ConnectionConfig::default()
+    };
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        let connection_config = connection_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config,
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    let client_handle = tokio::spawn(async move {
+        let mut config = UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config);
+        config.connection_config = connection_config;
+        config.tls.certificate_validation = CertificateValidation::Strict;
+        config.tls.certificate_validation_callback = Some(Arc::new(|_, _, _| {
+            std::thread::sleep(Duration::from_millis(250));
+            true
+        }));
+        connect_udp(config).await
+    });
+
+    let (server, client) = tokio::join!(server_handle, client_handle);
+    let mut server = server.expect("server join").expect("server transport");
+    let client = client.expect("client join").expect("client transport");
+    client.send(vec![0x01]).await.expect("send after delayed callback");
+    assert_eq!(server.recv().await.expect("receive after delayed callback"), vec![0x01]);
     client.shutdown().await.expect("client shutdown");
     server.shutdown().await.expect("server shutdown");
 }
@@ -237,55 +298,17 @@ async fn tunnel_rejection_mismatched_cookie() {
     );
 }
 
-/// A `ServerCertVerifier` that rejects every certificate, used to prove a
-/// caller-supplied verifier is actually consulted rather than silently
-/// ignored in favor of the built-in no-verification default.
-#[derive(Debug)]
-struct AlwaysRejectVerifier;
-
-impl tokio_rustls::rustls::client::danger::ServerCertVerifier for AlwaysRejectVerifier {
-    fn verify_server_cert(
-        &self,
-        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _: &[tokio_rustls::rustls::pki_types::CertificateDer<'_>],
-        _: &tokio_rustls::rustls::pki_types::ServerName<'_>,
-        _: &[u8],
-        _: tokio_rustls::rustls::pki_types::UnixTime,
-    ) -> Result<tokio_rustls::rustls::client::danger::ServerCertVerified, tokio_rustls::rustls::Error> {
-        Err(tokio_rustls::rustls::Error::General(
-            "test verifier rejects every certificate".into(),
-        ))
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _: &[u8],
-        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _: &tokio_rustls::rustls::DigitallySignedStruct,
-    ) -> Result<tokio_rustls::rustls::client::danger::HandshakeSignatureValid, tokio_rustls::rustls::Error> {
-        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _: &[u8],
-        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
-        _: &tokio_rustls::rustls::DigitallySignedStruct,
-    ) -> Result<tokio_rustls::rustls::client::danger::HandshakeSignatureValid, tokio_rustls::rustls::Error> {
-        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<tokio_rustls::rustls::SignatureScheme> {
-        vec![tokio_rustls::rustls::SignatureScheme::ECDSA_NISTP256_SHA256]
-    }
+fn rejecting_certificate_callback(hits: Arc<AtomicUsize>) -> CertificateValidationCallback {
+    Arc::new(move |_, endpoint, _| {
+        assert_eq!(endpoint, "rdp.example.test:3389");
+        hits.fetch_add(1, Ordering::SeqCst);
+        false
+    })
 }
 
-/// Verify a caller-supplied `server_cert_verifier` is actually used: the
-/// server's self-signed test certificate must be rejected when the caller
-/// asks for real validation, where the default (no verifier supplied)
-/// accepts it unconditionally.
+/// Verify the sideband applies the primary transport's certificate callback policy.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn connect_rejects_certificate_when_caller_supplies_a_verifier() {
+async fn connect_rejects_certificate_when_callback_declines_it() {
     let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
     let server_addr = server_sock.local_addr().expect("addr");
     let tunnel_config = test_tunnel_config();
@@ -306,29 +329,32 @@ async fn connect_rejects_certificate_when_caller_supplies_a_verifier() {
         }
     });
 
-    let client_handle = tokio::spawn(async move {
-        let mut config = UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config);
-        config.server_cert_verifier = Some(Arc::new(AlwaysRejectVerifier));
-        connect_udp(config).await
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+    let client_handle = tokio::spawn({
+        let callback_hits = Arc::clone(&callback_hits);
+        async move {
+            let mut config = UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config);
+            config.tls.certificate_validation = CertificateValidation::Strict;
+            config.tls.certificate_validation_callback = Some(rejecting_certificate_callback(callback_hits));
+            config.tls.certificate_validation_endpoint = "rdp.example.test:3389".into();
+            connect_udp(config).await
+        }
     });
 
     let client_result = client_handle.await.expect("client join");
     assert!(
         client_result.is_err(),
-        "the self-signed test certificate must be rejected once a verifier is supplied"
+        "the self-signed test certificate must be rejected when the callback declines it"
     );
+    assert_eq!(callback_hits.load(Ordering::SeqCst), 1);
 
     // The server side also errors, since the client aborts mid-handshake.
     let _ = server_handle.await;
 }
 
-/// The same proof as `connect_rejects_certificate_when_caller_supplies_a_verifier`,
-/// through `MultitransportBootstrap::connect` instead of `connect_udp`
-/// directly: before this path also accepted a `server_cert_verifier`, a
-/// caller going through the high-level orchestrator had no way to reach
-/// the verification `connect_udp` itself already supported.
+/// Verify the bootstrap forwards the same certificate policy to the sideband.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn bootstrap_connect_rejects_certificate_when_caller_supplies_a_verifier() {
+async fn bootstrap_connect_rejects_certificate_when_callback_declines_it() {
     let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
     let server_addr = server_sock.local_addr().expect("addr");
     let tunnel_config = test_tunnel_config();
@@ -361,28 +387,31 @@ async fn bootstrap_connect_rejects_certificate_when_caller_supplies_a_verifier()
         wire
     };
 
-    let client_handle = tokio::spawn(async move {
-        let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
-        let result = bootstrap
-            .connect(
-                server_addr,
-                "localhost".into(),
-                ConnectionConfig::default(),
-                Some(Arc::new(AlwaysRejectVerifier)),
-            )
-            .await;
-        (result, bootstrap.is_connected())
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+    let client_handle = tokio::spawn({
+        let callback_hits = Arc::clone(&callback_hits);
+        async move {
+            let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
+            let mut tls = UdpTlsConfig::new("rdp.example.test:3389".into());
+            tls.certificate_validation = CertificateValidation::Strict;
+            tls.certificate_validation_callback = Some(rejecting_certificate_callback(callback_hits));
+            let result = bootstrap
+                .connect(server_addr, "localhost".into(), ConnectionConfig::default(), tls)
+                .await;
+            (result, bootstrap.is_connected())
+        }
     });
 
     let (client_result, is_connected) = client_handle.await.expect("client join");
     assert!(
         client_result.is_err(),
-        "the self-signed test certificate must be rejected once a verifier is supplied through the bootstrap"
+        "the self-signed test certificate must be rejected when the bootstrap callback declines it"
     );
     assert!(
         !is_connected,
         "a rejected certificate must not leave a transport behind"
     );
+    assert_eq!(callback_hits.load(Ordering::SeqCst), 1);
 
     // The server side also errors, since the client aborts mid-handshake.
     let _ = server_handle.await;
@@ -431,7 +460,12 @@ async fn failed_reconnect_clears_the_transport_from_an_earlier_success() {
     };
     let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
     bootstrap
-        .connect(server_addr, "localhost".into(), ConnectionConfig::default(), None)
+        .connect(
+            server_addr,
+            "localhost".into(),
+            ConnectionConfig::default(),
+            UdpTlsConfig::new(server_addr.to_string()),
+        )
         .await
         .expect("first connect succeeds");
     assert!(bootstrap.is_connected());
@@ -440,7 +474,12 @@ async fn failed_reconnect_clears_the_transport_from_an_earlier_success() {
     // Reconnect against a closed loopback port nothing is listening on.
     let unreachable_addr: core::net::SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
     let result = bootstrap
-        .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default(), None)
+        .connect(
+            unreachable_addr,
+            "localhost".into(),
+            ConnectionConfig::default(),
+            UdpTlsConfig::new(unreachable_addr.to_string()),
+        )
         .await;
     assert!(result.is_err(), "reconnect against an unreachable address must fail");
 

--- a/crates/ironrdp-tls/Cargo.toml
+++ b/crates/ironrdp-tls/Cargo.toml
@@ -33,10 +33,15 @@ rustls-ring = ["rustls-no-provider", "tokio-rustls/ring"]
 # rustls CryptoProvider as the process default before opening a connection, otherwise
 # building the client configuration panics.
 rustls-no-provider = [
-    "dep:rustls-native-certs",
-    "dep:tokio-rustls",
+    "rustls-verifier",
     "dep:x509-cert",
     "tokio/io-util",
+]
+# Shared rustls verifier support without selecting rustls as this crate's stream backend.
+# This lets an RDP-UDP sideband use rustls alongside a native-tls primary transport.
+rustls-verifier = [
+    "dep:rustls-native-certs",
+    "dep:tokio-rustls",
     "tokio-rustls/logging",
     "tokio-rustls/tls12",
 ]

--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -3,6 +3,8 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "rustls-verifier")]
+use tokio as _;
 #[cfg(any(feature = "native-tls", test))]
 use tokio_native_tls as _;
 
@@ -18,8 +20,16 @@ mod impl_;
 #[path = "stub.rs"]
 mod impl_;
 
+#[cfg(feature = "rustls-verifier")]
+mod rustls_verifier;
+
 #[cfg(any(
-    not(any(feature = "stub", feature = "native-tls", feature = "rustls-no-provider")),
+    not(any(
+        feature = "stub",
+        feature = "native-tls",
+        feature = "rustls-no-provider",
+        feature = "rustls-verifier"
+    )),
     all(feature = "stub", feature = "native-tls"),
     all(feature = "stub", feature = "rustls-no-provider"),
     all(feature = "rustls-no-provider", feature = "native-tls"),
@@ -33,6 +43,8 @@ pub use impl_::{
     TlsStream, negotiated, upgrade, upgrade_with_certificate_validation, upgrade_with_certificate_validation_callback,
     upgrade_with_certificate_validation_callback_for_endpoint,
 };
+#[cfg(feature = "rustls-verifier")]
+pub use rustls_verifier::rustls_client_config;
 
 /// Called when the Rustls backend cannot validate a server certificate.
 ///

--- a/crates/ironrdp-tls/src/rustls.rs
+++ b/crates/ironrdp-tls/src/rustls.rs
@@ -2,8 +2,6 @@ use std::io;
 use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
-use tokio_rustls::rustls;
-use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use tokio_rustls::rustls::pki_types::ServerName;
 
 use crate::{CertificateValidation, CertificateValidationCallback};
@@ -29,27 +27,7 @@ where
     S: Unpin + AsyncRead + AsyncWrite,
 {
     let mut tls_stream = {
-        let mut config = match certificate_validation {
-            CertificateValidation::Strict => rustls::client::ClientConfig::builder()
-                .with_root_certificates(platform_root_certificates()?)
-                .with_no_client_auth(),
-            CertificateValidation::DangerouslyAcceptInvalidCertificate => rustls::client::ClientConfig::builder()
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(danger::NoCertificateVerification))
-                .with_no_client_auth(),
-        };
-
-        // This adds support for the SSLKEYLOGFILE env variable (https://wiki.wireshark.org/TLS#using-the-pre-master-secret)
-        config.key_log = Arc::new(rustls::KeyLogFile::new());
-
-        // Disable TLS resumption because it’s not supported by some services such as CredSSP.
-        //
-        // > The CredSSP Protocol does not extend the TLS wire protocol. TLS session resumption is not supported.
-        //
-        // source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cssp/385a7489-d46b-464c-b224-f7340e308a5c
-        config.resumption = rustls::client::Resumption::disabled();
-
-        let config = Arc::new(config);
+        let config = Arc::new(crate::rustls_client_config(certificate_validation, server_name, None)?);
 
         let domain = ServerName::try_from(server_name.to_owned()).map_err(io::Error::other)?;
 
@@ -103,22 +81,7 @@ pub async fn upgrade_with_certificate_validation_callback_for_endpoint<S>(
 where
     S: Unpin + AsyncRead + AsyncWrite,
 {
-    let verifier = rustls::client::WebPkiServerVerifier::builder(Arc::new(platform_root_certificates()?))
-        .build()
-        .map_err(io::Error::other)?;
-    let verifier: Arc<dyn ServerCertVerifier> = verifier;
-    let mut config = rustls::client::ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(CallbackVerifier {
-            verifier,
-            endpoint: endpoint.to_owned(),
-            callback,
-        }))
-        .with_no_client_auth();
-    config.key_log = Arc::new(rustls::KeyLogFile::new());
-    // TLS resumption is incompatible with CredSSP.
-    config.resumption = rustls::client::Resumption::disabled();
-
+    let config = crate::rustls_client_config(CertificateValidation::Strict, endpoint, Some(callback))?;
     let domain = ServerName::try_from(server_name.to_owned()).map_err(io::Error::other)?;
     let mut tls_stream = tokio_rustls::TlsConnector::from(Arc::new(config))
         .connect(domain, stream)
@@ -149,131 +112,5 @@ pub fn negotiated<S>(stream: &TlsStream<S>) -> crate::NegotiatedTls {
         cipher_suite: connection
             .negotiated_cipher_suite()
             .map(|suite| format!("{:?}", suite.suite())),
-    }
-}
-
-fn platform_root_certificates() -> io::Result<rustls::RootCertStore> {
-    let native_certificates = rustls_native_certs::load_native_certs();
-    let mut roots = rustls::RootCertStore::empty();
-    let (added, _) = roots.add_parsable_certificates(native_certificates.certs);
-    if added == 0 {
-        return Err(io::Error::other(
-            "the platform certificate store contains no usable roots",
-        ));
-    }
-
-    Ok(roots)
-}
-
-struct CallbackVerifier {
-    verifier: Arc<dyn ServerCertVerifier>,
-    endpoint: String,
-    callback: CertificateValidationCallback,
-}
-
-impl core::fmt::Debug for CallbackVerifier {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("CallbackVerifier")
-    }
-}
-
-impl ServerCertVerifier for CallbackVerifier {
-    fn verify_server_cert(
-        &self,
-        end_entity: &rustls::pki_types::CertificateDer<'_>,
-        intermediates: &[rustls::pki_types::CertificateDer<'_>],
-        server_name: &ServerName<'_>,
-        ocsp_response: &[u8],
-        now: rustls::pki_types::UnixTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        match self
-            .verifier
-            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
-        {
-            Ok(verified) => Ok(verified),
-            Err(error) if (self.callback)(end_entity.as_ref(), &self.endpoint, &error.to_string()) => {
-                Ok(ServerCertVerified::assertion())
-            }
-            Err(error) => Err(error),
-        }
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.verifier.verify_tls12_signature(message, cert, dss)
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &rustls::pki_types::CertificateDer<'_>,
-        dss: &rustls::DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.verifier.verify_tls13_signature(message, cert, dss)
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.verifier.supported_verify_schemes()
-    }
-}
-
-mod danger {
-    use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    use tokio_rustls::rustls::{DigitallySignedStruct, Error, SignatureScheme, pki_types};
-
-    #[derive(Debug)]
-    pub(super) struct NoCertificateVerification;
-
-    impl ServerCertVerifier for NoCertificateVerification {
-        fn verify_server_cert(
-            &self,
-            _: &pki_types::CertificateDer<'_>,
-            _: &[pki_types::CertificateDer<'_>],
-            _: &pki_types::ServerName<'_>,
-            _: &[u8],
-            _: pki_types::UnixTime,
-        ) -> Result<ServerCertVerified, Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _: &[u8],
-            _: &pki_types::CertificateDer<'_>,
-            _: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            _: &[u8],
-            _: &pki_types::CertificateDer<'_>,
-            _: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            vec![
-                SignatureScheme::RSA_PKCS1_SHA1,
-                SignatureScheme::ECDSA_SHA1_Legacy,
-                SignatureScheme::RSA_PKCS1_SHA256,
-                SignatureScheme::ECDSA_NISTP256_SHA256,
-                SignatureScheme::RSA_PKCS1_SHA384,
-                SignatureScheme::ECDSA_NISTP384_SHA384,
-                SignatureScheme::RSA_PKCS1_SHA512,
-                SignatureScheme::ECDSA_NISTP521_SHA512,
-                SignatureScheme::RSA_PSS_SHA256,
-                SignatureScheme::RSA_PSS_SHA384,
-                SignatureScheme::RSA_PSS_SHA512,
-                SignatureScheme::ED25519,
-                SignatureScheme::ED448,
-            ]
-        }
     }
 }

--- a/crates/ironrdp-tls/src/rustls_verifier.rs
+++ b/crates/ironrdp-tls/src/rustls_verifier.rs
@@ -1,0 +1,179 @@
+use std::io;
+use std::sync::Arc;
+
+use tokio_rustls::rustls;
+use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use tokio_rustls::rustls::pki_types::ServerName;
+
+use crate::{CertificateValidation, CertificateValidationCallback};
+
+/// Builds the rustls client configuration used by an RDP transport.
+///
+/// A callback augments strict platform-root and server-name validation.
+/// Combining a callback with the dangerous policy is rejected because the callback would never observe a validation failure.
+pub fn rustls_client_config(
+    certificate_validation: CertificateValidation,
+    endpoint: &str,
+    callback: Option<CertificateValidationCallback>,
+) -> io::Result<rustls::ClientConfig> {
+    let verifier = server_cert_verifier(certificate_validation, endpoint, callback)?;
+    let mut config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
+    config.resumption = rustls::client::Resumption::disabled();
+    Ok(config)
+}
+
+fn server_cert_verifier(
+    certificate_validation: CertificateValidation,
+    endpoint: &str,
+    callback: Option<CertificateValidationCallback>,
+) -> io::Result<Arc<dyn ServerCertVerifier>> {
+    if callback.is_some() && certificate_validation != CertificateValidation::Strict {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "a certificate-validation callback requires strict validation",
+        ));
+    }
+
+    let verifier: Arc<dyn ServerCertVerifier> = match certificate_validation {
+        CertificateValidation::Strict => {
+            rustls::client::WebPkiServerVerifier::builder(Arc::new(platform_root_certificates()?))
+                .build()
+                .map_err(io::Error::other)?
+        }
+        CertificateValidation::DangerouslyAcceptInvalidCertificate => Arc::new(NoCertificateVerification),
+    };
+
+    Ok(match callback {
+        Some(callback) => Arc::new(CallbackVerifier {
+            verifier,
+            endpoint: endpoint.to_owned(),
+            callback,
+        }),
+        None => verifier,
+    })
+}
+
+fn platform_root_certificates() -> io::Result<rustls::RootCertStore> {
+    let native_certificates = rustls_native_certs::load_native_certs();
+    let mut roots = rustls::RootCertStore::empty();
+    let (added, _) = roots.add_parsable_certificates(native_certificates.certs);
+    if added == 0 {
+        return Err(io::Error::other(
+            "the platform certificate store contains no usable roots",
+        ));
+    }
+
+    Ok(roots)
+}
+
+struct CallbackVerifier {
+    verifier: Arc<dyn ServerCertVerifier>,
+    endpoint: String,
+    callback: CertificateValidationCallback,
+}
+
+impl core::fmt::Debug for CallbackVerifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("CallbackVerifier")
+    }
+}
+
+impl ServerCertVerifier for CallbackVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
+        intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: rustls::pki_types::UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        match self
+            .verifier
+            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
+        {
+            Ok(verified) => Ok(verified),
+            Err(error) if (self.callback)(end_entity.as_ref(), &self.endpoint, &error.to_string()) => {
+                Ok(ServerCertVerified::assertion())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.verifier.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.verifier.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.verifier.supported_verify_schemes()
+    }
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &[rustls::pki_types::CertificateDer<'_>],
+        _: &ServerName<'_>,
+        _: &[u8],
+        _: rustls::pki_types::UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA1,
+            rustls::SignatureScheme::ECDSA_SHA1_Legacy,
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}

--- a/crates/ironrdp-tls/src/rustls_verifier.rs
+++ b/crates/ironrdp-tls/src/rustls_verifier.rs
@@ -11,6 +11,10 @@ use crate::{CertificateValidation, CertificateValidationCallback};
 ///
 /// A callback augments strict platform-root and server-name validation.
 /// Combining a callback with the dangerous policy is rejected because the callback would never observe a validation failure.
+///
+/// # Panics
+///
+/// Panics if no process-level crypto provider is installed and rustls cannot unambiguously select one from the enabled provider features.
 pub fn rustls_client_config(
     certificate_validation: CertificateValidation,
     endpoint: &str,


### PR DESCRIPTION
Extract the reusable rustls verifier and client-config builder so the RDPEUDP2 reliable-UDP TLS sideband shares the primary transport's certificate-validation policy and callback semantics without selecting a TLS stream backend.

Build callback-free client configurations on the blocking pool, and run callback-based handshakes on a dedicated blocking thread, so synchronous platform trust-store access and certificate decisions cannot starve a current-thread RDPEUDP driver. Bound the TLS and RDPEMT establishment phases with dedicated timeout errors. A TLS timeout cancels the connection attempt but cannot cancel a synchronous certificate callback that is already running.

Close `SharedIo` and wake parked readers when a driver is dropped before releasing its stream, preventing aborted connection attempts from stranding detached TLS work.

Pass `UdpTlsConfig` directly through `MultitransportBootstrap::connect`, and document that `S_OK` is sent only after Soft-Sync negotiation.