### PR TITLE
fix(mstsgu): default gateway port to HTTPS

### DIFF
--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -90,6 +90,10 @@ impl fmt::Debug for GwSmartCardCredentials {
 
 #[derive(Clone, Debug)]
 pub struct GwConnectTarget {
+    /// Gateway host with an optional port.
+    ///
+    /// Omitted ports use the HTTPS default of 443.
+    /// Bracket IPv6 literals, such as `[2001:db8::1]:8443`.
     pub gw_endpoint: String,
     pub gw_user: String,
     pub gw_pass: String,

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -351,35 +351,59 @@ async fn upgrade_gateway_tls(
 }
 
 fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
-    let (host, port) = endpoint
-        .rsplit_once(':')
-        .ok_or_else(|| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
-    let host = host
+    let authority = endpoint
+        .parse::<http::uri::Authority>()
+        .map_err(|_| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
+    let host = authority
+        .host()
         .strip_prefix('[')
         .and_then(|host| host.strip_suffix(']'))
-        .unwrap_or(host);
+        .unwrap_or_else(|| authority.host());
+    let bracketed = authority.host().starts_with('[');
     if host.is_empty()
         || host
             .bytes()
             .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        || (bracketed && !matches!(host.parse(), Ok(IpAddr::V6(_))))
     {
         return Err(Error::new("connect", GwErrorKind::InvalidGwTarget));
     }
 
-    let port = port
-        .parse()
-        .map_err(|_| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
+    let has_explicit_port = if bracketed {
+        match endpoint.rsplit_once(']') {
+            Some((_, "")) => false,
+            Some((_, suffix)) if suffix.starts_with(':') => true,
+            _ => return Err(Error::new("connect", GwErrorKind::InvalidGwTarget)),
+        }
+    } else {
+        endpoint.contains(':')
+    };
+    let port = match authority.port_u16() {
+        Some(port) => port,
+        None if !has_explicit_port => 443,
+        None => return Err(Error::new("connect", GwErrorKind::InvalidGwTarget)),
+    };
+    let endpoint = if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
 
     Ok(GatewayEndpoint {
         host: host.to_owned(),
         port,
-        endpoint: endpoint.to_owned(),
+        endpoint,
     })
 }
 
 #[cfg(feature = "test-support")]
 pub(crate) fn gateway_endpoint_is_valid(endpoint: &str) -> bool {
     parse_gateway_endpoint(endpoint).is_ok()
+}
+
+#[cfg(feature = "test-support")]
+pub(crate) fn gateway_endpoint_summary(endpoint: &str) -> Result<String, Error> {
+    parse_gateway_endpoint(endpoint).map(|gateway| gateway.endpoint)
 }
 
 async fn open_gateway_tcp(

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -351,6 +351,9 @@ async fn upgrade_gateway_tls(
 }
 
 fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
+    if endpoint.contains('@') {
+        return Err(Error::new("connect", GwErrorKind::InvalidGwTarget));
+    }
     let authority = endpoint
         .parse::<http::uri::Authority>()
         .map_err(|_| Error::new("connect", GwErrorKind::InvalidGwTarget))?;

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -6,7 +6,8 @@ use tokio::io::AsyncWriteExt as _;
 use crate::http_auth::basic_authorization;
 use crate::packet_io::{
     GatewayTransport as NetworkGatewayTransport, gateway_endpoint_is_valid as endpoint_is_valid,
-    open_gateway_transport, open_test_transport, parse_proxy_url, proxy_from_values, read_http_connect_response,
+    gateway_endpoint_summary as endpoint_summary, open_gateway_transport, open_test_transport, parse_proxy_url,
+    proxy_from_values, read_http_connect_response,
 };
 use crate::{ConsentFallback, Error, GwClient, GwConnectTarget, GwConsentCallback};
 
@@ -151,6 +152,11 @@ pub fn proxy_summary(
 /// Validate a gateway endpoint without opening a connection.
 pub fn gateway_endpoint_is_valid(endpoint: &str) -> bool {
     endpoint_is_valid(endpoint)
+}
+
+/// Normalize a gateway endpoint without opening a connection.
+pub fn gateway_endpoint_summary(endpoint: &str) -> Result<String, String> {
+    endpoint_summary(endpoint).map_err(|error| error.to_string())
 }
 
 /// Verify that a proxy URL can construct a Basic CONNECT authorization header.

--- a/crates/ironrdp-mstsgu/tests/proxy.rs
+++ b/crates/ironrdp-mstsgu/tests/proxy.rs
@@ -122,6 +122,7 @@ fn parses_gateway_endpoints_with_default_https_port() {
         "gateway.example.test:",
         "gateway.example.test:99999",
         "gateway.example.test:443:8443",
+        "display-name@actual-gateway:443",
         "2001:db8::1",
         "[2001:db8::1",
         "[2001:db8::1]443",

--- a/crates/ironrdp-mstsgu/tests/proxy.rs
+++ b/crates/ironrdp-mstsgu/tests/proxy.rs
@@ -12,8 +12,8 @@ use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use ironrdp_mstsgu::GwConnectTarget;
 use ironrdp_mstsgu::test_support::{
-    GatewayTransport, gateway_endpoint_is_valid, proxy_debug, proxy_summary, proxy_uses_basic_authorization,
-    validate_proxy_response,
+    GatewayTransport, gateway_endpoint_is_valid, gateway_endpoint_summary, proxy_debug, proxy_summary,
+    proxy_uses_basic_authorization, validate_proxy_response,
 };
 use ironrdp_tls::CertificateValidation;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -95,6 +95,40 @@ fn rejects_unsupported_or_malformed_proxy_urls() {
         assert!(proxy_summary("gateway.example.test", Some(proxy), None, None, None).is_err());
     }
     assert!(!gateway_endpoint_is_valid("gateway.example.test\r\nX-Injected: 443"));
+}
+
+#[test]
+fn parses_gateway_endpoints_with_default_https_port() {
+    assert_eq!(
+        gateway_endpoint_summary("gateway.example.test").expect("parse hostname"),
+        "gateway.example.test:443"
+    );
+    assert_eq!(
+        gateway_endpoint_summary("gateway.example.test:8443").expect("parse hostname and port"),
+        "gateway.example.test:8443"
+    );
+    assert_eq!(
+        gateway_endpoint_summary("[2001:db8::1]").expect("parse bracketed IPv6 address"),
+        "[2001:db8::1]:443"
+    );
+    assert_eq!(
+        gateway_endpoint_summary("[2001:db8::1]:8443").expect("parse bracketed IPv6 address and port"),
+        "[2001:db8::1]:8443"
+    );
+
+    for endpoint in [
+        "",
+        ":443",
+        "gateway.example.test:",
+        "gateway.example.test:99999",
+        "gateway.example.test:443:8443",
+        "2001:db8::1",
+        "[2001:db8::1",
+        "[2001:db8::1]443",
+        "[gateway.example.test]:443",
+    ] {
+        assert!(!gateway_endpoint_is_valid(endpoint), "must reject {endpoint:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Accept host-only gateway endpoints as HTTPS authorities and connect to port 443. Explicit ports and bracketed IPv6 literals retain their normalized endpoints.