### PR TITLE
feat(activex): trace the failing PDU layer

### DIFF
--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -29,7 +29,6 @@ use ironrdp_cliprdr_native::WinClipboard;
 use ironrdp_connector::{ConnectorError, ConnectorErrorKind, Credentials};
 use ironrdp_core::{DecodeError, DecodeErrorKind, ReadCursor, encode_vec};
 use ironrdp_input::{Database as InputDatabase, MouseButton, MousePosition, Operation, Scancode, WheelRotations};
-use ironrdp_pdu::PduResult;
 use ironrdp_pdu::gcc::{
     ChannelName, ChannelOptions, ClientMonitorData, ConnectionType, KeyboardType, MONITOR_COUNT_MAX, Monitor,
     MonitorFlags,
@@ -39,6 +38,7 @@ use ironrdp_pdu::rdp::{
     client_info::PerformanceFlags,
 };
 use ironrdp_pdu::window::try_decode_slow_path_windowing_orders;
+use ironrdp_pdu::{PduError, PduErrorKind, PduResult};
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rail::pdu::{
     ActivatePdu, ExecutePdu, ExecuteResult, ExecuteResultPdu, RailPdu, SystemCommand, SystemCommandPdu,
@@ -798,9 +798,24 @@ fn trace_decode_failure(error: &DecodeError) {
     ));
 }
 
+fn trace_pdu_failure(error: &PduError) {
+    let marker = match error.kind() {
+        PduErrorKind::Encode => "Encode",
+        PduErrorKind::Decode => "Decode",
+        PduErrorKind::Other { .. } => "Other",
+        _ => "Unknown",
+    };
+    let location = error.location();
+    let file = location.file().rsplit(['/', '\\']).next().unwrap_or("unknown");
+    trace_host_call(&format!(
+        "RdpWorker::SessionFailure:Pdu:{marker}:{file}:line_{}",
+        location.line()
+    ));
+}
+
 fn trace_session_failure(error: &SessionError) {
     match error.kind() {
-        SessionErrorKind::Pdu(_) => trace_host_call("RdpWorker::SessionFailure:Pdu"),
+        SessionErrorKind::Pdu(pdu_error) => trace_pdu_failure(pdu_error),
         SessionErrorKind::Encode(_) => trace_host_call("RdpWorker::SessionFailure:Encode"),
         SessionErrorKind::Decode(decode_error) => trace_decode_failure(decode_error),
         SessionErrorKind::FastPathBulkDecompression(failure) => {
@@ -18430,6 +18445,15 @@ mod tests {
             "general context must not be traced",
             SessionErrorKind::General,
         ));
+        trace_session_failure(&SessionError::new(
+            "outer PDU context must not be traced",
+            SessionErrorKind::Pdu(PduError::new(
+                "nested PDU context must not be traced",
+                PduErrorKind::Other {
+                    description: "PDU detail must not be traced",
+                },
+            )),
+        ));
         drop(trace_guard);
         let trace = std::fs::read_to_string(&trace_path).expect("session failure trace must be written");
         let _ = std::fs::remove_file(trace_path);
@@ -18439,6 +18463,7 @@ mod tests {
             "RdpWorker::SessionFailure:Decode:Other:control.rs:line_",
             "RdpWorker::SessionFailure:Reason:control.rs:line_",
             "RdpWorker::SessionFailure:General:control.rs:line_",
+            "RdpWorker::SessionFailure:Pdu:Other:control.rs:line_",
         ] {
             assert!(lines.next().is_some_and(|line| line.starts_with(prefix)));
         }
@@ -18450,6 +18475,9 @@ mod tests {
             "reason context must not be traced",
             "reason detail must not be traced",
             "general context must not be traced",
+            "outer PDU context must not be traced",
+            "nested PDU context must not be traced",
+            "PDU detail must not be traced",
         ] {
             assert!(!trace.contains(secret));
         }


### PR DESCRIPTION
Session failure traces previously recorded a bare "Pdu" marker with
no indication of which PDU layer or location caused the failure.

Add trace_pdu_failure to emit the PDU error kind (Encode, Decode,
Other, or Unknown) together with the source file basename and line
of the originating PduError, matching the existing decode-failure
tracing. Route SessionErrorKind::Pdu through this helper instead of
the static host call.

The tracing stays value-free: only kind, file, and line are recorded,
never the error message, context, or payload. Extend the trace test
to cover a nested PDU error and assert its context and description
never reach the trace output.