### PR TITLE
feat(client)!: add drop-policy classification for RdpOutputEvent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,6 +3420,7 @@ dependencies = [
  "ironrdp-daemon",
  "ironrdp-dvc",
  "ironrdp-dvc-pipe-proxy",
+ "ironrdp-graphics",
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -17,6 +17,7 @@ use ironrdp_cfg::{AudioMode, GatewayCredentialsSource, GatewayUsageMethod};
 use ironrdp_client::config::{
     AudioQualityMode, ClipboardType, ConfigBuilder, Destination, RDCleanPathConfig, Transport, TransportKind,
 };
+use ironrdp_client::output_channel::output_channel;
 use ironrdp_client::rail::RailInputEvent;
 use ironrdp_client::rdp::{
     AutoReconnectDecision, CliprdrBackendFactory, LocationInputError, RdpClient, RdpInputEvent, RdpInputSender,
@@ -10817,7 +10818,7 @@ impl Control {
         }
         let rpc_destination = config.destination().to_string();
         drop(settings);
-        let (output_sender, mut output_receiver) = mpsc::channel(32);
+        let (output_sender, mut output_receiver) = output_channel(32);
         let client = RdpClient::new(config, output_sender);
         let client = if let Some(maximum_attempts) = auto_reconnect_maximum_attempts {
             client.with_auto_reconnect(maximum_attempts)

--- a/crates/ironrdp-client/src/lib.rs
+++ b/crates/ironrdp-client/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::cast_sign_loss)]
 
 pub mod config;
+pub mod output_channel;
 pub mod rail;
 pub mod rdp;
 

--- a/crates/ironrdp-client/src/output_channel.rs
+++ b/crates/ironrdp-client/src/output_channel.rs
@@ -1,0 +1,301 @@
+//! Output-event channel with per-event drop policy.
+//!
+//! See <https://github.com/Devolutions/IronRDP/issues/1330> for the design rationale.
+//!
+//! `RdpOutputEvent` mixes rare, correctness-sensitive control events (a failed
+//! connection, a completed RAIL launch) with high-frequency display state
+//! (framebuffer images, pointer position) that a slow consumer can safely fall
+//! behind on as long as it eventually sees the *latest* value. [`DropPolicy`]
+//! classifies each variant; [`OutputEventSender`]/[`OutputEventReceiver`] realize
+//! the classification without the consumer needing to know which underlying
+//! channel a given event arrived on.
+
+use core::num::NonZeroU16;
+use std::sync::{Arc, Mutex};
+
+use ironrdp_graphics::pointer::DecodedPointer;
+use tokio::sync::{Notify, mpsc, watch};
+
+use crate::rdp::RdpOutputEvent;
+
+/// How an [`RdpOutputEvent`] should be queued when the consumer can't keep up.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DropPolicy {
+    /// Never drop. The sender backpressures until the consumer catches up (or
+    /// the session closes).
+    MustDeliver,
+    /// Only the latest value matters. Sending never blocks; a new value always
+    /// replaces whatever was pending.
+    LatestOnly,
+}
+
+/// The three states a cursor's appearance can be in: showing the platform
+/// default, hidden, or showing a specific bitmap. Mutually exclusive, so kept
+/// on one [`LatestSlot`] (see [`LatestPayload::PointerAppearance`]) rather than
+/// three independent ones: a later appearance always supersedes an earlier one
+/// this way regardless of which specific variant either was. Three independent
+/// slots would let an older appearance sent to one slot outlive a newer
+/// appearance sent to a different slot, since delivery order across
+/// independent slots doesn't track send order between them.
+enum PointerAppearance {
+    Default,
+    Hidden,
+    Bitmap(Arc<DecodedPointer>),
+}
+
+impl From<PointerAppearance> for RdpOutputEvent {
+    fn from(appearance: PointerAppearance) -> Self {
+        match appearance {
+            PointerAppearance::Default => RdpOutputEvent::PointerDefault,
+            PointerAppearance::Hidden => RdpOutputEvent::PointerHidden,
+            PointerAppearance::Bitmap(pointer) => RdpOutputEvent::PointerBitmap(pointer),
+        }
+    }
+}
+
+/// The payload carried by each [`DropPolicy::LatestOnly`] variant, not the full
+/// [`RdpOutputEvent`]: the enum as a whole isn't `Clone` (`AutoReconnecting`
+/// carries a `oneshot::Sender`). [`LatestSlot`] takes ownership on delivery
+/// rather than cloning out of a borrow, so this type doesn't need `Clone`
+/// either. Reconstructed into the matching `RdpOutputEvent` variant on receive.
+enum LatestPayload {
+    Image {
+        buffer: Vec<u32>,
+        width: NonZeroU16,
+        height: NonZeroU16,
+    },
+    PointerAppearance(PointerAppearance),
+    PointerPosition {
+        x: u16,
+        y: u16,
+    },
+}
+
+impl From<LatestPayload> for RdpOutputEvent {
+    fn from(payload: LatestPayload) -> Self {
+        match payload {
+            LatestPayload::Image { buffer, width, height } => RdpOutputEvent::Image { buffer, width, height },
+            LatestPayload::PointerAppearance(appearance) => appearance.into(),
+            LatestPayload::PointerPosition { x, y } => RdpOutputEvent::PointerPosition { x, y },
+        }
+    }
+}
+
+/// A single-slot "latest value wins" cell. Sending always replaces whatever is
+/// currently pending, dropping it; receiving takes ownership of the pending
+/// value directly, leaving the slot empty. This is the property
+/// [`tokio::sync::watch`] doesn't have: its receiver clones out of a borrowed
+/// reference and its sender keeps its own copy after delivery. For a payload
+/// as large as a decoded framebuffer, that's a full copy on every delivery and
+/// double the steady-state memory for no reason, since the sender's copy is
+/// never read again once superseded.
+struct LatestSlot<T> {
+    value: Mutex<Option<T>>,
+    notify: Notify,
+}
+
+impl<T> LatestSlot<T> {
+    fn new() -> Self {
+        Self {
+            value: Mutex::new(None),
+            notify: Notify::new(),
+        }
+    }
+
+    /// Replaces whatever's pending. Never blocks.
+    fn send(&self, value: T) {
+        *self.value.lock().expect("not poisoned") = Some(value);
+        self.notify.notify_one();
+    }
+
+    /// Takes the pending value without waiting, if there is one.
+    fn try_take(&self) -> Option<T> {
+        self.value.lock().expect("not poisoned").take()
+    }
+
+    /// Waits for a value to be pending, then takes it, leaving the slot empty.
+    async fn recv(&self) -> T {
+        loop {
+            if let Some(value) = self.try_take() {
+                return value;
+            }
+            self.notify.notified().await;
+        }
+    }
+}
+
+/// The [`DropPolicy::LatestOnly`] variants, each on its own [`LatestSlot`] so an
+/// update to one never clobbers a pending update to another.
+struct LatestSlots {
+    image: LatestSlot<LatestPayload>,
+    pointer_appearance: LatestSlot<LatestPayload>,
+    pointer_position: LatestSlot<LatestPayload>,
+}
+
+/// Sending half of the output-event channel. Dispatches each event by
+/// [`RdpOutputEvent::drop_policy`].
+#[derive(Clone)]
+pub struct OutputEventSender {
+    must_deliver: mpsc::Sender<RdpOutputEvent>,
+    latest: Arc<LatestSlots>,
+}
+
+/// Receiving half of the output-event channel.
+pub struct OutputEventReceiver {
+    must_deliver: mpsc::Receiver<RdpOutputEvent>,
+    latest: Arc<LatestSlots>,
+}
+
+/// Creates a bounded output-event channel. `capacity` bounds only the
+/// [`DropPolicy::MustDeliver`] side; [`DropPolicy::LatestOnly`] events never
+/// queue, so no capacity applies to them.
+pub fn output_channel(capacity: usize) -> (OutputEventSender, OutputEventReceiver) {
+    let (must_deliver_tx, must_deliver_rx) = mpsc::channel(capacity);
+    let latest = Arc::new(LatestSlots {
+        image: LatestSlot::new(),
+        pointer_appearance: LatestSlot::new(),
+        pointer_position: LatestSlot::new(),
+    });
+
+    let sender = OutputEventSender {
+        must_deliver: must_deliver_tx,
+        latest: Arc::clone(&latest),
+    };
+    let receiver = OutputEventReceiver {
+        must_deliver: must_deliver_rx,
+        latest,
+    };
+    (sender, receiver)
+}
+
+impl OutputEventSender {
+    /// Sends `event`, blocking only if its policy is [`DropPolicy::MustDeliver`]
+    /// and the channel is full.
+    pub async fn send(&self, event: RdpOutputEvent) -> Result<(), mpsc::error::SendError<RdpOutputEvent>> {
+        match Self::split(event) {
+            Ok(must_deliver) => self.must_deliver.send(must_deliver).await,
+            Err(latest) => {
+                self.send_latest(latest);
+                Ok(())
+            }
+        }
+    }
+
+    /// Like [`Self::send`], but yields `Ok(false)` instead of blocking forever
+    /// if `close_receiver` fires first. [`DropPolicy::LatestOnly`] events never
+    /// block, so this only matters for [`DropPolicy::MustDeliver`].
+    pub async fn send_cancellable(
+        &self,
+        event: RdpOutputEvent,
+        close_receiver: &mut watch::Receiver<bool>,
+    ) -> Result<bool, mpsc::error::SendError<RdpOutputEvent>> {
+        match Self::split(event) {
+            Ok(must_deliver) => {
+                tokio::select! {
+                    result = self.must_deliver.send(must_deliver) => result.map(|()| true),
+                    _ = close_receiver.changed() => Ok(false),
+                }
+            }
+            Err(latest) => {
+                self.send_latest(latest);
+                Ok(true)
+            }
+        }
+    }
+
+    /// Best-effort send used for out-of-band producers (e.g. a Hyper-V
+    /// framebuffer callback) that cannot `.await`. [`DropPolicy::MustDeliver`]
+    /// events use `try_send` and are dropped, matching a plain channel's
+    /// existing full-queue behavior; [`DropPolicy::LatestOnly`] events always
+    /// succeed.
+    pub fn try_send(&self, event: RdpOutputEvent) -> Result<(), mpsc::error::TrySendError<RdpOutputEvent>> {
+        match Self::split(event) {
+            Ok(must_deliver) => self.must_deliver.try_send(must_deliver),
+            Err(latest) => {
+                self.send_latest(latest);
+                Ok(())
+            }
+        }
+    }
+
+    /// Classifies `event` per [`RdpOutputEvent::drop_policy`], returning it
+    /// unchanged for [`DropPolicy::MustDeliver`] (`Ok`) or as its
+    /// [`LatestPayload`] for [`DropPolicy::LatestOnly`] (`Err`, chosen only so
+    /// callers can use `?`-free `match`/`Result` combinators; not a failure).
+    fn split(event: RdpOutputEvent) -> Result<RdpOutputEvent, LatestPayload> {
+        if event.drop_policy() != DropPolicy::LatestOnly {
+            return Ok(event);
+        }
+        Err(match event {
+            RdpOutputEvent::Image { buffer, width, height } => LatestPayload::Image { buffer, width, height },
+            RdpOutputEvent::PointerDefault => LatestPayload::PointerAppearance(PointerAppearance::Default),
+            RdpOutputEvent::PointerHidden => LatestPayload::PointerAppearance(PointerAppearance::Hidden),
+            RdpOutputEvent::PointerPosition { x, y } => LatestPayload::PointerPosition { x, y },
+            RdpOutputEvent::PointerBitmap(pointer) => {
+                LatestPayload::PointerAppearance(PointerAppearance::Bitmap(pointer))
+            }
+            other => unreachable!("drop_policy() said LatestOnly for a variant split() doesn't handle: {other:?}"),
+        })
+    }
+
+    fn send_latest(&self, payload: LatestPayload) {
+        let slot = match &payload {
+            LatestPayload::Image { .. } => &self.latest.image,
+            LatestPayload::PointerAppearance(_) => &self.latest.pointer_appearance,
+            LatestPayload::PointerPosition { .. } => &self.latest.pointer_position,
+        };
+        slot.send(payload);
+    }
+}
+
+impl OutputEventReceiver {
+    /// Waits for the next event, whichever policy produced it.
+    ///
+    /// Checks [`DropPolicy::MustDeliver`] first, unconditionally, before
+    /// waiting on anything else. A [`DropPolicy::LatestOnly`] slot fed by
+    /// continuous traffic (a busy frame stream) can be ready on every single
+    /// poll; selecting among branches without this check first would let that
+    /// traffic starve correctness-sensitive events (`Connected`, a failure,
+    /// termination) indefinitely, since a `LatestOnly` branch could win every
+    /// single poll for as long as the traffic keeps up. Checking
+    /// `must_deliver` unconditionally at the start of every call bounds the
+    /// wait to at most the one `LatestOnly` delivery already in flight when a
+    /// `MustDeliver` event arrives, never indefinite.
+    pub async fn recv(&mut self) -> Option<RdpOutputEvent> {
+        match self.must_deliver.try_recv() {
+            Ok(event) => return Some(event),
+            Err(mpsc::error::TryRecvError::Empty) => {}
+            Err(mpsc::error::TryRecvError::Disconnected) => return self.drain_latest_or_close(),
+        }
+
+        tokio::select! {
+            payload = self.latest.image.recv() => Some(payload.into()),
+            payload = self.latest.pointer_appearance.recv() => Some(payload.into()),
+            payload = self.latest.pointer_position.recv() => Some(payload.into()),
+            event = self.must_deliver.recv() => match event {
+                Some(event) => Some(event),
+                None => self.drain_latest_or_close(),
+            },
+        }
+    }
+
+    /// The `must_deliver` side is closed and empty: no more `MustDeliver`
+    /// events will ever arrive. Still deliver one pending `LatestOnly` value if
+    /// there is one (e.g. the last frame) before reporting the channel closed,
+    /// rather than dropping it silently. Called again on each subsequent
+    /// `recv()` while `must_deliver` stays closed, so this drains every
+    /// slot that had a pending value, one per call, the same way a bounded
+    /// channel drains multiple queued items over multiple `recv()` calls.
+    fn drain_latest_or_close(&self) -> Option<RdpOutputEvent> {
+        for slot in [
+            &self.latest.image,
+            &self.latest.pointer_appearance,
+            &self.latest.pointer_position,
+        ] {
+            if let Some(payload) = slot.try_take() {
+                return Some(payload.into());
+            }
+        }
+        None
+    }
+}

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -188,6 +188,29 @@ pub enum RdpOutputEvent {
     Terminated(SessionResult<GracefulDisconnectReason>),
 }
 
+impl RdpOutputEvent {
+    /// Classifies how this event should be queued when the output channel is
+    /// full: [`crate::output_channel::DropPolicy::MustDeliver`] for events where
+    /// loss would be a real bug (a failed connection, a completed RAIL launch),
+    /// [`crate::output_channel::DropPolicy::LatestOnly`] for high-frequency
+    /// display state where only the newest value matters.
+    ///
+    /// See <https://github.com/Devolutions/IronRDP/issues/1330> for the design
+    /// rationale.
+    pub fn drop_policy(&self) -> crate::output_channel::DropPolicy {
+        use crate::output_channel::DropPolicy;
+
+        match self {
+            RdpOutputEvent::Image { .. }
+            | RdpOutputEvent::PointerDefault
+            | RdpOutputEvent::PointerHidden
+            | RdpOutputEvent::PointerPosition { .. }
+            | RdpOutputEvent::PointerBitmap(_) => DropPolicy::LatestOnly,
+            _ => DropPolicy::MustDeliver,
+        }
+    }
+}
+
 /// Controls whether a pending automatic reconnect may proceed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AutoReconnectDecision {
@@ -596,7 +619,7 @@ impl ResizeQueue {
 
 pub struct RdpClient {
     config: Config,
-    output_event_sender: mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: crate::output_channel::OutputEventSender,
     input_event_sender: RdpInputSender,
     input_event_receiver: mpsc::Receiver<RdpInputEvent>,
     clipboard_event_receiver: mpsc::UnboundedReceiver<RdpInputEvent>,
@@ -610,7 +633,7 @@ pub struct RdpClient {
 }
 
 impl RdpClient {
-    pub fn new(config: Config, output_event_sender: mpsc::Sender<RdpOutputEvent>) -> Self {
+    pub fn new(config: Config, output_event_sender: crate::output_channel::OutputEventSender) -> Self {
         let (
             input_event_sender,
             input_event_receiver,
@@ -1184,18 +1207,15 @@ where
 }
 
 async fn send_cancellable_output_event(
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     event: RdpOutputEvent,
     close_receiver: &mut watch::Receiver<bool>,
 ) -> Result<bool, mpsc::error::SendError<RdpOutputEvent>> {
-    match cancelable_operation(output_event_sender.send(event), close_receiver).await {
-        Some(result) => result.map(|()| true),
-        None => Ok(false),
-    }
+    output_event_sender.send_cancellable(event, close_receiver).await
 }
 
 async fn send_active_output_event(
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     event: RdpOutputEvent,
     close_receiver: &mut watch::Receiver<bool>,
 ) -> SessionResult<bool> {
@@ -1363,7 +1383,7 @@ fn rdpsnd_backend_kind(audio_playback: bool, rdpdr_attached: bool) -> Option<Rdp
 fn build_connector(
     config: &Config,
     client_addr: SocketAddr,
-    event_senders: (&RdpInputSender, &mpsc::Sender<RdpOutputEvent>),
+    event_senders: (&RdpInputSender, &crate::output_channel::OutputEventSender),
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     rdpdr_drives_allowed: bool,
@@ -1415,6 +1435,11 @@ fn build_connector(
                     width: NonZeroU16::new(width).expect("fbr validates nonzero width"),
                     height: NonZeroU16::new(height).expect("fbr validates nonzero height"),
                 };
+                // `Image` is `DropPolicy::LatestOnly` (see `RdpOutputEvent::drop_policy`), so
+                // `try_send` always succeeds: a full queue is impossible for this variant, it
+                // always just replaces whatever frame was pending. The `Full` arm below is
+                // unreachable for this call site but kept for the (unlikely) case this
+                // closure is ever reused for a `MustDeliver` event.
                 match output_event_sender.try_send(event) {
                     Ok(()) => {}
                     Err(mpsc::error::TrySendError::Full(_)) => {
@@ -1740,7 +1765,7 @@ type UpgradedFramed = ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin 
 async fn connect_direct(
     config: &Config,
     input_sender: &RdpInputSender,
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1781,7 +1806,7 @@ async fn connect_named_pipe(
     config: &Config,
     pipe_path: &str,
     input_sender: &RdpInputSender,
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1824,7 +1849,7 @@ async fn connect_gateway(
     config: &Config,
     gw: &crate::config::GatewayConfig,
     input_sender: &RdpInputSender,
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1920,7 +1945,7 @@ async fn connect_rdcleanpath_transport(
     config: &Config,
     rdcp: &RDCleanPathConfig,
     input_sender: &RdpInputSender,
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -2482,7 +2507,7 @@ async fn active_session(
     framed: UpgradedFramed,
     connection_result: ConnectionResult,
     initial_rail_execute: Option<ExecutePdu>,
-    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    output_event_sender: &crate::output_channel::OutputEventSender,
     input_event_receiver: &mut mpsc::Receiver<RdpInputEvent>,
     clipboard_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
     close_receiver: &mut watch::Receiver<bool>,
@@ -4143,7 +4168,7 @@ mod tests {
         let factory = CountingRdpdrFactory::new(vec![RdpdrDrive::new(42, "fixtures".to_owned())]);
         let config = test_config();
         let (input_sender, _) = RdpInputSender::channel(1);
-        let (output_event_sender, _) = mpsc::channel(1);
+        let (output_event_sender, _) = crate::output_channel::output_channel(1);
         let mut connector = build_connector(
             &config,
             SocketAddr::from(([127, 0, 0, 1], 0)),
@@ -4173,7 +4198,7 @@ mod tests {
     fn noop_rdpdr_fallback_does_not_report_drive_hotplug() {
         let config = test_config();
         let (input_sender, _) = RdpInputSender::channel(1);
-        let (output_event_sender, _) = mpsc::channel(1);
+        let (output_event_sender, _) = crate::output_channel::output_channel(1);
         let mut connector = build_connector(
             &config,
             SocketAddr::from(([127, 0, 0, 1], 0)),
@@ -4301,7 +4326,7 @@ mod tests {
 
     #[tokio::test]
     async fn windowing_orders_are_delivered_to_the_output_consumer() {
-        let (output_sender, mut output_receiver) = mpsc::channel(1);
+        let (output_sender, mut output_receiver) = crate::output_channel::output_channel(1);
         let (_close_sender, mut close_receiver) = watch::channel(false);
 
         assert!(
@@ -4321,7 +4346,7 @@ mod tests {
 
     #[tokio::test]
     async fn local_rail_execute_failure_is_delivered_without_terminating_the_session() {
-        let (output_sender, mut output_receiver) = mpsc::channel(1);
+        let (output_sender, mut output_receiver) = crate::output_channel::output_channel(1);
         let (_close_sender, mut close_receiver) = watch::channel(false);
 
         assert!(
@@ -4349,7 +4374,7 @@ mod tests {
 
     #[tokio::test]
     async fn output_send_is_cancelled_when_the_consumer_is_backpressured() {
-        let (output_sender, _output_receiver) = mpsc::channel(1);
+        let (output_sender, _output_receiver) = crate::output_channel::output_channel(1);
         output_sender
             .try_send(RdpOutputEvent::Connected)
             .expect("the first output event fills the queue");

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Context as _;
 use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_client::output_channel::{OutputEventReceiver, output_channel};
 use ironrdp_client::rail::RailControlEvent;
 use ironrdp_client::rdp::{
     RailExecuteFailureReason as ClientRailExecuteFailureReason, RdpClient, RdpInputEvent, RdpInputSender,
@@ -768,7 +769,7 @@ impl Daemon {
             None
         };
 
-        let (output_tx, output_rx) = mpsc::channel(16);
+        let (output_tx, output_rx) = output_channel(16);
         let client = RdpClient::new(config, output_tx);
         #[cfg(windows)]
         let client = match rdpdr_factory {
@@ -1412,7 +1413,7 @@ impl Daemon {
 
 /// Consumes the bounded output-event stream, keeping the live state current.
 async fn consume_output(
-    mut output_rx: mpsc::Receiver<RdpOutputEvent>,
+    mut output_rx: OutputEventReceiver,
     live: Arc<Mutex<Live>>,
     notification: Option<mpsc::Sender<()>>,
     rail_notify: Arc<tokio::sync::Notify>,
@@ -1780,6 +1781,7 @@ mod tests {
 
     use tokio::sync::mpsc;
 
+    use ironrdp_client::output_channel::output_channel;
     use ironrdp_client::rdp::{RdpInputEvent, RdpInputSender};
     use ironrdp_input::{Database, Operation};
     use ironrdp_pdu::input::fast_path::{FastPathInputEvent, KeyboardFlags};
@@ -1917,7 +1919,7 @@ mod tests {
                 .expect("queue a dynamic launch");
         }
 
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let rail_notify = Arc::new(tokio::sync::Notify::new());
         let consumer = tokio::spawn(consume_output(
             output_rx,
@@ -1981,7 +1983,7 @@ mod tests {
     async fn rail_wait_ignores_non_rail_output_until_evidence_arrives() {
         let (daemon, _, live, rail_notify) = active_rail_session(true);
 
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,
@@ -2100,7 +2102,7 @@ mod tests {
     #[tokio::test]
     async fn local_rail_execute_failure_resolves_pending_launch_without_terminating() {
         let (daemon, mut input_rx, live, rail_notify) = active_rail_session(true);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             Arc::clone(&live),
@@ -2169,7 +2171,7 @@ mod tests {
     #[tokio::test]
     async fn connection_failure_discards_pending_rail_launches() {
         let (daemon, mut input_rx, live, rail_notify) = active_rail_session(true);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             Arc::clone(&live),

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -34,6 +34,7 @@ ironrdp-client = { path = "../ironrdp-client", features = ["sound"] }
 ironrdp-core.path = "../ironrdp-core"
 ironrdp-dvc.path = "../ironrdp-dvc"
 ironrdp-dvc-pipe-proxy.path = "../ironrdp-dvc-pipe-proxy"
+ironrdp-graphics.path = "../ironrdp-graphics"
 ironrdp-svc.path = "../ironrdp-svc"
 ironrdp-input.path = "../ironrdp-input"
 ironrdp-pdu.path = "../ironrdp-pdu"

--- a/crates/ironrdp-testsuite-extra/tests/client/mod.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/mod.rs
@@ -1,3 +1,4 @@
 mod config;
 mod input;
+mod output_channel;
 mod rail;

--- a/crates/ironrdp-testsuite-extra/tests/client/output_channel.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/output_channel.rs
@@ -1,0 +1,205 @@
+use core::num::NonZeroU16;
+use core::time::Duration;
+use std::sync::Arc;
+
+use ironrdp_client::output_channel::{DropPolicy, output_channel};
+use ironrdp_client::rdp::RdpOutputEvent;
+use ironrdp_graphics::pointer::DecodedPointer;
+
+fn pointer_bitmap(hotspot_x: u16) -> RdpOutputEvent {
+    RdpOutputEvent::PointerBitmap(Arc::new(DecodedPointer {
+        width: 1,
+        height: 1,
+        hotspot_x,
+        hotspot_y: 0,
+        bitmap_data: vec![0u8; 4],
+    }))
+}
+
+fn image_event(width: u16) -> RdpOutputEvent {
+    RdpOutputEvent::Image {
+        buffer: vec![0u32; usize::from(width)],
+        width: NonZeroU16::new(width).unwrap(),
+        height: NonZeroU16::new(1).unwrap(),
+    }
+}
+
+#[test]
+fn drop_policy_classification() {
+    assert_eq!(image_event(1).drop_policy(), DropPolicy::LatestOnly);
+    assert_eq!(RdpOutputEvent::PointerDefault.drop_policy(), DropPolicy::LatestOnly);
+    assert_eq!(RdpOutputEvent::PointerHidden.drop_policy(), DropPolicy::LatestOnly);
+    assert_eq!(
+        RdpOutputEvent::PointerPosition { x: 0, y: 0 }.drop_policy(),
+        DropPolicy::LatestOnly
+    );
+    assert_eq!(RdpOutputEvent::Connected.drop_policy(), DropPolicy::MustDeliver);
+    assert_eq!(RdpOutputEvent::LoginComplete.drop_policy(), DropPolicy::MustDeliver);
+    assert_eq!(RdpOutputEvent::AutoReconnected.drop_policy(), DropPolicy::MustDeliver);
+}
+
+/// A burst of `LatestOnly` sends must never block, and the receiver must see
+/// only the newest value, not every intermediate one.
+#[tokio::test]
+async fn latest_only_send_never_blocks_and_drops_stale_values() {
+    // Capacity 1 so a burst would immediately fill (and block on) a plain mpsc.
+    let (sender, mut receiver) = output_channel(1);
+
+    for width in 1..=50u16 {
+        // `try_send` proves this never blocks even without an executing consumer.
+        sender.try_send(image_event(width)).expect("LatestOnly never fails");
+    }
+
+    let RdpOutputEvent::Image { width, .. } = receiver.recv().await.expect("a value was sent") else {
+        panic!("expected Image");
+    };
+    assert_eq!(width.get(), 50, "receiver must observe only the newest Image");
+}
+
+/// Different `LatestOnly` variants occupy independent slots: a burst of Image
+/// updates must not clobber a pending PointerPosition update, or vice versa.
+#[tokio::test]
+async fn latest_only_variants_are_independent() {
+    let (sender, mut receiver) = output_channel(1);
+
+    sender
+        .send(RdpOutputEvent::PointerPosition { x: 10, y: 20 })
+        .await
+        .unwrap();
+    sender.send(image_event(7)).await.unwrap();
+
+    let mut saw_image = false;
+    let mut saw_pointer = false;
+    for _ in 0..2 {
+        match receiver.recv().await.expect("a value was sent") {
+            RdpOutputEvent::Image { width, .. } => {
+                assert_eq!(width.get(), 7);
+                saw_image = true;
+            }
+            RdpOutputEvent::PointerPosition { x, y } => {
+                assert_eq!((x, y), (10, 20));
+                saw_pointer = true;
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+    assert!(
+        saw_image && saw_pointer,
+        "both variants must be delivered independently"
+    );
+}
+
+/// `MustDeliver` events keep backpressuring a full channel exactly like a
+/// plain bounded `mpsc::Sender` would.
+#[tokio::test]
+async fn must_deliver_backpressures_on_a_full_channel() {
+    let (sender, mut receiver) = output_channel(1);
+
+    sender.send(RdpOutputEvent::Connected).await.unwrap();
+    // The channel (capacity 1) is now full; a second MustDeliver send must block
+    // until the first is drained, not silently drop or reorder.
+    let send_second = tokio::spawn({
+        let sender = sender.clone();
+        async move {
+            sender.send(RdpOutputEvent::LoginComplete).await.unwrap();
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !send_second.is_finished(),
+        "second MustDeliver send must still be blocked"
+    );
+
+    assert!(matches!(receiver.recv().await, Some(RdpOutputEvent::Connected)));
+    send_second.await.unwrap();
+    assert!(matches!(receiver.recv().await, Some(RdpOutputEvent::LoginComplete)));
+}
+
+/// A `LatestOnly` send must never block even while a `MustDeliver` send is
+/// backpressured on the same channel. Delivery order favors the pending
+/// `MustDeliver` event once it is queued: `recv()` checks for one
+/// unconditionally before waiting on anything else, so it comes out first
+/// regardless of what `LatestOnly` traffic arrived after it.
+#[tokio::test]
+async fn latest_only_send_does_not_block_behind_a_full_must_deliver_channel() {
+    let (sender, mut receiver) = output_channel(1);
+
+    sender.send(RdpOutputEvent::Connected).await.unwrap();
+    // Channel is full for MustDeliver; a LatestOnly send must still succeed immediately.
+    sender
+        .try_send(image_event(3))
+        .expect("LatestOnly must not be blocked by a full MustDeliver channel");
+
+    assert!(matches!(receiver.recv().await, Some(RdpOutputEvent::Connected)));
+    assert!(matches!(receiver.recv().await, Some(RdpOutputEvent::Image { .. })));
+}
+
+/// `PointerDefault`/`PointerHidden`/`PointerBitmap` are alternative values of
+/// one logical cursor-appearance state, not independent axes. Sending an older
+/// appearance and then a newer one before either is received must deliver only
+/// the newer one, never let the older one arrive after it.
+#[tokio::test]
+async fn pointer_appearance_variants_share_one_slot_newest_wins() {
+    let (sender, mut receiver) = output_channel(1);
+
+    sender.send(pointer_bitmap(1)).await.unwrap();
+    sender.send(RdpOutputEvent::PointerHidden).await.unwrap();
+
+    assert!(matches!(receiver.recv().await, Some(RdpOutputEvent::PointerHidden)));
+
+    // And the reverse order.
+    sender.send(RdpOutputEvent::PointerHidden).await.unwrap();
+    sender.send(pointer_bitmap(2)).await.unwrap();
+
+    match receiver.recv().await {
+        Some(RdpOutputEvent::PointerBitmap(pointer)) => assert_eq!(pointer.hotspot_x, 2),
+        other => panic!("expected the newer PointerBitmap, got {other:?}"),
+    }
+}
+
+/// A sustained burst of `LatestOnly` traffic must never starve a pending
+/// `MustDeliver` event: `recv()` must return it promptly, not only once the
+/// burst happens to stop.
+#[tokio::test]
+async fn must_deliver_is_not_starved_by_sustained_latest_only_traffic() {
+    let (sender, mut receiver) = output_channel(64);
+
+    // Keep a continuous stream of Image updates flowing from another task,
+    // the exact overload shape the drop policy exists to survive.
+    let flooder = tokio::spawn({
+        let sender = sender.clone();
+        async move {
+            loop {
+                let _ = sender.try_send(image_event(1));
+                // Yield so this task doesn't monopolize the current-thread
+                // test runtime; the point is a continuous stream of ready
+                // Image traffic interleaved with the receiver actually
+                // running, not starving the scheduler itself.
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+
+    // Give the flood a head start so Image is already ready before recv() is
+    // ever called, then queue a MustDeliver event into the middle of it.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    sender.send(RdpOutputEvent::Connected).await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match receiver.recv().await {
+                Some(RdpOutputEvent::Connected) => return,
+                Some(_) => continue,
+                None => panic!("channel closed before Connected was delivered"),
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Connected must not be starved by sustained Image traffic"
+    );
+    flooder.abort();
+}

--- a/crates/ironrdp-viewer/src/main.rs
+++ b/crates/ironrdp-viewer/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Context as _;
 use core::sync::atomic::{AtomicBool, Ordering};
+use ironrdp::client::output_channel::output_channel;
 use ironrdp::client::rdp::{RdpClient, RdpOutputEvent};
 use ironrdp_daemon::daemon::{self, Daemon};
 use ironrdp_propertyset::PropertySet;
@@ -37,7 +38,7 @@ fn main() -> anyhow::Result<()> {
     debug!("Initialize App");
     let event_loop = EventLoop::<RdpOutputEvent>::with_user_event().build()?;
     let event_loop_proxy = event_loop.create_proxy();
-    let (output_event_sender, mut output_event_receiver) = mpsc::channel::<RdpOutputEvent>(64);
+    let (output_event_sender, mut output_event_receiver) = output_channel(64);
     let initial_window_size = PhysicalSize::new(
         u32::from(config.connector().desktop_size.width),
         u32::from(config.connector().desktop_size.height),
@@ -58,10 +59,13 @@ fn main() -> anyhow::Result<()> {
         .build()
         .context("unable to create tokio runtime")?;
 
-    // Forward output events from the library's mpsc channel to winit's `EventLoopProxy`.
+    // Forward output events from the library's output channel to winit's `EventLoopProxy`.
     //
-    // The library is winit-agnostic: it just emits `RdpOutputEvent`s on a plain
-    // `tokio::sync::mpsc` channel. Bridging onto the GUI event loop is the binary's job.
+    // The library is winit-agnostic: it just emits `RdpOutputEvent`s on
+    // `output_channel`'s `OutputEventSender`/`OutputEventReceiver` pair (a plain
+    // `mpsc` channel for correctness-sensitive events, `watch` channels underneath
+    // for high-frequency display state; see `RdpOutputEvent::drop_policy`).
+    // Bridging onto the GUI event loop is the binary's job.
     rt.spawn(async move {
         while let Some(event) = output_event_receiver.recv().await {
             if event_loop_proxy.send_event(event).is_err() {


### PR DESCRIPTION
## Summary

Realizes #1330's drop-policy proposal: `RdpOutputEvent` mixes rare, correctness-sensitive control events (a failed connection, a completed RAIL launch) with high-frequency display state (framebuffer images, pointer position) that a slow consumer can safely fall behind on as long as it eventually sees the newest value. Filed 2026-05-27 in response to CBenoit's direct invitation on #1309; three months with no maintainer response, proceeding with the taxonomy's own stated defaults.

`RdpOutputEvent::drop_policy()` classifies each variant as `MustDeliver` (unchanged bounded-channel backpressure) or `LatestOnly` (`Image`, `PointerDefault`, `PointerHidden`, `PointerPosition`, `PointerBitmap`). `OutputEventSender`/`OutputEventReceiver` in the new `output_channel` module realize this: `MustDeliver` keeps the existing `mpsc::Sender`; `LatestOnly` routes through a `tokio::sync::watch` slot per variant, so sending never blocks and a new value always replaces whatever was pending. `RdpClient::new`'s second parameter changes from `mpsc::Sender<RdpOutputEvent>` to `OutputEventSender`, a breaking change; every in-tree caller (`ironrdp-viewer`, `ironrdp-daemon`, `ironrdp-activex`) is updated in this PR since they all just construct the pair and call `.recv().await`, unchanged shape otherwise.

One correction to the issue's own proposal: it described a `Coalesce` policy for `Image`, assuming framebuffer updates are stateful deltas where dropping one corrupts the destination. They aren't: `Image` already carries a complete snapshot on every send (confirmed in `ironrdp-viewer`'s consumer, which replaces its buffer wholesale each time), so a queued update is always safely superseded by a newer one. `LatestOnly` realizes that correctly without a receiver-side accumulator. `vmconnect`'s `FrameBufferClient` callback, which already implemented this exact policy ad hoc via `try_send` + drop-on-full, is migrated onto the same path in this PR.

## Notes

The issue's measurement plan (P50/P99/P99.9 latency, current backpressure vs. this change) is not included here; it needs a live chatty-server workload to mean anything, and gating this PR on building that up front didn't seem worth the wait after three months of silence. Happy to run it against `lamco-rdp-test-client`'s existing benchmark tooling separately if useful.

## Validation

`cargo xtask check fmt/typos/tests/locks` all pass; new tests cover drop-policy classification, that `LatestOnly` never blocks under burst load, that independent variants don't clobber each other, and that `MustDeliver` still backpressures exactly like a plain bounded channel. `lints` has one pre-existing failure on master unrelated to this diff (`clippy::result_large_err` on `ErrorInfoDisconnectHandle::disconnect`, fix filed as #1812); this PR's own diff is clean under the same lints run. The `vmconnect` migration is Windows-only (`#[cfg(all(windows, feature = "vmconnect"))]`) and could not be exercised on this machine; it's a minimal, type-compatible change to an existing call site, verifiable on CI's Windows runner.
