### PR TITLE
feat(dvc): route channels over Soft-Sync tunnels

### DIFF
--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -2234,7 +2234,7 @@ mod tests {
     #[tokio::test]
     async fn connection_failure_status_preserves_gateway_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,
@@ -2271,7 +2271,7 @@ mod tests {
     #[tokio::test]
     async fn terminated_error_status_preserves_session_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -19,8 +19,8 @@ use crate::pdu::{
     DrdynvcDataPdu, DrdynvcServerPdu, SoftSyncResponsePdu, SoftSyncTunnelType,
 };
 use crate::{
-    DvcMessage, DvcProcessor, DynamicChannelId, DynamicChannelMut, DynamicChannelName, DynamicChannelRef,
-    encode_dvc_messages,
+    DvcMessage, DvcMessageBatch, DvcProcessor, DynamicChannelId, DynamicChannelMut, DynamicChannelName,
+    DynamicChannelRef, encode_dvc_messages,
 };
 
 pub trait DvcClientProcessor: DvcProcessor {}
@@ -320,6 +320,14 @@ impl DrdynvcClient {
         self.available_tunnels.insert(tunnel_type);
     }
 
+    /// Marks a multitransport tunnel as unavailable, e.g. after it failed or was torn down.
+    ///
+    /// A future Soft-Sync request that selects this tunnel is rejected; channels already routed
+    /// to it by a prior Soft-Sync exchange are unaffected.
+    pub fn disable_soft_sync_tunnel(&mut self, tunnel_type: SoftSyncTunnelType) {
+        self.available_tunnels.remove(&tunnel_type);
+    }
+
     /// Returns whether the client has produced its Soft-Sync response and activated
     /// its local routing state.
     pub const fn soft_sync_complete(&self) -> bool {
@@ -331,19 +339,35 @@ impl DrdynvcClient {
         self.tunnel_channels.get(&channel_id).copied()
     }
 
-    /// Processes raw DRDYNVC data received through an established multitransport tunnel.
-    pub fn process_tunnel(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+    /// Returns whether Soft-Sync routed any dynamic channel to `tunnel_type`.
+    pub fn has_channels_on_tunnel(&self, tunnel_type: SoftSyncTunnelType) -> bool {
+        self.tunnel_channels.values().any(|selected| *selected == tunnel_type)
+    }
+
+    /// Processes raw DRDYNVC data received through `tunnel_type`.
+    ///
+    /// The channel's Soft-Sync-selected route is validated before the dynamic channel sees the
+    /// data, so data arriving on the wrong tunnel is rejected (MS-RDPEDYC 3.1.5.4.3, 3.2.5.3.2).
+    /// The returned batch carries the channel ID so response messages can be routed back onto
+    /// the same tunnel.
+    pub fn process_tunnel(&mut self, tunnel_type: SoftSyncTunnelType, payload: &[u8]) -> PduResult<DvcMessageBatch> {
         let pdu = decode_dvc_message(payload).map_err(|e| decode_err!(e))?;
         let DrdynvcServerPdu::Data(data) = pdu else {
             return Err(pdu_other_err!("only DVC data is permitted on a multitransport tunnel"));
         };
         let channel_id = data.channel_id();
-        if !self.tunnel_channels.contains_key(&channel_id) {
+        let selected_tunnel = self
+            .tunnel_channels
+            .get(&channel_id)
+            .copied()
+            .ok_or_else(|| pdu_other_err!("received tunneled data for a channel not selected by Soft-Sync"))?;
+        if tunnel_type != selected_tunnel {
             return Err(pdu_other_err!(
-                "received tunneled data for a channel not selected by Soft-Sync"
+                "received tunneled data on a tunnel not selected for the dynamic channel"
             ));
         }
-        self.process_data(data)
+        let messages = self.process_data(data)?;
+        Ok(DvcMessageBatch::new(channel_id, messages))
     }
 
     fn process_data(&mut self, data: DrdynvcDataPdu) -> PduResult<Vec<SvcMessage>> {
@@ -365,6 +389,9 @@ impl DrdynvcClient {
         let mut tunnel_channels = BTreeMap::new();
         let mut tunnels_to_switch = Vec::new();
         for list in request.channel_lists() {
+            // MS-RDPEDYC 3.2.5.3.1: the server manager starts sending data for these channels
+            // on the tunnel as soon as it sends the request, before it sees our response, so an
+            // unavailable tunnel cannot be silently skipped without losing that inbound data.
             if !self.available_tunnels.contains(&list.tunnel_type()) {
                 return Err(pdu_other_err!("soft-sync request selected an unavailable tunnel"));
             }
@@ -672,7 +699,11 @@ mod tests {
             crate::pdu::DataPdu::new(1, Vec::new()),
         )))
         .unwrap();
-        assert!(client.process_tunnel(&tunnel_data).is_err());
+        assert!(
+            client
+                .process_tunnel(SoftSyncTunnelType::RELIABLE_UDP, &tunnel_data)
+                .is_err()
+        );
 
         let request = crate::pdu::SoftSyncRequestPdu::new(alloc::vec![crate::pdu::SoftSyncChannelList::new(
             SoftSyncTunnelType::RELIABLE_UDP,
@@ -682,18 +713,32 @@ mod tests {
 
         assert!(client.soft_sync_complete());
         assert_eq!(client.tunnel_for_channel(1), Some(SoftSyncTunnelType::RELIABLE_UDP));
-        assert!(client.process_tunnel(&tunnel_data).is_ok());
+        assert!(client.has_channels_on_tunnel(SoftSyncTunnelType::RELIABLE_UDP));
+
+        assert!(
+            client
+                .process_tunnel(SoftSyncTunnelType::LOSSY_UDP, &tunnel_data)
+                .is_err()
+        );
+        let batch = client
+            .process_tunnel(SoftSyncTunnelType::RELIABLE_UDP, &tunnel_data)
+            .unwrap();
+        assert_eq!(batch.channel_id(), 1);
+        assert!(batch.messages().is_empty());
 
         assert!(client.process(&tunnel_data).is_err());
 
         client.close_channel(1).unwrap();
         assert_eq!(client.tunnel_for_channel(1), None);
+        assert!(!client.has_channels_on_tunnel(SoftSyncTunnelType::RELIABLE_UDP));
     }
 
     #[test]
     fn soft_sync_rejects_an_unavailable_tunnel() {
         let mut client = DrdynvcClient::new();
         add_active_channel(&mut client, 1);
+        client.enable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
+        client.disable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
 
         let request = crate::pdu::SoftSyncRequestPdu::new(alloc::vec![crate::pdu::SoftSyncChannelList::new(
             SoftSyncTunnelType::RELIABLE_UDP,
@@ -702,5 +747,15 @@ mod tests {
 
         assert!(client.process_soft_sync_request(request).is_err());
         assert!(!client.soft_sync_complete());
+        assert!(!client.has_channels_on_tunnel(SoftSyncTunnelType::RELIABLE_UDP));
+    }
+
+    #[test]
+    fn message_batch_rejects_a_mismatched_channel_id() {
+        let message = SvcMessage::from(DrdynvcClientPdu::Data(DrdynvcDataPdu::Data(crate::pdu::DataPdu::new(
+            7,
+            Vec::new(),
+        ))));
+        assert!(DvcMessageBatch::try_new(8, alloc::vec![message]).is_err());
     }
 }

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -13,8 +13,10 @@ use pdu::DrdynvcDataPdu;
 // Re-export ironrdp_pdu crate for convenience
 #[rustfmt::skip] // do not re-order this pub use
 pub use ironrdp_pdu;
-use ironrdp_core::{AsAny, Encode, EncodeResult, assert_obj_safe, cast_length, encode_vec, other_err};
-use ironrdp_pdu::PduResult;
+use ironrdp_core::{
+    AsAny, Decode as _, Encode, EncodeResult, ReadCursor, assert_obj_safe, cast_length, encode_vec, other_err,
+};
+use ironrdp_pdu::{PduResult, decode_err, encode_err, pdu_other_err};
 use ironrdp_svc::SvcMessage;
 
 mod complete_data;
@@ -33,6 +35,59 @@ pub mod pdu;
 /// (being split into multiple of such PDUs if necessary).
 pub trait DvcEncode: Encode + Send {}
 pub type DvcMessage = Box<dyn DvcEncode>;
+
+/// A batch of outgoing DRDYNVC data messages, all addressed to the same dynamic channel.
+///
+/// Carrying the channel ID alongside the messages lets a caller route the batch onto the
+/// multitransport tunnel (or the main connection) selected for that channel by Soft-Sync,
+/// without re-parsing the encoded messages.
+#[derive(Debug)]
+pub struct DvcMessageBatch {
+    channel_id: DynamicChannelId,
+    messages: Vec<SvcMessage>,
+}
+
+impl DvcMessageBatch {
+    /// Creates a batch, trusting the caller that every message already carries `channel_id`.
+    ///
+    /// Crate-private: callers outside this crate cannot vouch for that invariant and must go
+    /// through [`Self::try_new`] instead, which verifies it.
+    pub(crate) fn new(channel_id: DynamicChannelId, messages: Vec<SvcMessage>) -> Self {
+        Self { channel_id, messages }
+    }
+
+    /// Creates a batch after verifying that every message is DVC data addressed to `channel_id`.
+    ///
+    /// Use this for messages obtained from outside this crate, where the channel ID has not
+    /// already been established by construction (e.g. [`Self::new`]).
+    pub fn try_new(channel_id: DynamicChannelId, messages: Vec<SvcMessage>) -> PduResult<Self> {
+        for message in &messages {
+            let encoded = message.encode_unframed_pdu().map_err(|error| encode_err!(error))?;
+            let pdu =
+                pdu::DrdynvcClientPdu::decode(&mut ReadCursor::new(&encoded)).map_err(|error| decode_err!(error))?;
+            match pdu {
+                pdu::DrdynvcClientPdu::Data(data) if data.channel_id() == channel_id => {}
+                pdu::DrdynvcClientPdu::Data(_) => {
+                    return Err(pdu_other_err!("DVC message channel ID does not match its batch"));
+                }
+                _ => return Err(pdu_other_err!("DVC message batch contains a non-data PDU")),
+            }
+        }
+        Ok(Self::new(channel_id, messages))
+    }
+
+    pub fn channel_id(&self) -> DynamicChannelId {
+        self.channel_id
+    }
+
+    pub fn messages(&self) -> &[SvcMessage] {
+        &self.messages
+    }
+
+    pub fn into_messages(self) -> Vec<SvcMessage> {
+        self.messages
+    }
+}
 
 /// A type that is a Dynamic Virtual Channel (DVC)
 ///

--- a/crates/ironrdp-testsuite-core/tests/dvc/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/client.rs
@@ -1,7 +1,11 @@
 use ironrdp_core::{encode_vec, impl_as_any};
 use ironrdp_dvc::ironrdp_pdu::{PduResult, pdu_other_err};
-use ironrdp_dvc::pdu::{DataPdu, DrdynvcDataPdu, DrdynvcServerPdu};
-use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DvcMessage, DvcProcessor};
+use ironrdp_dvc::pdu::{
+    DataPdu, DrdynvcClientPdu, DrdynvcDataPdu, DrdynvcServerPdu, SoftSyncChannelList, SoftSyncRequestPdu,
+    SoftSyncTunnelType,
+};
+use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DvcMessage, DvcMessageBatch, DvcProcessor};
+use ironrdp_svc::SvcMessage;
 use ironrdp_svc::SvcProcessor as _;
 
 #[derive(Default)]
@@ -105,4 +109,37 @@ fn failed_established_dynamic_channel_attachment_is_not_registered() {
             .attach_established_dynamic_channel(7, RecordedDvc::default())
             .is_ok()
     );
+}
+
+#[test]
+fn soft_sync_rejects_a_tunnel_that_became_unavailable_before_migration() {
+    let mut client = DrdynvcClient::new();
+    client
+        .attach_established_dynamic_channel(7, RecordedDvc::default())
+        .expect("recorded channel should attach");
+    client.enable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
+    client.disable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
+
+    let request = encode_vec(&DrdynvcServerPdu::SoftSyncRequest(SoftSyncRequestPdu::new(vec![
+        SoftSyncChannelList::new(SoftSyncTunnelType::RELIABLE_UDP, vec![7]),
+    ])))
+    .expect("Soft-Sync request should encode");
+
+    // MS-RDPEDYC 3.2.5.3.1: the server manager starts sending data for these channels on the
+    // tunnel as soon as it sends the request, so a tunnel we can no longer honor must fail the
+    // whole request rather than being silently dropped from the response.
+    assert!(client.process(&request).is_err());
+    assert!(!client.soft_sync_complete());
+    assert_eq!(client.tunnel_for_channel(7), None);
+    assert!(!client.has_channels_on_tunnel(SoftSyncTunnelType::RELIABLE_UDP));
+}
+
+#[test]
+fn message_batch_rejects_a_mismatched_channel_id() {
+    let message = SvcMessage::from(DrdynvcClientPdu::Data(DrdynvcDataPdu::Data(DataPdu::new(
+        7,
+        Vec::new(),
+    ))));
+
+    assert!(DvcMessageBatch::try_new(8, vec![message]).is_err());
 }


### PR DESCRIPTION
Add DvcMessageBatch to carry a dynamic channel ID alongside its
encoded SVC messages, and validate that a Soft-Sync-selected tunnel
matches the channel before forwarding tunneled DRDYNVC data.

DrdynvcClient::process_tunnel now takes the tunnel type it was
called for and returns a DvcMessageBatch instead of a bare message
list, so a caller juggling several tunnels can route responses back
onto the correct one. disable_soft_sync_tunnel and
has_channels_on_tunnel let a caller retire a tunnel and check
whether Soft-Sync ever routed a channel onto it.

When a Soft-Sync request selects a tunnel the client does not have
available, the request is rejected outright: per MS-RDPEDYC
3.2.5.3.1 the server manager starts sending data for the selected
channels on that tunnel as soon as it sends the request, before it
sees our response, so silently omitting an unavailable tunnel from
the response would lose that inbound data.

Also includes an unrelated one-line fix in
crates/ironrdp-daemon/src/daemon.rs (separate commit): two tests
added in #1822 constructed a raw tokio::sync::mpsc::channel instead
of the OutputEventReceiver wrapper from #1815, which breaks
`cargo test --workspace --locked --no-run` on master for every PR
regardless of what it changes. Bundled here to unblock this PR's CI;
tracked upstream as #1830.