### PR TITLE
fix(input): clamp wheel rotation units to the wire's 9-bit range

### DIFF
--- a/crates/ironrdp-input/src/lib.rs
+++ b/crates/ironrdp-input/src/lib.rs
@@ -278,7 +278,15 @@ impl Database {
                     } else {
                         PointerFlags::HORIZONTAL_WHEEL
                     },
-                    number_of_wheel_rotation_units: rotations.rotation_units,
+                    // A single OS scroll event can report a delta beyond the wire's
+                    // representable range (e.g. a fast trackpad fling), so clamp here
+                    // rather than passing it through: this is the single call site
+                    // every frontend (winit viewer, ActiveX control, daemon) funnels
+                    // through, so clamping once here covers all of them.
+                    number_of_wheel_rotation_units: rotations.rotation_units.clamp(
+                        *MousePdu::WHEEL_ROTATION_RANGE.start(),
+                        *MousePdu::WHEEL_ROTATION_RANGE.end(),
+                    ),
                     x_position: self.mouse_position.x,
                     y_position: self.mouse_position.y,
                 })),

--- a/crates/ironrdp-pdu/src/input/mouse.rs
+++ b/crates/ironrdp-pdu/src/input/mouse.rs
@@ -14,6 +14,16 @@ impl MousePdu {
     const NAME: &'static str = "MousePdu";
 
     const FIXED_PART_SIZE: usize = 2 /* flags */ + 2 /* x */ + 2 /* y */;
+
+    /// `number_of_wheel_rotation_units`'s wire representation is 9-bit two's
+    /// complement (MS-RDPBCGR 2.2.8.1.1.3.1.1.3, WheelRotationMask), narrower
+    /// than `i16`. Callers constructing a wheel event should clamp to this
+    /// range rather than passing an out-of-range value through: [`encode`]
+    /// only debug-asserts it, so a value outside this range panics in debug
+    /// builds and silently wraps (truncating cast) in release builds.
+    ///
+    /// [`encode`]: Self::encode
+    pub const WHEEL_ROTATION_RANGE: core::ops::RangeInclusive<i16> = -256..=255;
 }
 
 impl Encode for MousePdu {
@@ -26,11 +36,10 @@ impl Encode for MousePdu {
             PointerFlags::empty().bits()
         };
 
-        // The wire field is 9-bit two's complement: representable range is
-        // [-256, 255], narrower than i16.
         debug_assert!(
-            (-256..=255).contains(&self.number_of_wheel_rotation_units),
-            "number_of_wheel_rotation_units out of the 9-bit two's-complement range [-256, 255]: {}",
+            Self::WHEEL_ROTATION_RANGE.contains(&self.number_of_wheel_rotation_units),
+            "number_of_wheel_rotation_units out of the 9-bit two's-complement range {:?}: {}",
+            Self::WHEEL_ROTATION_RANGE,
             self.number_of_wheel_rotation_units
         );
 

--- a/crates/ironrdp-testsuite-core/tests/input/fastpath_packets.rs
+++ b/crates/ironrdp-testsuite-core/tests/input/fastpath_packets.rs
@@ -328,3 +328,36 @@ fn wheel_rotations() {
 
     assert_eq!(actual_inputs.as_slice(), expected_inputs.as_slice());
 }
+
+#[rstest]
+#[case(300, 255)]
+#[case(-300, -256)]
+#[case(i16::MAX, 255)]
+#[case(i16::MIN, -256)]
+#[case(255, 255)]
+#[case(-256, -256)]
+fn wheel_rotations_out_of_range_is_clamped(#[case] rotation_units: i16, #[case] expected: i16) {
+    // A single OS scroll event (fast trackpad fling, etc.) can report a delta beyond
+    // the wire's 9-bit two's-complement range (MS-RDPBCGR 2.2.8.1.1.3.1.1.3,
+    // WheelRotationMask, representable range [-256, 255]). `Database::apply` must
+    // clamp rather than pass it through: `MousePdu::encode` only debug_asserts the
+    // range, so an out-of-range value panics in debug builds and silently wraps
+    // (via a truncating cast) in release builds.
+    let mut db = Database::default();
+
+    let packets = db.apply(core::iter::once(Operation::WheelRotations(WheelRotations {
+        is_vertical: true,
+        rotation_units,
+    })));
+    let packet = packets.into_iter().next().expect("one input event");
+
+    assert_eq!(
+        packet,
+        FastPathInputEvent::MouseEvent(MousePdu {
+            flags: PointerFlags::VERTICAL_WHEEL,
+            number_of_wheel_rotation_units: expected,
+            x_position: 0,
+            y_position: 0,
+        })
+    );
+}


### PR DESCRIPTION
Fixes #1816.

A single OS scroll event can report a wheel delta larger than the wire can
carry: `number_of_wheel_rotation_units` is a 9-bit two's-complement field
(MS-RDPBCGR 2.2.8.1.1.3.1.1.3, WheelRotationMask), representable range
[-256, 255], narrower than the `i16` it's stored in. `MousePdu::encode`
already documents this and `debug_assert!`s it, but nothing enforced it at
the point the value is constructed, so a fast trackpad fling (reported as
several lines per event) trivially exceeds the range: `-3.0 * 100 = -300`
in the reporter's case.

Because the guard is a `debug_assert!`, this only panics in debug builds.
In release, the out-of-range value truncates via the existing `as u8` cast
in `encode`, silently wrapping mod 256 instead of panicking: worse than a
crash, since it sends a wrong scroll delta to the server with no signal
anything went wrong.

`ironrdp-input`'s `Database::apply` is the single call site every client
frontend (winit viewer, ActiveX control, daemon) funnels a `WheelRotations`
operation through on its way to `MousePdu`, so it's the one place to clamp
rather than patching each frontend's own delta conversion separately. Added
`MousePdu::WHEEL_ROTATION_RANGE` as a shared public constant so the encode
side's assertion and the input side's clamp can't drift apart, and use it
from both.
