### PR TITLE
fix(server): suppress result_large_err on ErrorInfoDisconnectHandle::disconnect

### DIFF
--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -707,6 +707,11 @@ impl ErrorInfoDisconnectHandle {
     /// The disconnect takes effect only after the server handles this event.
     /// Unlike [`ServerEvent::Quit`], the client is told why: it decodes the
     /// PDU and can surface `error` to the user before the connection drops.
+    #[expect(
+        clippy::result_large_err,
+        reason = "SendError<ServerEvent> hands the whole event back on a closed channel; ServerEvent's size is \
+                  driven by its largest per-channel payload (RdpdrServerMessage), not by anything this method does"
+    )]
     pub fn disconnect(&self, error: ErrorInfo) -> Result<(), mpsc::error::SendError<ServerEvent>> {
         self.sender.send(ServerEvent::Disconnect(error))
     }


### PR DESCRIPTION
## Summary

`cargo xtask check lints` is currently red on master. `ErrorInfoDisconnectHandle::disconnect` (added in #1798) returns `Result<(), mpsc::error::SendError<ServerEvent>>`, and `ServerEvent` grew past clippy's `result_large_err` threshold when #1784 added `RdpdrServerMessage`. `AutoReconnectCookieHandle::set` already carries the same error type and got a scoped `#[expect(clippy::result_large_err, ...)]` for exactly this reason; `disconnect` didn't get the matching suppression when it landed.

This adds the identical `#[expect]`, same attribute, same reason text, to `disconnect`.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Confirmed the failure reproduces on bare master before this change and clears after.

## Notes

No behavior change. `ServerEvent`'s size is driven by its largest per-channel payload regardless of this method; boxing the payload to shrink the type is a separate, larger change out of scope here.
