### PR TITLE
feat(pdu): decode the Server Heartbeat PDU on the message channel

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/heartbeat.rs
+++ b/crates/ironrdp-pdu/src/rdp/heartbeat.rs
@@ -1,0 +1,197 @@
+//! Server Heartbeat PDU.
+//!
+//! Defined in [\[MS-RDPBCGR\] 2.2.16.1].
+//!
+//! [\[MS-RDPBCGR\] 2.2.16.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/86db1222-6b5c-4001-9923-6b292e1ccb47
+
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
+};
+
+use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+
+/// Server Heartbeat PDU.
+///
+/// Sent by the server on the MCS message channel to let the client monitor
+/// connection health in real time. Only sent when no other PDU has gone out
+/// in the current heartbeat interval; the client is free to ignore `count1`
+/// and `count2`.
+///
+/// Defined in [\[MS-RDPBCGR\] 2.2.16.1].
+///
+/// [\[MS-RDPBCGR\] 2.2.16.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/86db1222-6b5c-4001-9923-6b292e1ccb47
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct HeartbeatPdu {
+    pub security_header: BasicSecurityHeader,
+    /// Seconds between Heartbeat PDUs.
+    pub period: u8,
+    /// Missed heartbeats that SHOULD trigger a client-side warning. The client MAY ignore this.
+    pub count1: u8,
+    /// Missed heartbeats after the warning that SHOULD trigger a client-side reconnect attempt.
+    /// The client MAY ignore this.
+    pub count2: u8,
+}
+
+impl HeartbeatPdu {
+    const NAME: &'static str = "HeartbeatPdu";
+
+    const FIXED_PART_SIZE: usize = BasicSecurityHeader::FIXED_PART_SIZE
+        + 1 /* reserved */
+        + 1 /* period */
+        + 1 /* count1 */
+        + 1 /* count2 */;
+}
+
+impl Encode for HeartbeatPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        self.security_header.encode(dst)?;
+        dst.write_u8(0); // reserved, MUST be zero
+        dst.write_u8(self.period);
+        dst.write_u8(self.count1);
+        dst.write_u8(self.count2);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for HeartbeatPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let security_header = BasicSecurityHeader::decode(src)?;
+
+        // MS-RDPBCGR 2.2.8.1.1.2.1 says SEC_RESET_SEQNO and SEC_IGNORE_SEQNO "MUST be
+        // ignored", so they are masked off before comparing, matching
+        // MultitransportRequestPdu/MultitransportResponsePdu's decode. What remains is
+        // compared for equality rather than `contains`, so a successful decode is a
+        // reliable signal that this really is a Heartbeat PDU and not some other
+        // message-channel traffic (auto-detect) that happens to also set SEC_HEARTBEAT
+        // alongside its own discriminator.
+        let flags = security_header
+            .flags
+            .difference(BasicSecurityHeaderFlags::RESET_SEQNO | BasicSecurityHeaderFlags::IGNORE_SEQNO);
+        if flags != BasicSecurityHeaderFlags::HEARTBEAT {
+            return Err(invalid_field_err!(
+                "securityHeader",
+                "expected securityHeader flags to contain SEC_HEARTBEAT and no other PDU-type flag",
+                in: src
+            ));
+        }
+
+        let _reserved = src.read_u8();
+        let period = src.read_u8();
+        let count1 = src.read_u8();
+        let count2 = src.read_u8();
+
+        Ok(Self {
+            security_header,
+            period,
+            count1,
+            count2,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEARTBEAT_WIRE: &[u8] = &[
+        // BasicSecurityHeader (4 bytes)
+        0x00, 0x40, // flags = HEARTBEAT (0x4000)
+        0x00, 0x00, // flagsHi = 0
+        // Payload (4 bytes)
+        0x00, // reserved
+        0x05, // period = 5 seconds
+        0x02, // count1 = 2
+        0x03, // count2 = 3
+    ];
+
+    #[test]
+    fn decode() {
+        let pdu = ironrdp_core::decode::<HeartbeatPdu>(HEARTBEAT_WIRE).unwrap();
+        assert_eq!(pdu.period, 5);
+        assert_eq!(pdu.count1, 2);
+        assert_eq!(pdu.count2, 3);
+    }
+
+    #[test]
+    fn encode() {
+        let pdu = HeartbeatPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::HEARTBEAT,
+            },
+            period: 5,
+            count1: 2,
+            count2: 3,
+        };
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(encoded.as_slice(), HEARTBEAT_WIRE);
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = HeartbeatPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::HEARTBEAT,
+            },
+            period: 30,
+            count1: 4,
+            count2: 8,
+        };
+        let encoded = ironrdp_core::encode_vec(&original).unwrap();
+        let decoded = ironrdp_core::decode::<HeartbeatPdu>(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn size() {
+        assert_eq!(HeartbeatPdu::FIXED_PART_SIZE, 8);
+    }
+
+    /// Same rationale as MultitransportRequestPdu's identical test: the spec says
+    /// these two flags MUST be ignored, and rejecting a PDU that sets them would
+    /// abort the connection over bits the peer is told to disregard.
+    #[test]
+    fn decode_ignores_the_seqno_flags() {
+        const RESET_SEQNO: u16 = 0x0010;
+        const IGNORE_SEQNO: u16 = 0x0020;
+
+        for (variant, extra) in [
+            ("SEC_RESET_SEQNO", RESET_SEQNO),
+            ("SEC_IGNORE_SEQNO", IGNORE_SEQNO),
+            ("both seqno flags", RESET_SEQNO | IGNORE_SEQNO),
+        ] {
+            let flags: u16 = 0x4000 | extra;
+            let mut wire = HEARTBEAT_WIRE.to_vec();
+            wire[0..2].copy_from_slice(&flags.to_le_bytes());
+            let pdu =
+                ironrdp_core::decode::<HeartbeatPdu>(&wire).unwrap_or_else(|e| panic!("{variant} must decode: {e}"));
+            assert_eq!(pdu.period, 5, "{variant}");
+        }
+    }
+
+    /// Mirrors MultitransportRequestPdu's cross-PDU-type rejection test: the
+    /// message channel also carries auto-detect traffic, so a bare `contains`
+    /// check on SEC_HEARTBEAT would happily accept an auto-detect PDU that
+    /// happened to also set it. The masked-equality check must reject that.
+    #[test]
+    fn decode_rejects_another_pdu_type_alongside_the_discriminator() {
+        const AUTODETECT_REQ: u16 = 0x1000;
+
+        let mut wire = HEARTBEAT_WIRE.to_vec();
+        wire[0..2].copy_from_slice(&(0x4000u16 | AUTODETECT_REQ).to_le_bytes());
+        assert!(ironrdp_core::decode::<HeartbeatPdu>(&wire).is_err());
+    }
+}

--- a/crates/ironrdp-pdu/src/rdp/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/mod.rs
@@ -10,6 +10,7 @@ pub mod capability_sets;
 pub mod client_info;
 pub mod finalization_messages;
 pub mod headers;
+pub mod heartbeat;
 pub mod multitransport;
 pub mod refresh_rectangle;
 pub mod server_error_info;

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -1,11 +1,14 @@
 use ironrdp_bulk::BulkCompressor;
-use ironrdp_core::{WriteBuf, decode};
+use ironrdp_core::{Decode as _, ReadCursor, WriteBuf, decode};
 use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DynamicChannelMut, DynamicChannelRef};
 use ironrdp_pdu::gcc::{ChannelName, Monitor};
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
 use ironrdp_pdu::rdp::client_info::CompressionType;
-use ironrdp_pdu::rdp::headers::{CompressionFlags, ShareDataCtx, ShareDataPdu};
+use ironrdp_pdu::rdp::headers::{
+    BasicSecurityHeader, BasicSecurityHeaderFlags, CompressionFlags, ShareDataCtx, ShareDataPdu,
+};
+use ironrdp_pdu::rdp::heartbeat::HeartbeatPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::rdp::session_info::{InfoData, SaveSessionInfoPdu, ServerAutoReconnect};
@@ -395,15 +398,43 @@ impl Processor {
         Ok(decompressed)
     }
 
-    /// Process an auto-detect request received on the MCS message channel.
+    /// Process a PDU received on the MCS message channel: auto-detect
+    /// ([MS-RDPBCGR] 2.2.14) or Heartbeat ([MS-RDPBCGR] 2.2.16.1).
     ///
-    /// During continuous auto-detection ([MS-RDPBCGR] 2.2.14) the server sends
-    /// RTT (and bandwidth) requests on the message channel; the client answers
-    /// RTT requests and surfaces the final Network Characteristics Result.
+    /// The two PDU families share the channel and are told apart by the
+    /// `BasicSecurityHeader` flags (masking off `SEC_RESET_SEQNO`/
+    /// `SEC_IGNORE_SEQNO`, which the spec says MUST be ignored, before
+    /// comparing), peeked here before committing to either decode. Any other
+    /// flag combination is logged and ignored rather than treated as a
+    /// session-fatal decode error: this channel is forward-safe for future
+    /// message-channel PDU types the same way the connect-time demux
+    /// (`ironrdp-connector`) already is.
     fn process_message_channel(&self, data_ctx: SendDataIndicationCtx<'_>) -> SessionResult<Vec<ProcessorOutput>> {
         let Some(message_channel_id) = self.message_channel_id else {
             return Err(reason_err!("message channel", "no message channel negotiated"));
         };
+
+        let mut peek = ReadCursor::new(data_ctx.user_data);
+        let security_header = BasicSecurityHeader::decode(&mut peek).map_err(SessionError::decode)?;
+        let flags = security_header
+            .flags
+            .difference(BasicSecurityHeaderFlags::RESET_SEQNO | BasicSecurityHeaderFlags::IGNORE_SEQNO);
+
+        if flags == BasicSecurityHeaderFlags::HEARTBEAT {
+            let heartbeat = decode::<HeartbeatPdu>(data_ctx.user_data).map_err(SessionError::decode)?;
+            debug!(
+                period = heartbeat.period,
+                count1 = heartbeat.count1,
+                count2 = heartbeat.count2,
+                "Received Heartbeat PDU"
+            );
+            return Ok(Vec::new());
+        }
+
+        if flags != BasicSecurityHeaderFlags::AUTODETECT_REQ {
+            debug!(flags = ?security_header.flags, "Unrecognized message-channel PDU, ignoring");
+            return Ok(Vec::new());
+        }
 
         let req = decode::<AutoDetectReqPdu>(data_ctx.user_data).map_err(SessionError::decode)?;
 

--- a/crates/ironrdp-testsuite-core/tests/session/heartbeat.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/heartbeat.rs
@@ -1,0 +1,113 @@
+use std::borrow::Cow;
+
+use ironrdp_core::encode_vec;
+use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
+use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest};
+use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+use ironrdp_pdu::rdp::heartbeat::HeartbeatPdu;
+use ironrdp_pdu::x224::X224;
+use ironrdp_session::x224::Processor;
+use ironrdp_svc::StaticChannelSet;
+
+const USER_CHANNEL_ID: u16 = 1002;
+const IO_CHANNEL_ID: u16 = 1003;
+const MESSAGE_CHANNEL_ID: u16 = 1004;
+const SHARE_ID: u32 = 0x0001_0000;
+
+fn make_processor() -> Processor {
+    Processor::new(
+        StaticChannelSet::new(),
+        USER_CHANNEL_ID,
+        IO_CHANNEL_ID,
+        Some(MESSAGE_CHANNEL_ID),
+        SHARE_ID,
+    )
+}
+
+fn process_frame(processor: &mut Processor, frame: &[u8]) -> Vec<ironrdp_session::x224::ProcessorOutput> {
+    let mut bulk_decompressor = None;
+    processor.process(frame, &mut bulk_decompressor).expect("process frame")
+}
+
+/// Encode a Heartbeat PDU as a server-to-client SendDataIndication on the MCS
+/// message channel ([MS-RDPBCGR] 2.2.16.1): framed by a Basic Security Header
+/// (SEC_HEARTBEAT), the same channel Auto-Detect traffic shares.
+fn encode_server_heartbeat(period: u8, count1: u8, count2: u8) -> Vec<u8> {
+    let pdu = HeartbeatPdu {
+        security_header: BasicSecurityHeader {
+            flags: BasicSecurityHeaderFlags::HEARTBEAT,
+        },
+        period,
+        count1,
+        count2,
+    };
+    let user_data = encode_vec(&pdu).unwrap();
+
+    let indication = McsMessage::SendDataIndication(SendDataIndication {
+        initiator_id: USER_CHANNEL_ID,
+        channel_id: MESSAGE_CHANNEL_ID,
+        user_data: Cow::Owned(user_data),
+    });
+
+    encode_vec(&X224(indication)).unwrap()
+}
+
+/// A Heartbeat PDU is purely informational: [MS-RDPBCGR] 2.2.16.1 defines no
+/// client response, unlike Auto-Detect RTT requests on the same channel.
+#[test]
+fn heartbeat_produces_no_response() {
+    let mut processor = make_processor();
+    let frame = encode_server_heartbeat(30, 4, 8);
+
+    let outputs = process_frame(&mut processor, &frame);
+
+    assert!(outputs.is_empty(), "Heartbeat PDU must not produce any output");
+}
+
+/// The message channel demux must still route ordinary Auto-Detect traffic
+/// correctly once it also recognizes Heartbeat: the two PDU families are told
+/// apart by security-header flags before either decode is attempted.
+#[test]
+fn autodetect_still_works_alongside_heartbeat() {
+    let mut processor = make_processor();
+
+    let heartbeat_frame = encode_server_heartbeat(30, 4, 8);
+    assert!(process_frame(&mut processor, &heartbeat_frame).is_empty());
+
+    let autodetect_pdu = AutoDetectReqPdu::new(AutoDetectRequest::rtt_continuous(7));
+    let user_data = encode_vec(&autodetect_pdu).unwrap();
+    let indication = McsMessage::SendDataIndication(SendDataIndication {
+        initiator_id: USER_CHANNEL_ID,
+        channel_id: MESSAGE_CHANNEL_ID,
+        user_data: Cow::Owned(user_data),
+    });
+    let autodetect_frame = encode_vec(&X224(indication)).unwrap();
+
+    let outputs = process_frame(&mut processor, &autodetect_frame);
+    assert_eq!(outputs.len(), 1, "RTT request must still produce a response frame");
+}
+
+/// A message-channel PDU with a flag combination this session doesn't
+/// recognize must be ignored, not treated as a session-fatal decode error:
+/// the channel is forward-safe for future MS-RDPBCGR message-channel PDU
+/// types the same way the connect-time demux already is.
+#[test]
+fn unrecognized_message_channel_pdu_is_ignored_not_fatal() {
+    let mut processor = make_processor();
+
+    // A bare BasicSecurityHeader with no recognized discriminator flag, no
+    // trailing payload.
+    let unrecognized = BasicSecurityHeader {
+        flags: BasicSecurityHeaderFlags::empty(),
+    };
+    let user_data = encode_vec(&unrecognized).unwrap();
+    let indication = McsMessage::SendDataIndication(SendDataIndication {
+        initiator_id: USER_CHANNEL_ID,
+        channel_id: MESSAGE_CHANNEL_ID,
+        user_data: Cow::Owned(user_data),
+    });
+    let frame = encode_vec(&X224(indication)).unwrap();
+
+    let outputs = process_frame(&mut processor, &frame);
+    assert!(outputs.is_empty(), "unrecognized PDU must be ignored, not error");
+}

--- a/crates/ironrdp-testsuite-core/tests/session/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/mod.rs
@@ -2,6 +2,7 @@ mod active_stage;
 mod autodetect;
 mod connection_activation;
 mod fast_path;
+mod heartbeat;
 mod rfx;
 mod save_session_info;
 


### PR DESCRIPTION
## Summary

Adds `HeartbeatPdu` (MS-RDPBCGR 2.2.16.1), decoded on the MCS message channel that #1347/#1348 wired up for Auto-Detect. The Heartbeat PDU is server-to-client only and defines no client response; the client is free to ignore `count1`/`count2`.

Fixes a real gap this exposed: the message-channel demux in `ironrdp-session` unconditionally decoded incoming traffic as an Auto-Detect Request PDU. A Heartbeat PDU arriving on the same channel would fail that decode and error the session. The demux now peeks the security-header flags first (masking `SEC_RESET_SEQNO`/`SEC_IGNORE_SEQNO`, which MS-RDPBCGR 2.2.8.1.1.2.1 says MUST be ignored, the same way `MultitransportRequestPdu`/`MultitransportResponsePdu` already do) and dispatches by the masked value. Anything it doesn't recognize is logged and ignored rather than treated as session-fatal, matching the forward-safe posture the connect-time demux in `ironrdp-connector` already has.

Multitransport Bootstrapping, the other optional feature the message channel carries, is already fully implemented (#1098); this PR is the Heartbeat half only.

## Validation

`cargo xtask check fmt/typos/tests/locks` and `wasm check` all pass. `lints` has one pre-existing failure on master unrelated to this diff (`clippy::result_large_err` on `ErrorInfoDisconnectHandle::disconnect`, fix filed as #1812); this PR's own diff is clean under the same lints run.

New tests: `HeartbeatPdu` encode/decode round-trip plus the same seqno-flag and cross-PDU-discriminator coverage `MultitransportRequestPdu` has, in `ironrdp-pdu`; a `Processor::process` integration test in `ironrdp-testsuite-core` covering the full message-channel path (Heartbeat produces no output, Auto-Detect still works alongside it, and an unrecognized PDU is ignored rather than erroring).
