### PR TITLE
fix(mstsgu): support RPCH IN authentication probes

### DIFF
--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -2234,7 +2234,7 @@ mod tests {
     #[tokio::test]
     async fn connection_failure_status_preserves_gateway_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,
@@ -2271,7 +2271,7 @@ mod tests {
     #[tokio::test]
     async fn terminated_error_status_preserves_session_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,

--- a/crates/ironrdp-mstsgu/src/rpc_transport.rs
+++ b/crates/ironrdp-mstsgu/src/rpc_transport.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use crate::{Error, GwErrorKind};
 
 const MAX_RESPONSE_HEADERS: usize = 16 * 1024;
+const MAX_AUTH_RESPONSE_BODY: u32 = 16 * 1024;
 
 /// The TS Proxy RPC interface UUID advertised in `Pragma: ResourceTypeUuid`.
 ///
@@ -42,8 +43,7 @@ pub(crate) struct RpchRequestHead<'a> {
 /// An RPCH IN request whose streaming body is committed after authentication.
 ///
 /// Authentication probes use a zero-length request body.
-/// The final authenticated request reserves the channel-lifetime body length before
-/// the caller writes any RPC bytes.
+/// The final authenticated request reserves the full body length before the caller writes any RPC bytes.
 pub(crate) struct RpchInRequest<S> {
     stream: S,
     host: String,
@@ -89,13 +89,22 @@ where
 
     /// Reads the response to the current request head.
     ///
-    /// Error bodies from authentication challenges are drained before a retry can
-    /// reuse the connection.
+    /// Bounded authentication challenge bodies are drained before a retry can reuse the connection.
     pub(crate) async fn receive_response(&mut self) -> Result<RpchResponseHead, Error> {
         let response = read_rpch_response_head(&mut self.stream).await?;
-        if response.status == 401
-            && let Some(length) = response.content_length
-        {
+        if response.status == 401 {
+            let length = response.content_length.ok_or_else(|| {
+                Error::new(
+                    "rpch authentication response missing content length",
+                    GwErrorKind::Decode,
+                )
+            })?;
+            if length > MAX_AUTH_RESPONSE_BODY {
+                return Err(Error::new(
+                    "rpch authentication response body exceeds limit",
+                    GwErrorKind::Decode,
+                ));
+            }
             drain_body(&mut self.stream, length).await?;
         }
         Ok(response)
@@ -109,14 +118,12 @@ where
             return Err(Error::new("rpch IN retry after body", GwErrorKind::Connect));
         }
 
-        let host = self.host.clone();
-        let target = self.target.clone();
         write_rpch_request_head(
             &mut self.stream,
             RpchRequestHead {
                 method: "RPC_IN_DATA",
-                host: &host,
-                target: &target,
+                host: &self.host,
+                target: &self.target,
                 content_length,
                 authorization,
                 cookie: None,

--- a/crates/ironrdp-mstsgu/src/rpc_transport.rs
+++ b/crates/ironrdp-mstsgu/src/rpc_transport.rs
@@ -39,6 +39,131 @@ pub(crate) struct RpchRequestHead<'a> {
     pub(crate) expect_continue: bool,
 }
 
+/// An RPCH IN request whose streaming body is committed after authentication.
+///
+/// Authentication probes use a zero-length request body.
+/// The final authenticated request reserves the channel-lifetime body length before
+/// the caller writes any RPC bytes.
+pub(crate) struct RpchInRequest<S> {
+    stream: S,
+    host: String,
+    target: String,
+    remaining: u32,
+    body_committed: bool,
+}
+
+impl<S> RpchInRequest<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Opens the IN channel with a zero-length authentication probe.
+    pub(crate) async fn open(
+        mut stream: S,
+        host: &str,
+        target: &str,
+        authorization: Option<&str>,
+    ) -> Result<Self, Error> {
+        write_rpch_request_head(
+            &mut stream,
+            RpchRequestHead {
+                method: "RPC_IN_DATA",
+                host,
+                target,
+                content_length: 0,
+                authorization,
+                cookie: None,
+                session_id: None,
+                expect_continue: false,
+            },
+        )
+        .await?;
+
+        Ok(Self {
+            stream,
+            host: host.to_owned(),
+            target: target.to_owned(),
+            remaining: 0,
+            body_committed: false,
+        })
+    }
+
+    /// Reads the response to the current request head.
+    ///
+    /// Error bodies from authentication challenges are drained before a retry can
+    /// reuse the connection.
+    pub(crate) async fn receive_response(&mut self) -> Result<RpchResponseHead, Error> {
+        let response = read_rpch_response_head(&mut self.stream).await?;
+        if response.status == 401
+            && let Some(length) = response.content_length
+        {
+            drain_body(&mut self.stream, length).await?;
+        }
+        Ok(response)
+    }
+
+    /// Retries the request head after an authentication challenge.
+    ///
+    /// A nonzero `content_length` commits the streaming body.
+    pub(crate) async fn retry(mut self, authorization: Option<&str>, content_length: u32) -> Result<Self, Error> {
+        if self.body_committed {
+            return Err(Error::new("rpch IN retry after body", GwErrorKind::Connect));
+        }
+
+        let host = self.host.clone();
+        let target = self.target.clone();
+        write_rpch_request_head(
+            &mut self.stream,
+            RpchRequestHead {
+                method: "RPC_IN_DATA",
+                host: &host,
+                target: &target,
+                content_length,
+                authorization,
+                cookie: None,
+                session_id: None,
+                expect_continue: false,
+            },
+        )
+        .await?;
+        self.remaining = content_length;
+        self.body_committed = content_length != 0;
+
+        Ok(self)
+    }
+
+    /// Writes bytes into the committed streaming body.
+    pub(crate) async fn write_body(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        if !self.body_committed {
+            return Err(Error::new("rpch IN body before authentication", GwErrorKind::Connect));
+        }
+
+        let length = u32::try_from(bytes.len()).map_err(|_| Error::new("rpch IN body length", GwErrorKind::Encode))?;
+        if length > self.remaining {
+            return Err(Error::new("rpch IN body exceeds content length", GwErrorKind::Encode));
+        }
+
+        self.stream
+            .write_all(bytes)
+            .await
+            .map_err(|error| custom_err!("write rpch IN body", error))?;
+        self.remaining -= length;
+
+        Ok(())
+    }
+
+    pub(crate) const fn remaining(&self) -> u32 {
+        self.remaining
+    }
+
+    /// Flushes buffered body bytes to the gateway.
+    pub(crate) async fn flush(&mut self) -> Result<(), Error> {
+        self.stream
+            .flush()
+            .await
+            .map_err(|error| custom_err!("flush rpch IN body", error))
+    }
+}
+
 /// Writes an RPCH IN or OUT channel request head without committing any body bytes.
 ///
 /// Callers that set `expect_continue` must wait for `100 Continue` before
@@ -137,7 +262,10 @@ fn validate_request_head(head: &RpchRequestHead<'_>) -> Result<Option<uuid::Uuid
         .map_err(|_| Error::new("invalid RPCH session ID", GwErrorKind::Encode))?;
 
     match head.method {
-        "RPC_IN_DATA" if !(MIN_IN_CONTENT_LENGTH..=MAX_IN_CONTENT_LENGTH).contains(&head.content_length) => {
+        "RPC_IN_DATA"
+            if head.content_length != 0
+                && !(MIN_IN_CONTENT_LENGTH..=MAX_IN_CONTENT_LENGTH).contains(&head.content_length) =>
+        {
             Err(Error::new("invalid RPCH IN content length", GwErrorKind::Encode))
         }
         "RPC_OUT_DATA" if !matches!(head.content_length, 76 | 120) => {

--- a/crates/ironrdp-mstsgu/tests/rpch_http.rs
+++ b/crates/ironrdp-mstsgu/tests/rpch_http.rs
@@ -274,6 +274,62 @@ async fn in_authentication_probe_precedes_the_committed_body() {
 }
 
 #[tokio::test]
+async fn in_authentication_response_requires_a_bounded_body() {
+    for response in [
+        b"HTTP/1.1 401 Unauthorized\r\n\r\n".as_slice(),
+        b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 16385\r\n\r\n",
+    ] {
+        let (client, mut server) = tokio::io::duplex(4096);
+        let server_task = tokio::spawn(async move {
+            server.write_all(response).await.expect("write authentication response");
+        });
+
+        let mut request = rpc_transport::RpchInRequest::open(client, "gateway.example", "target.example:3389", None)
+            .await
+            .expect("open authentication probe");
+        let error = request
+            .receive_response()
+            .await
+            .expect_err("reject unbounded authentication response");
+        assert_eq!(error.kind().to_string(), "decode");
+        server_task.await.expect("join server");
+    }
+}
+
+#[tokio::test]
+async fn in_authentication_response_drains_body_at_limit() {
+    let (client, mut server) = tokio::io::duplex(32 * 1024);
+    let server_task = tokio::spawn(async move {
+        server
+            .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 16384\r\n\r\n")
+            .await
+            .expect("write authentication response head");
+        server
+            .write_all(&[b'x'; 16 * 1024])
+            .await
+            .expect("write authentication response body");
+        server
+            .write_all(b"HTTP/1.1 200 OK\r\n\r\n")
+            .await
+            .expect("write following response");
+    });
+
+    let mut request = rpc_transport::RpchInRequest::open(client, "gateway.example", "target.example:3389", None)
+        .await
+        .expect("open authentication probe");
+    assert_eq!(request.receive_response().await.expect("read challenge").status, 401);
+    assert_eq!(
+        request
+            .receive_response()
+            .await
+            .expect("read following response")
+            .status,
+        200
+    );
+    server_task.await.expect("join server");
+}
+
+#[tokio::test]
 async fn request_head_rejects_expect_continue_for_out_channel() {
     let (mut client, _) = tokio::io::duplex(4096);
     assert!(

--- a/crates/ironrdp-mstsgu/tests/rpch_http.rs
+++ b/crates/ironrdp-mstsgu/tests/rpch_http.rs
@@ -8,6 +8,7 @@ type Error = ironrdp_error::Error<GwErrorKind>;
 
 #[derive(Debug)]
 enum GwErrorKind {
+    Connect,
     PacketEof,
     Custom,
     Encode,
@@ -32,6 +33,7 @@ impl GwErrorExt for Error {
 impl fmt::Display for GwErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            Self::Connect => "connection error",
             Self::PacketEof => "packet EOF",
             Self::Custom => "custom",
             Self::Encode => "encode",
@@ -212,7 +214,7 @@ async fn request_head_rejects_invalid_values_before_writing() {
 #[tokio::test]
 async fn request_head_rejects_invalid_rpch_content_lengths() {
     for (method, content_length) in [
-        ("RPC_IN_DATA", 128 * 1024 - 1),
+        ("RPC_IN_DATA", 1),
         ("RPC_IN_DATA", 2 * 1024 * 1024 * 1024 + 1),
         ("RPC_OUT_DATA", 75),
         ("RPC_OUT_DATA", 77),
@@ -236,6 +238,39 @@ async fn request_head_rejects_invalid_rpch_content_lengths() {
             .is_err()
         );
     }
+}
+
+#[tokio::test]
+async fn in_authentication_probe_precedes_the_committed_body() {
+    let (client, mut server) = tokio::io::duplex(4096);
+    let server_task = tokio::spawn(async move {
+        assert!(read_head(&mut server).await.contains("Content-Length: 0"));
+        server
+            .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 4\r\n\r\ndeny")
+            .await
+            .expect("write authentication challenge");
+        let request = read_head(&mut server).await;
+        assert!(request.contains("Content-Length: 131072"));
+        assert!(request.contains("Authorization: NTLM token"));
+        let mut body = [0; 4];
+        server.read_exact(&mut body).await.expect("read committed body");
+        assert_eq!(body, *b"B1!!");
+    });
+
+    let mut request = rpc_transport::RpchInRequest::open(client, "gateway.example", "target.example:3389", None)
+        .await
+        .expect("open authentication probe");
+    assert!(request.write_body(b"B1!!").await.is_err());
+    assert_eq!(request.receive_response().await.expect("read challenge").status, 401);
+    request = request
+        .retry(Some("NTLM token"), 128 * 1024)
+        .await
+        .expect("commit authenticated request");
+    request.write_body(b"B1!!").await.expect("write body");
+    assert_eq!(request.remaining(), 128 * 1024 - 4);
+    assert!(request.write_body(&vec![0; 128 * 1024]).await.is_err());
+    request.flush().await.expect("flush body");
+    server_task.await.expect("join server");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Allow raw RPCH IN framing to authenticate with a zero-length probe before committing the channel-lifetime request body.

Require a declared 401 response body no larger than 16 KiB before draining it, so retries occur only on a reusable connection. The internal request wrapper exposes only the remaining-length and flush operations needed by this framing contract.

Update daemon error-status tests to create the bounded output-event receiver that `consume_output` requires.