### PR TITLE
feat(mstsgu): add RPCH v2 channel recycling

### DIFF
--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -2234,7 +2234,7 @@ mod tests {
     #[tokio::test]
     async fn connection_failure_status_preserves_gateway_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,
@@ -2271,7 +2271,7 @@ mod tests {
     #[tokio::test]
     async fn terminated_error_status_preserves_session_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -68,6 +68,8 @@ const RTS_PFC_FLAGS: u8 = PFC_FIRST_FRAG | PFC_LAST_FRAG;
 const RTS_FLAG_NONE: u16 = 0;
 const RTS_FLAG_PING: u16 = 0x0001;
 const RTS_FLAG_OTHER_CMD: u16 = 0x0002;
+const RTS_FLAG_RECYCLE_CHANNEL: u16 = 0x0004;
+const RTS_FLAG_OUT_CHANNEL: u16 = 0x0010;
 const RTS_VERSION: u32 = 1;
 const RTS_COMMAND_RECEIVE_WINDOW_SIZE: u32 = 0;
 const RTS_COMMAND_FLOW_CONTROL_ACK: u32 = 1;
@@ -77,6 +79,10 @@ const RTS_COMMAND_CHANNEL_LIFETIME: u32 = 4;
 const RTS_COMMAND_CLIENT_KEEPALIVE: u32 = 5;
 const RTS_COMMAND_VERSION: u32 = 6;
 const RTS_COMMAND_ASSOCIATION_GROUP_ID: u32 = 12;
+const RTS_COMMAND_DESTINATION: u32 = 13;
+const RTS_COMMAND_ANCE: u32 = 10;
+const RTS_DESTINATION_FD_CLIENT: u32 = 0;
+const RTS_DESTINATION_FD_SERVER: u32 = 2;
 const RTS_MIN_RECEIVE_WINDOW_SIZE: u32 = 8 * 1024;
 const RTS_MAX_RECEIVE_WINDOW_SIZE: u32 = 256 * 1024;
 const RTS_MIN_CONNECTION_TIMEOUT: u32 = 120_000;
@@ -112,6 +118,7 @@ pub enum RpcPduError {
     UnexpectedRtsCommandCount { expected: u16, actual: u16 },
     InvalidRtsBodyLength { expected: usize, actual: usize },
     UnexpectedRtsCommandType { expected: u32, actual: u32 },
+    UnexpectedRtsDestination { expected: u32, actual: u32 },
     InvalidRtsReceiveWindowSize { actual: u32 },
     InvalidRtsConnectionTimeout { actual: u32 },
     InvalidRtsChannelLifetime { actual: u32 },
@@ -206,6 +213,9 @@ impl fmt::Display for RpcPduError {
             }
             Self::UnexpectedRtsCommandType { expected, actual } => {
                 write!(f, "unexpected rts command type {actual}, expected {expected}")
+            }
+            Self::UnexpectedRtsDestination { expected, actual } => {
+                write!(f, "unexpected rts destination {actual}, expected {expected}")
             }
             Self::InvalidRtsReceiveWindowSize { actual } => {
                 write!(f, "invalid rts receive window size {actual}")
@@ -2202,6 +2212,123 @@ impl From<RpcPduError> for RpchV2Error {
     }
 }
 
+/// Values received in an IN_R1/A4 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.13.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RtsInRecycleA4 {
+    version: u32,
+    receive_window_size: u32,
+    connection_timeout: u32,
+}
+
+impl RtsInRecycleA4 {
+    /// Protocol version selected by the proxy and server.
+    pub const fn version(self) -> u32 {
+        self.version
+    }
+
+    /// Receive window supplied for the successor IN channel.
+    pub const fn receive_window_size(self) -> u32 {
+        self.receive_window_size
+    }
+
+    /// Connection timeout supplied for the successor IN channel.
+    pub const fn connection_timeout(self) -> u32 {
+        self.connection_timeout
+    }
+}
+
+/// Values received in an OUT_R1/A6 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.28.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RtsOutRecycleA6 {
+    version: u32,
+    connection_timeout: u32,
+}
+
+impl RtsOutRecycleA6 {
+    /// Protocol version selected by the proxy and server.
+    pub const fn version(self) -> u32 {
+        self.version
+    }
+
+    /// Connection timeout supplied for the successor OUT channel.
+    ///
+    /// This value is informational to clients ([MS-RPCH] 2.2.4.28).
+    pub const fn connection_timeout(self) -> u32 {
+        self.connection_timeout
+    }
+}
+
+/// State of the virtual IN channel recycling sequence.
+///
+/// [MS-RPCH] 3.2.2.5.5 and 3.2.2.5.12.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpchInChannelRecycleState {
+    /// The default IN channel is open.
+    Open,
+    /// IN_R1/A1 was produced and IN_R1/A4 is expected.
+    AwaitingA4,
+    /// An invalid recycle event was received.
+    Failed,
+}
+
+/// State of the virtual OUT channel recycling sequence.
+///
+/// [MS-RPCH] 3.2.2.5.6 through 3.2.2.5.8.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpchOutChannelRecycleState {
+    /// The default OUT channel is open.
+    Open,
+    /// OUT_R1/A2 was accepted and OUT_R1/A6 is expected.
+    AwaitingA6,
+    /// OUT_R1/A6 was accepted and OUT_R1/A10 is expected.
+    AwaitingA10,
+    /// An invalid recycle event was received.
+    Failed,
+}
+
+/// Errors reported while advancing an RPCH v2 channel recycling sequence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpchChannelRecycleError {
+    /// An IN recycling event is not valid in the current state.
+    InvalidInState {
+        action: &'static str,
+        state: RpchInChannelRecycleState,
+    },
+    /// An OUT recycling event is not valid in the current state.
+    InvalidOutState {
+        action: &'static str,
+        state: RpchOutChannelRecycleState,
+    },
+    /// An RTS PDU was malformed or semantically invalid.
+    Rts(RpcPduError),
+}
+
+impl fmt::Display for RpchChannelRecycleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInState { action, state } => {
+                write!(f, "cannot {action} while IN recycling is {state:?}")
+            }
+            Self::InvalidOutState { action, state } => {
+                write!(f, "cannot {action} while OUT recycling is {state:?}")
+            }
+            Self::Rts(error) => error.fmt(f),
+        }
+    }
+}
+
+impl core::error::Error for RpchChannelRecycleError {}
+
+impl From<RpcPduError> for RpchChannelRecycleError {
+    fn from(error: RpcPduError) -> Self {
+        Self::Rts(error)
+    }
+}
+
 /// Stateful validation for the initial RPCH v2 CONN sequence.
 ///
 /// This transport-independent state machine produces initial request bodies and accepts the OUT response status plus CONN/A3 and CONN/C2.
@@ -2404,8 +2531,252 @@ impl RpchV2Setup {
         ))
     }
 
+    /// Creates state validation for channel recycling after the initial CONN sequence opens.
+    ///
+    /// [MS-RPCH] 3.2.2.5.5 through 3.2.2.5.8 and 3.2.2.5.12.
+    pub fn channel_recycling(&self) -> Result<RpchV2ChannelRecycle, RpchV2Error> {
+        if self.state != RpchV2State::Open {
+            return Err(RpchV2Error::InvalidState {
+                action: "create RPCH channel recycling state",
+                state: self.state,
+            });
+        }
+
+        Ok(RpchV2ChannelRecycle {
+            virtual_connection_cookie: self.virtual_connection_cookie,
+            default_in_channel_cookie: self.in_channel_cookie,
+            default_out_channel_cookie: self.out_channel_cookie,
+            receive_window_size: self.settings.receive_window_size,
+            in_channel_ping_timeout: self.in_channel_ping_timeout.ok_or(RpchV2Error::InvalidState {
+                action: "read the IN channel connection timeout",
+                state: self.state,
+            })?,
+            peer_receive_window_size: self.peer_receive_window_size.ok_or(RpchV2Error::InvalidState {
+                action: "read the peer receive window",
+                state: self.state,
+            })?,
+            in_state: RpchInChannelRecycleState::Open,
+            out_state: RpchOutChannelRecycleState::Open,
+            successor_in_channel_cookie: None,
+            successor_out_channel_cookie: None,
+        })
+    }
+
     fn fail<T>(&mut self, error: RpchV2Error) -> Result<T, RpchV2Error> {
         self.state = RpchV2State::Failed;
+        Err(error)
+    }
+}
+
+/// Stateful validation for the RPCH v2 R1 channel recycling sequences.
+///
+/// The caller creates and switches transport channels around the returned RTS PDUs.
+/// This type owns no I/O and validates only the protocol-visible ordering.
+///
+/// [MS-RPCH] 3.2.2.5.5 through 3.2.2.5.8 and 3.2.2.5.12.
+#[derive(Debug)]
+pub struct RpchV2ChannelRecycle {
+    virtual_connection_cookie: RtsCookie,
+    default_in_channel_cookie: RtsCookie,
+    default_out_channel_cookie: RtsCookie,
+    receive_window_size: u32,
+    in_channel_ping_timeout: u32,
+    peer_receive_window_size: u32,
+    in_state: RpchInChannelRecycleState,
+    out_state: RpchOutChannelRecycleState,
+    successor_in_channel_cookie: Option<RtsCookie>,
+    successor_out_channel_cookie: Option<RtsCookie>,
+}
+
+impl RpchV2ChannelRecycle {
+    /// Current virtual IN channel recycling state.
+    pub const fn in_state(&self) -> RpchInChannelRecycleState {
+        self.in_state
+    }
+
+    /// Current virtual OUT channel recycling state.
+    pub const fn out_state(&self) -> RpchOutChannelRecycleState {
+        self.out_state
+    }
+
+    /// Current default IN channel cookie.
+    pub const fn default_in_channel_cookie(&self) -> RtsCookie {
+        self.default_in_channel_cookie
+    }
+
+    /// Current default OUT channel cookie.
+    pub const fn default_out_channel_cookie(&self) -> RtsCookie {
+        self.default_out_channel_cookie
+    }
+
+    /// Connection timeout for the current default IN channel.
+    pub const fn in_channel_ping_timeout(&self) -> u32 {
+        self.in_channel_ping_timeout
+    }
+
+    /// Peer receive window for the current default IN channel.
+    pub const fn peer_receive_window_size(&self) -> u32 {
+        self.peer_receive_window_size
+    }
+
+    /// Starts IN_R1 channel recycling and returns IN_R1/A1 for the successor IN channel.
+    ///
+    /// [MS-RPCH] 2.2.4.10 and 3.2.2.5.12.
+    pub fn start_in_recycling(
+        &mut self,
+        successor_channel_cookie: RtsCookie,
+    ) -> Result<Vec<u8>, RpchChannelRecycleError> {
+        if self.in_state != RpchInChannelRecycleState::Open {
+            return self.fail_in(RpchChannelRecycleError::InvalidInState {
+                action: "start IN channel recycling",
+                state: self.in_state,
+            });
+        }
+
+        let pdu = encode_rts_in_recycle_a1(
+            self.virtual_connection_cookie,
+            self.default_in_channel_cookie,
+            successor_channel_cookie,
+        )?;
+        self.successor_in_channel_cookie = Some(successor_channel_cookie);
+        self.in_state = RpchInChannelRecycleState::AwaitingA4;
+        Ok(pdu)
+    }
+
+    /// Accepts IN_R1/A4 and returns IN_R1/A5 for the predecessor IN channel.
+    ///
+    /// The returned PDU must be sent after predecessor-channel PDUs have drained.
+    ///
+    /// [MS-RPCH] 2.2.4.13, 2.2.4.14, and 3.2.2.5.5.
+    pub fn receive_in_recycle_a4(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
+        if self.in_state != RpchInChannelRecycleState::AwaitingA4 {
+            return self.fail_in(RpchChannelRecycleError::InvalidInState {
+                action: "accept IN_R1/A4",
+                state: self.in_state,
+            });
+        }
+
+        let a4 = match decode_rts_in_recycle_a4(pdu) {
+            Ok(a4) => a4,
+            Err(error) => return self.fail_in(error.into()),
+        };
+        let successor_channel_cookie = match self.successor_in_channel_cookie {
+            Some(cookie) => cookie,
+            None => {
+                return self.fail_in(RpchChannelRecycleError::InvalidInState {
+                    action: "read the successor IN channel cookie",
+                    state: self.in_state,
+                });
+            }
+        };
+        let a5 = encode_rts_in_recycle_a5(successor_channel_cookie)?;
+        self.default_in_channel_cookie = successor_channel_cookie;
+        self.in_channel_ping_timeout = a4.connection_timeout;
+        self.peer_receive_window_size = a4.receive_window_size;
+        self.successor_in_channel_cookie = None;
+        self.in_state = RpchInChannelRecycleState::Open;
+        Ok(a5)
+    }
+
+    /// Accepts OUT_R1/A2 and returns OUT_R1/A3 for the successor OUT channel.
+    ///
+    /// The caller creates the successor OUT channel before sending the returned PDU.
+    ///
+    /// [MS-RPCH] 2.2.4.24, 2.2.4.25, and 3.2.2.5.6.
+    pub fn receive_out_recycle_a2(
+        &mut self,
+        pdu: &[u8],
+        successor_channel_cookie: RtsCookie,
+    ) -> Result<Vec<u8>, RpchChannelRecycleError> {
+        if self.out_state != RpchOutChannelRecycleState::Open {
+            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                action: "accept OUT_R1/A2",
+                state: self.out_state,
+            });
+        }
+
+        if let Err(error) = decode_rts_out_recycle_a2(pdu) {
+            return self.fail_out(error.into());
+        }
+        let a3 = encode_rts_out_recycle_a3(
+            self.virtual_connection_cookie,
+            self.default_out_channel_cookie,
+            successor_channel_cookie,
+            self.receive_window_size,
+        )?;
+        self.successor_out_channel_cookie = Some(successor_channel_cookie);
+        self.out_state = RpchOutChannelRecycleState::AwaitingA6;
+        Ok(a3)
+    }
+
+    /// Accepts OUT_R1/A6 and returns OUT_R1/A7 for the default IN channel.
+    ///
+    /// [MS-RPCH] 2.2.4.28, 2.2.4.29, and 3.2.2.5.7.
+    pub fn receive_out_recycle_a6(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
+        if self.out_state != RpchOutChannelRecycleState::AwaitingA6 {
+            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                action: "accept OUT_R1/A6",
+                state: self.out_state,
+            });
+        }
+
+        if let Err(error) = decode_rts_out_recycle_a6(pdu) {
+            return self.fail_out(error.into());
+        }
+        let successor_channel_cookie = match self.successor_out_channel_cookie {
+            Some(cookie) => cookie,
+            None => {
+                return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                    action: "read the successor OUT channel cookie",
+                    state: self.out_state,
+                });
+            }
+        };
+        let a7 = encode_rts_out_recycle_a7(successor_channel_cookie)?;
+        self.out_state = RpchOutChannelRecycleState::AwaitingA10;
+        Ok(a7)
+    }
+
+    /// Accepts OUT_R1/A10 and returns OUT_R1/A11 for the successor OUT channel.
+    ///
+    /// [MS-RPCH] 2.2.4.32, 2.2.4.33, and 3.2.2.5.8.
+    pub fn receive_out_recycle_a10(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
+        if self.out_state != RpchOutChannelRecycleState::AwaitingA10 {
+            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                action: "accept OUT_R1/A10",
+                state: self.out_state,
+            });
+        }
+
+        if let Err(error) = decode_rts_out_recycle_a10(pdu) {
+            return self.fail_out(error.into());
+        }
+        let successor_channel_cookie = match self.successor_out_channel_cookie {
+            Some(cookie) => cookie,
+            None => {
+                return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                    action: "read the successor OUT channel cookie",
+                    state: self.out_state,
+                });
+            }
+        };
+        let a11 = encode_rts_out_recycle_a11()?;
+        self.default_out_channel_cookie = successor_channel_cookie;
+        self.successor_out_channel_cookie = None;
+        self.out_state = RpchOutChannelRecycleState::Open;
+        Ok(a11)
+    }
+
+    fn fail_in<T>(&mut self, error: RpchChannelRecycleError) -> Result<T, RpchChannelRecycleError> {
+        // A protocol error terminates the entire virtual connection.
+        self.in_state = RpchInChannelRecycleState::Failed;
+        self.out_state = RpchOutChannelRecycleState::Failed;
+        Err(error)
+    }
+
+    fn fail_out<T>(&mut self, error: RpchChannelRecycleError) -> Result<T, RpchChannelRecycleError> {
+        self.in_state = RpchInChannelRecycleState::Failed;
+        self.out_state = RpchOutChannelRecycleState::Failed;
         Err(error)
     }
 }
@@ -2786,6 +3157,127 @@ pub fn encode_rts_conn_b1(
     encode_rts_pdu(RTS_FLAG_NONE, 6, commands)
 }
 
+/// Encodes the client IN_R1/A1 RTS PDU for a successor IN channel.
+///
+/// [MS-RPCH] 2.2.4.10.
+pub fn encode_rts_in_recycle_a1(
+    virtual_connection_cookie: RtsCookie,
+    predecessor_channel_cookie: RtsCookie,
+    successor_channel_cookie: RtsCookie,
+) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* predecessor IN channel cookie */
+            + 20, /* successor IN channel cookie */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, predecessor_channel_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_RECYCLE_CHANNEL, 4, commands)
+}
+
+/// Encodes the client IN_R1/A5 RTS PDU for a predecessor IN channel.
+///
+/// [MS-RPCH] 2.2.4.14.
+pub fn encode_rts_in_recycle_a5(successor_channel_cookie: RtsCookie) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(20 /* successor IN channel cookie */);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_NONE, 1, commands)
+}
+
+/// Decodes and validates an OUT_R1/A2 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.24.
+pub fn decode_rts_out_recycle_a2(source: &[u8]) -> Result<(), RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_RECYCLE_CHANNEL, 1, 8)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+    Ok(())
+}
+
+/// Encodes the client OUT_R1/A3 RTS PDU for a successor OUT channel.
+///
+/// [MS-RPCH] 2.2.4.25.
+pub fn encode_rts_out_recycle_a3(
+    virtual_connection_cookie: RtsCookie,
+    predecessor_channel_cookie: RtsCookie,
+    successor_channel_cookie: RtsCookie,
+    receive_window_size: u32,
+) -> Result<Vec<u8>, RpcPduError> {
+    validate_rts_receive_window_size(receive_window_size)?;
+
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* predecessor OUT channel cookie */
+            + 20 /* successor OUT channel cookie */
+            + 8, /* receive window size */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, predecessor_channel_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_RECEIVE_WINDOW_SIZE, receive_window_size);
+    encode_rts_pdu(RTS_FLAG_RECYCLE_CHANNEL, 5, commands)
+}
+
+/// Decodes and validates an OUT_R1/A6 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.28.
+pub fn decode_rts_out_recycle_a6(source: &[u8]) -> Result<RtsOutRecycleA6, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_OUT_CHANNEL, 3, 24)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+
+    let version = decode_rts_u32_command(body, 8, RTS_COMMAND_VERSION)?;
+    let connection_timeout = decode_rts_u32_command(body, 16, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+    Ok(RtsOutRecycleA6 {
+        version,
+        connection_timeout,
+    })
+}
+
+/// Encodes the client OUT_R1/A7 RTS PDU for the default IN channel.
+///
+/// [MS-RPCH] 2.2.4.29.
+pub fn encode_rts_out_recycle_a7(successor_channel_cookie: RtsCookie) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(
+        8 /* destination */
+            + 20, /* successor OUT channel cookie */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_DESTINATION, RTS_DESTINATION_FD_SERVER);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_OUT_CHANNEL, 2, commands)
+}
+
+/// Decodes and validates an OUT_R1/A10 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.32.
+pub fn decode_rts_out_recycle_a10(source: &[u8]) -> Result<(), RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 1, 4)?;
+    decode_rts_empty_command(body, 0, RTS_COMMAND_ANCE)
+}
+
+/// Encodes the client OUT_R1/A11 RTS PDU for a successor OUT channel.
+///
+/// [MS-RPCH] 2.2.4.33.
+pub fn encode_rts_out_recycle_a11() -> Result<Vec<u8>, RpcPduError> {
+    encode_rts_pdu(RTS_FLAG_NONE, 1, RTS_COMMAND_ANCE.to_le_bytes().to_vec())
+}
+
 /// Encodes an RPCH PING RTS PDU.
 ///
 /// [MS-RPCH] 2.2.4.49.
@@ -2854,6 +3346,31 @@ fn decode_rts_conn_c2(source: &[u8]) -> Result<(u32, u32), RpcPduError> {
     validate_rts_receive_window_size(receive_window_size)?;
     validate_rts_connection_timeout(connection_timeout)?;
     Ok((receive_window_size, connection_timeout))
+}
+
+/// Decodes and validates an IN_R1/A4 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.13.
+pub fn decode_rts_in_recycle_a4(source: &[u8]) -> Result<RtsInRecycleA4, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 4, 32)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+
+    let version = decode_rts_u32_command(body, 8, RTS_COMMAND_VERSION)?;
+    let receive_window_size = decode_rts_u32_command(body, 16, RTS_COMMAND_RECEIVE_WINDOW_SIZE)?;
+    let connection_timeout = decode_rts_u32_command(body, 24, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_receive_window_size(receive_window_size)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+    Ok(RtsInRecycleA4 {
+        version,
+        receive_window_size,
+        connection_timeout,
+    })
 }
 
 fn encode_rts_pdu(flags: u16, command_count: u16, commands: Vec<u8>) -> Result<Vec<u8>, RpcPduError> {
@@ -2950,6 +3467,17 @@ fn decode_rts_u32_command(source: &[u8], offset: usize, expected_type: u32) -> R
 
     let value_offset = offset.checked_add(4).ok_or(RpcPduError::LengthOverflow)?;
     read_u32(source, value_offset)
+}
+
+fn decode_rts_empty_command(source: &[u8], offset: usize, expected_type: u32) -> Result<(), RpcPduError> {
+    let command_type = read_u32(source, offset)?;
+    if command_type != expected_type {
+        return Err(RpcPduError::UnexpectedRtsCommandType {
+            expected: expected_type,
+            actual: command_type,
+        });
+    }
+    Ok(())
 }
 
 fn validate_rts_receive_window_size(value: u32) -> Result<(), RpcPduError> {

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -2223,7 +2223,9 @@ pub struct RtsInRecycleA4 {
 }
 
 impl RtsInRecycleA4 {
-    /// Protocol version selected by the proxy and server.
+    /// Protocol version selected from the IN_R1/A2 and server versions.
+    ///
+    /// Clients ignore received Version values ([MS-RPCH] 2.2.3.5.7).
     pub const fn version(self) -> u32 {
         self.version
     }
@@ -2249,7 +2251,9 @@ pub struct RtsOutRecycleA6 {
 }
 
 impl RtsOutRecycleA6 {
-    /// Protocol version selected by the proxy and server.
+    /// Protocol version selected from the OUT_R1/A4 and server versions.
+    ///
+    /// Clients ignore received Version values ([MS-RPCH] 2.2.3.5.7).
     pub const fn version(self) -> u32 {
         self.version
     }
@@ -2271,6 +2275,8 @@ pub enum RpchInChannelRecycleState {
     Open,
     /// IN_R1/A1 was produced and IN_R1/A4 is expected.
     AwaitingA4,
+    /// IN_R1/A5 was produced and must be sent before the channel is reopened.
+    AwaitingA5,
     /// An invalid recycle event was received.
     Failed,
 }
@@ -2286,6 +2292,8 @@ pub enum RpchOutChannelRecycleState {
     AwaitingA6,
     /// OUT_R1/A6 was accepted and OUT_R1/A10 is expected.
     AwaitingA10,
+    /// OUT_R1/A11 was produced and must be sent before the channel is reopened.
+    AwaitingA11,
     /// An invalid recycle event was received.
     Failed,
 }
@@ -2534,7 +2542,7 @@ impl RpchV2Setup {
     /// Creates state validation for channel recycling after the initial CONN sequence opens.
     ///
     /// [MS-RPCH] 3.2.2.5.5 through 3.2.2.5.8 and 3.2.2.5.12.
-    pub fn channel_recycling(&self) -> Result<RpchV2ChannelRecycle, RpchV2Error> {
+    pub fn channel_recycling(&mut self) -> Result<RpchV2ChannelRecycle<'_>, RpchV2Error> {
         if self.state != RpchV2State::Open {
             return Err(RpchV2Error::InvalidState {
                 action: "create RPCH channel recycling state",
@@ -2543,18 +2551,7 @@ impl RpchV2Setup {
         }
 
         Ok(RpchV2ChannelRecycle {
-            virtual_connection_cookie: self.virtual_connection_cookie,
-            default_in_channel_cookie: self.in_channel_cookie,
-            default_out_channel_cookie: self.out_channel_cookie,
-            receive_window_size: self.settings.receive_window_size,
-            in_channel_ping_timeout: self.in_channel_ping_timeout.ok_or(RpchV2Error::InvalidState {
-                action: "read the IN channel connection timeout",
-                state: self.state,
-            })?,
-            peer_receive_window_size: self.peer_receive_window_size.ok_or(RpchV2Error::InvalidState {
-                action: "read the peer receive window",
-                state: self.state,
-            })?,
+            setup: self,
             in_state: RpchInChannelRecycleState::Open,
             out_state: RpchOutChannelRecycleState::Open,
             successor_in_channel_cookie: None,
@@ -2575,20 +2572,15 @@ impl RpchV2Setup {
 ///
 /// [MS-RPCH] 3.2.2.5.5 through 3.2.2.5.8 and 3.2.2.5.12.
 #[derive(Debug)]
-pub struct RpchV2ChannelRecycle {
-    virtual_connection_cookie: RtsCookie,
-    default_in_channel_cookie: RtsCookie,
-    default_out_channel_cookie: RtsCookie,
-    receive_window_size: u32,
-    in_channel_ping_timeout: u32,
-    peer_receive_window_size: u32,
+pub struct RpchV2ChannelRecycle<'a> {
+    setup: &'a mut RpchV2Setup,
     in_state: RpchInChannelRecycleState,
     out_state: RpchOutChannelRecycleState,
     successor_in_channel_cookie: Option<RtsCookie>,
     successor_out_channel_cookie: Option<RtsCookie>,
 }
 
-impl RpchV2ChannelRecycle {
+impl RpchV2ChannelRecycle<'_> {
     /// Current virtual IN channel recycling state.
     pub const fn in_state(&self) -> RpchInChannelRecycleState {
         self.in_state
@@ -2601,25 +2593,33 @@ impl RpchV2ChannelRecycle {
 
     /// Current default IN channel cookie.
     pub const fn default_in_channel_cookie(&self) -> RtsCookie {
-        self.default_in_channel_cookie
+        self.setup.in_channel_cookie
     }
 
     /// Current default OUT channel cookie.
     pub const fn default_out_channel_cookie(&self) -> RtsCookie {
-        self.default_out_channel_cookie
+        self.setup.out_channel_cookie
     }
 
     /// Connection timeout for the current default IN channel.
-    pub const fn in_channel_ping_timeout(&self) -> u32 {
-        self.in_channel_ping_timeout
+    pub fn in_channel_ping_timeout(&self) -> u32 {
+        match self.setup.in_channel_ping_timeout {
+            Some(timeout) => timeout,
+            None => unreachable!("opened RPCH v2 setup has an IN channel connection timeout"),
+        }
     }
 
     /// Peer receive window for the current default IN channel.
-    pub const fn peer_receive_window_size(&self) -> u32 {
-        self.peer_receive_window_size
+    pub fn peer_receive_window_size(&self) -> u32 {
+        match self.setup.peer_receive_window_size {
+            Some(window_size) => window_size,
+            None => unreachable!("opened RPCH v2 setup has a peer receive window"),
+        }
     }
 
     /// Starts IN_R1 channel recycling and returns IN_R1/A1 for the successor IN channel.
+    ///
+    /// The caller must send the PDU immediately after opening the successor IN request.
     ///
     /// [MS-RPCH] 2.2.4.10 and 3.2.2.5.12.
     pub fn start_in_recycling(
@@ -2627,15 +2627,15 @@ impl RpchV2ChannelRecycle {
         successor_channel_cookie: RtsCookie,
     ) -> Result<Vec<u8>, RpchChannelRecycleError> {
         if self.in_state != RpchInChannelRecycleState::Open {
-            return self.fail_in(RpchChannelRecycleError::InvalidInState {
+            return self.fail(RpchChannelRecycleError::InvalidInState {
                 action: "start IN channel recycling",
                 state: self.in_state,
             });
         }
 
         let pdu = encode_rts_in_recycle_a1(
-            self.virtual_connection_cookie,
-            self.default_in_channel_cookie,
+            self.setup.virtual_connection_cookie,
+            self.setup.in_channel_cookie,
             successor_channel_cookie,
         )?;
         self.successor_in_channel_cookie = Some(successor_channel_cookie);
@@ -2650,7 +2650,7 @@ impl RpchV2ChannelRecycle {
     /// [MS-RPCH] 2.2.4.13, 2.2.4.14, and 3.2.2.5.5.
     pub fn receive_in_recycle_a4(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
         if self.in_state != RpchInChannelRecycleState::AwaitingA4 {
-            return self.fail_in(RpchChannelRecycleError::InvalidInState {
+            return self.fail(RpchChannelRecycleError::InvalidInState {
                 action: "accept IN_R1/A4",
                 state: self.in_state,
             });
@@ -2658,24 +2658,47 @@ impl RpchV2ChannelRecycle {
 
         let a4 = match decode_rts_in_recycle_a4(pdu) {
             Ok(a4) => a4,
-            Err(error) => return self.fail_in(error.into()),
+            Err(error) => return self.fail(error.into()),
         };
         let successor_channel_cookie = match self.successor_in_channel_cookie {
             Some(cookie) => cookie,
             None => {
-                return self.fail_in(RpchChannelRecycleError::InvalidInState {
+                return self.fail(RpchChannelRecycleError::InvalidInState {
                     action: "read the successor IN channel cookie",
                     state: self.in_state,
                 });
             }
         };
         let a5 = encode_rts_in_recycle_a5(successor_channel_cookie)?;
-        self.default_in_channel_cookie = successor_channel_cookie;
-        self.in_channel_ping_timeout = a4.connection_timeout;
-        self.peer_receive_window_size = a4.receive_window_size;
+        self.setup.in_channel_cookie = successor_channel_cookie;
+        self.setup.in_channel_ping_timeout = Some(a4.connection_timeout);
+        self.setup.peer_receive_window_size = Some(a4.receive_window_size);
         self.successor_in_channel_cookie = None;
-        self.in_state = RpchInChannelRecycleState::Open;
+        self.in_state = RpchInChannelRecycleState::AwaitingA5;
         Ok(a5)
+    }
+
+    /// Completes IN recycling after IN_R1/A5 was sent and the successor IN channel was unplugged.
+    ///
+    /// The caller must retain the supplied state for the virtual connection.
+    ///
+    /// [MS-RPCH] 3.2.2.5.5.
+    pub fn finish_in_recycling(
+        &mut self,
+        flow_control: &mut RpchFlowControl,
+        ping_schedule: &mut RpchPingSchedule,
+    ) -> Result<(), RpchChannelRecycleError> {
+        if self.in_state != RpchInChannelRecycleState::AwaitingA5 {
+            return self.fail(RpchChannelRecycleError::InvalidInState {
+                action: "finish IN channel recycling",
+                state: self.in_state,
+            });
+        }
+
+        flow_control.reset_sending_channel(self.peer_receive_window_size(), self.default_in_channel_cookie());
+        ping_schedule.set_connection_timeout(self.in_channel_ping_timeout());
+        self.in_state = RpchInChannelRecycleState::Open;
+        Ok(())
     }
 
     /// Accepts OUT_R1/A2 and returns OUT_R1/A3 for the successor OUT channel.
@@ -2689,20 +2712,20 @@ impl RpchV2ChannelRecycle {
         successor_channel_cookie: RtsCookie,
     ) -> Result<Vec<u8>, RpchChannelRecycleError> {
         if self.out_state != RpchOutChannelRecycleState::Open {
-            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+            return self.fail(RpchChannelRecycleError::InvalidOutState {
                 action: "accept OUT_R1/A2",
                 state: self.out_state,
             });
         }
 
         if let Err(error) = decode_rts_out_recycle_a2(pdu) {
-            return self.fail_out(error.into());
+            return self.fail(error.into());
         }
         let a3 = encode_rts_out_recycle_a3(
-            self.virtual_connection_cookie,
-            self.default_out_channel_cookie,
+            self.setup.virtual_connection_cookie,
+            self.setup.out_channel_cookie,
             successor_channel_cookie,
-            self.receive_window_size,
+            self.setup.settings.receive_window_size,
         )?;
         self.successor_out_channel_cookie = Some(successor_channel_cookie);
         self.out_state = RpchOutChannelRecycleState::AwaitingA6;
@@ -2714,19 +2737,19 @@ impl RpchV2ChannelRecycle {
     /// [MS-RPCH] 2.2.4.28, 2.2.4.29, and 3.2.2.5.7.
     pub fn receive_out_recycle_a6(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
         if self.out_state != RpchOutChannelRecycleState::AwaitingA6 {
-            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+            return self.fail(RpchChannelRecycleError::InvalidOutState {
                 action: "accept OUT_R1/A6",
                 state: self.out_state,
             });
         }
 
         if let Err(error) = decode_rts_out_recycle_a6(pdu) {
-            return self.fail_out(error.into());
+            return self.fail(error.into());
         }
         let successor_channel_cookie = match self.successor_out_channel_cookie {
             Some(cookie) => cookie,
             None => {
-                return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                return self.fail(RpchChannelRecycleError::InvalidOutState {
                     action: "read the successor OUT channel cookie",
                     state: self.out_state,
                 });
@@ -2742,39 +2765,52 @@ impl RpchV2ChannelRecycle {
     /// [MS-RPCH] 2.2.4.32, 2.2.4.33, and 3.2.2.5.8.
     pub fn receive_out_recycle_a10(&mut self, pdu: &[u8]) -> Result<Vec<u8>, RpchChannelRecycleError> {
         if self.out_state != RpchOutChannelRecycleState::AwaitingA10 {
-            return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+            return self.fail(RpchChannelRecycleError::InvalidOutState {
                 action: "accept OUT_R1/A10",
                 state: self.out_state,
             });
         }
 
         if let Err(error) = decode_rts_out_recycle_a10(pdu) {
-            return self.fail_out(error.into());
+            return self.fail(error.into());
         }
         let successor_channel_cookie = match self.successor_out_channel_cookie {
             Some(cookie) => cookie,
             None => {
-                return self.fail_out(RpchChannelRecycleError::InvalidOutState {
+                return self.fail(RpchChannelRecycleError::InvalidOutState {
                     action: "read the successor OUT channel cookie",
                     state: self.out_state,
                 });
             }
         };
         let a11 = encode_rts_out_recycle_a11()?;
-        self.default_out_channel_cookie = successor_channel_cookie;
+        self.setup.out_channel_cookie = successor_channel_cookie;
         self.successor_out_channel_cookie = None;
-        self.out_state = RpchOutChannelRecycleState::Open;
+        self.out_state = RpchOutChannelRecycleState::AwaitingA11;
         Ok(a11)
     }
 
-    fn fail_in<T>(&mut self, error: RpchChannelRecycleError) -> Result<T, RpchChannelRecycleError> {
-        // A protocol error terminates the entire virtual connection.
-        self.in_state = RpchInChannelRecycleState::Failed;
-        self.out_state = RpchOutChannelRecycleState::Failed;
-        Err(error)
+    /// Completes OUT recycling after OUT_R1/A11 was sent.
+    ///
+    /// The caller must retain the supplied state for the virtual connection.
+    ///
+    /// [MS-RPCH] 3.2.2.5.8.
+    pub fn finish_out_recycling(&mut self, flow_control: &mut RpchFlowControl) -> Result<(), RpchChannelRecycleError> {
+        if self.out_state != RpchOutChannelRecycleState::AwaitingA11 {
+            return self.fail(RpchChannelRecycleError::InvalidOutState {
+                action: "finish OUT channel recycling",
+                state: self.out_state,
+            });
+        }
+
+        flow_control.reset_receiving_channel(self.default_out_channel_cookie());
+        self.out_state = RpchOutChannelRecycleState::Open;
+        Ok(())
     }
 
-    fn fail_out<T>(&mut self, error: RpchChannelRecycleError) -> Result<T, RpchChannelRecycleError> {
+    fn fail<T>(&mut self, error: RpchChannelRecycleError) -> Result<T, RpchChannelRecycleError> {
+        // A protocol error terminates the entire virtual connection.
+        self.setup.state = RpchV2State::Failed;
         self.in_state = RpchInChannelRecycleState::Failed;
         self.out_state = RpchOutChannelRecycleState::Failed;
         Err(error)
@@ -2954,6 +2990,21 @@ impl RpchFlowControl {
         }
     }
 
+    fn reset_sending_channel(&mut self, peer_receive_window_size: u32, channel_cookie: RtsCookie) {
+        self.peer_receive_window_size = peer_receive_window_size;
+        self.send_available_window = peer_receive_window_size;
+        self.send_bytes_sent = 0;
+        self.send_bytes_acknowledged = 0;
+        self.send_channel_cookie = channel_cookie;
+    }
+
+    fn reset_receiving_channel(&mut self, channel_cookie: RtsCookie) {
+        self.receive_available_window = self.receive_window_size;
+        self.receive_available_window_advertised = i64::from(self.receive_window_size);
+        self.receive_bytes_received = 0;
+        self.receive_channel_cookie = channel_cookie;
+    }
+
     /// Current available capacity for IN-channel RPC PDUs.
     pub const fn send_available_window(&self) -> u32 {
         self.send_available_window
@@ -3089,6 +3140,10 @@ impl RpchPingSchedule {
             keepalive_interval,
             last_send: now,
         }
+    }
+
+    fn set_connection_timeout(&mut self, connection_timeout: u32) {
+        self.connection_timeout = Duration::from_millis(u64::from(connection_timeout));
     }
 
     /// Returns whether a PING must be sent at `now`.
@@ -3268,7 +3323,14 @@ pub fn encode_rts_out_recycle_a7(successor_channel_cookie: RtsCookie) -> Result<
 /// [MS-RPCH] 2.2.4.32.
 pub fn decode_rts_out_recycle_a10(source: &[u8]) -> Result<(), RpcPduError> {
     let body = decode_rts_pdu(source, RTS_FLAG_NONE, 1, 4)?;
-    decode_rts_empty_command(body, 0, RTS_COMMAND_ANCE)
+    let command_type = read_u32(body, 0)?;
+    if command_type != RTS_COMMAND_ANCE {
+        return Err(RpcPduError::UnexpectedRtsCommandType {
+            expected: RTS_COMMAND_ANCE,
+            actual: command_type,
+        });
+    }
+    Ok(())
 }
 
 /// Encodes the client OUT_R1/A11 RTS PDU for a successor OUT channel.
@@ -3467,17 +3529,6 @@ fn decode_rts_u32_command(source: &[u8], offset: usize, expected_type: u32) -> R
 
     let value_offset = offset.checked_add(4).ok_or(RpcPduError::LengthOverflow)?;
     read_u32(source, value_offset)
-}
-
-fn decode_rts_empty_command(source: &[u8], offset: usize, expected_type: u32) -> Result<(), RpcPduError> {
-    let command_type = read_u32(source, offset)?;
-    if command_type != expected_type {
-        return Err(RpcPduError::UnexpectedRtsCommandType {
-            expected: expected_type,
-            actual: command_type,
-        });
-    }
-    Ok(())
 }
 
 fn validate_rts_receive_window_size(value: u32) -> Result<(), RpcPduError> {

--- a/crates/ironrdp-mstsgu/tests/rpch_v2.rs
+++ b/crates/ironrdp-mstsgu/tests/rpch_v2.rs
@@ -3,9 +3,12 @@
 use core::time::Duration;
 
 use ironrdp_mstsgu::rpc::{
-    PFC_FIRST_FRAG, PFC_LAST_FRAG, PTYPE_RTS, RPCH_OUT_CONTENT_LENGTH, RpcPduError, RpchFlowControlError, RpchV2Error,
-    RpchV2Settings, RpchV2Setup, RpchV2State, RtsCookie, RtsFlowControlAck, decode_rts_flow_control_ack,
-    encode_rts_conn_a1, encode_rts_conn_b1, encode_rts_flow_control_ack, encode_rts_ping,
+    PFC_FIRST_FRAG, PFC_LAST_FRAG, PTYPE_RTS, RPCH_OUT_CONTENT_LENGTH, RpcPduError, RpchFlowControlError,
+    RpchInChannelRecycleState, RpchOutChannelRecycleState, RpchV2Error, RpchV2Settings, RpchV2Setup, RpchV2State,
+    RtsCookie, RtsFlowControlAck, decode_rts_flow_control_ack, decode_rts_in_recycle_a4, decode_rts_out_recycle_a2,
+    decode_rts_out_recycle_a6, decode_rts_out_recycle_a10, encode_rts_conn_a1, encode_rts_conn_b1,
+    encode_rts_flow_control_ack, encode_rts_in_recycle_a1, encode_rts_in_recycle_a5, encode_rts_out_recycle_a3,
+    encode_rts_out_recycle_a7, encode_rts_out_recycle_a11, encode_rts_ping,
 };
 
 const VIRTUAL_CONNECTION_COOKIE: RtsCookie = RtsCookie::new([0x10; RtsCookie::SIZE]);
@@ -232,6 +235,252 @@ fn flow_control_accounts_windows_and_encodes_acknowledgements() {
     assert_eq!(
         decode_rts_flow_control_ack(&encoded_ack).expect("decode flow-control ACK"),
         acknowledgement
+    );
+}
+
+#[test]
+fn channel_recycling_encodes_exact_r1_vectors_and_updates_defaults() {
+    let successor_in_channel_cookie = RtsCookie::new([0x50; RtsCookie::SIZE]);
+    let successor_out_channel_cookie = RtsCookie::new([0x60; RtsCookie::SIZE]);
+    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+
+    let expected_in_a1 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &88u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &6u32.to_le_bytes(),
+        &1u32.to_le_bytes(),
+        &3u32.to_le_bytes(),
+        VIRTUAL_CONNECTION_COOKIE.as_bytes(),
+        &3u32.to_le_bytes(),
+        IN_CHANNEL_COOKIE.as_bytes(),
+        &3u32.to_le_bytes(),
+        successor_in_channel_cookie.as_bytes(),
+    ]
+    .concat();
+    assert_eq!(
+        recycling
+            .start_in_recycling(successor_in_channel_cookie)
+            .expect("IN_R1/A1"),
+        expected_in_a1
+    );
+    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::AwaitingA4);
+
+    let in_a4 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &52u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &13u32.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &6u32.to_le_bytes(),
+        &1u32.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &(8 * 1024u32).to_le_bytes(),
+        &2u32.to_le_bytes(),
+        &CONNECTION_TIMEOUT.to_le_bytes(),
+    ]
+    .concat();
+    let decoded_a4 = decode_rts_in_recycle_a4(&in_a4).expect("IN_R1/A4");
+    assert_eq!(decoded_a4.version(), 1);
+    assert_eq!(decoded_a4.receive_window_size(), 8 * 1024);
+    assert_eq!(decoded_a4.connection_timeout(), CONNECTION_TIMEOUT);
+
+    let expected_in_a5 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &40u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &1u16.to_le_bytes(),
+        &3u32.to_le_bytes(),
+        successor_in_channel_cookie.as_bytes(),
+    ]
+    .concat();
+    assert_eq!(
+        recycling.receive_in_recycle_a4(&in_a4).expect("IN_R1/A5"),
+        expected_in_a5
+    );
+    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::Open);
+    assert_eq!(recycling.default_in_channel_cookie(), successor_in_channel_cookie);
+    assert_eq!(recycling.peer_receive_window_size(), 8 * 1024);
+
+    let out_a2 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &28u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &1u16.to_le_bytes(),
+        &13u32.to_le_bytes(),
+        &0u32.to_le_bytes(),
+    ]
+    .concat();
+    decode_rts_out_recycle_a2(&out_a2).expect("OUT_R1/A2");
+    let expected_out_a3 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &96u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &5u16.to_le_bytes(),
+        &6u32.to_le_bytes(),
+        &1u32.to_le_bytes(),
+        &3u32.to_le_bytes(),
+        VIRTUAL_CONNECTION_COOKIE.as_bytes(),
+        &3u32.to_le_bytes(),
+        OUT_CHANNEL_COOKIE.as_bytes(),
+        &3u32.to_le_bytes(),
+        successor_out_channel_cookie.as_bytes(),
+        &0u32.to_le_bytes(),
+        &RECEIVE_WINDOW_SIZE.to_le_bytes(),
+    ]
+    .concat();
+    assert_eq!(
+        recycling
+            .receive_out_recycle_a2(&out_a2, successor_out_channel_cookie)
+            .expect("OUT_R1/A3"),
+        expected_out_a3
+    );
+    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA6);
+
+    let out_a6 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &44u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &0x10u16.to_le_bytes(),
+        &3u16.to_le_bytes(),
+        &13u32.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &6u32.to_le_bytes(),
+        &1u32.to_le_bytes(),
+        &2u32.to_le_bytes(),
+        &CONNECTION_TIMEOUT.to_le_bytes(),
+    ]
+    .concat();
+    let decoded_a6 = decode_rts_out_recycle_a6(&out_a6).expect("OUT_R1/A6");
+    assert_eq!(decoded_a6.version(), 1);
+    assert_eq!(decoded_a6.connection_timeout(), CONNECTION_TIMEOUT);
+
+    let expected_out_a7 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &48u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &0x10u16.to_le_bytes(),
+        &2u16.to_le_bytes(),
+        &13u32.to_le_bytes(),
+        &2u32.to_le_bytes(),
+        &3u32.to_le_bytes(),
+        successor_out_channel_cookie.as_bytes(),
+    ]
+    .concat();
+    assert_eq!(
+        recycling.receive_out_recycle_a6(&out_a6).expect("OUT_R1/A7"),
+        expected_out_a7
+    );
+    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA10);
+
+    let out_a10 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &24u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &1u16.to_le_bytes(),
+        &10u32.to_le_bytes(),
+    ]
+    .concat();
+    decode_rts_out_recycle_a10(&out_a10).expect("OUT_R1/A10");
+    assert_eq!(
+        recycling.receive_out_recycle_a10(&out_a10).expect("OUT_R1/A11"),
+        out_a10
+    );
+    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::Open);
+    assert_eq!(recycling.default_out_channel_cookie(), successor_out_channel_cookie);
+
+    assert_eq!(
+        encode_rts_in_recycle_a1(
+            VIRTUAL_CONNECTION_COOKIE,
+            IN_CHANNEL_COOKIE,
+            successor_in_channel_cookie,
+        )
+        .expect("IN_R1/A1"),
+        expected_in_a1
+    );
+    assert_eq!(
+        encode_rts_in_recycle_a5(successor_in_channel_cookie).expect("IN_R1/A5"),
+        expected_in_a5
+    );
+    assert_eq!(
+        encode_rts_out_recycle_a3(
+            VIRTUAL_CONNECTION_COOKIE,
+            OUT_CHANNEL_COOKIE,
+            successor_out_channel_cookie,
+            RECEIVE_WINDOW_SIZE,
+        )
+        .expect("OUT_R1/A3"),
+        expected_out_a3
+    );
+    assert_eq!(
+        encode_rts_out_recycle_a7(successor_out_channel_cookie).expect("OUT_R1/A7"),
+        expected_out_a7
+    );
+    assert_eq!(encode_rts_out_recycle_a11().expect("OUT_R1/A11"), out_a10);
+}
+
+#[test]
+fn channel_recycling_rejects_invalid_order_and_destinations() {
+    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+    let out_a2 = [
+        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+        &28u16.to_le_bytes(),
+        &0u16.to_le_bytes(),
+        &0u32.to_le_bytes(),
+        &4u16.to_le_bytes(),
+        &1u16.to_le_bytes(),
+        &13u32.to_le_bytes(),
+        &1u32.to_le_bytes(),
+    ]
+    .concat();
+    assert_eq!(
+        recycling.receive_out_recycle_a2(&out_a2, RtsCookie::new([0x60; RtsCookie::SIZE])),
+        Err(ironrdp_mstsgu::rpc::RpchChannelRecycleError::Rts(
+            RpcPduError::UnexpectedRtsDestination { expected: 0, actual: 1 }
+        ))
+    );
+    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::Failed);
+    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::Failed);
+    assert_eq!(
+        recycling.start_in_recycling(RtsCookie::new([0x50; RtsCookie::SIZE])),
+        Err(ironrdp_mstsgu::rpc::RpchChannelRecycleError::InvalidInState {
+            action: "start IN channel recycling",
+            state: RpchInChannelRecycleState::Failed,
+        })
+    );
+
+    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+    assert_eq!(
+        recycling.receive_in_recycle_a4(&[]),
+        Err(ironrdp_mstsgu::rpc::RpchChannelRecycleError::InvalidInState {
+            action: "accept IN_R1/A4",
+            state: RpchInChannelRecycleState::Open,
+        })
+    );
+    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::Failed);
+    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::Failed);
+    assert_eq!(
+        recycling.receive_out_recycle_a2(&[], RtsCookie::new([0x60; RtsCookie::SIZE])),
+        Err(ironrdp_mstsgu::rpc::RpchChannelRecycleError::InvalidOutState {
+            action: "accept OUT_R1/A2",
+            state: RpchOutChannelRecycleState::Failed,
+        })
     );
 }
 

--- a/crates/ironrdp-mstsgu/tests/rpch_v2.rs
+++ b/crates/ironrdp-mstsgu/tests/rpch_v2.rs
@@ -17,6 +17,7 @@ const IN_CHANNEL_COOKIE: RtsCookie = RtsCookie::new([0x30; RtsCookie::SIZE]);
 const ASSOCIATION_GROUP_ID: RtsCookie = RtsCookie::new([0x40; RtsCookie::SIZE]);
 const RECEIVE_WINDOW_SIZE: u32 = 128 * 1024;
 const CONNECTION_TIMEOUT: u32 = 120_000;
+const IN_RECYCLE_CONNECTION_TIMEOUT: u32 = 240_000;
 
 #[test]
 fn conn_a1_and_conn_b1_encode_exact_rts_vectors() {
@@ -242,202 +243,250 @@ fn flow_control_accounts_windows_and_encodes_acknowledgements() {
 fn channel_recycling_encodes_exact_r1_vectors_and_updates_defaults() {
     let successor_in_channel_cookie = RtsCookie::new([0x50; RtsCookie::SIZE]);
     let successor_out_channel_cookie = RtsCookie::new([0x60; RtsCookie::SIZE]);
-    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+    let mut setup = opened_setup(0);
+    let mut flow_control = setup.flow_control().expect("open flow control");
+    let mut ping_schedule = setup
+        .ping_schedule(Duration::ZERO, Duration::ZERO)
+        .expect("open ping schedule");
+    {
+        let mut recycling = setup.channel_recycling().expect("open setup");
 
-    let expected_in_a1 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &88u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &4u16.to_le_bytes(),
-        &4u16.to_le_bytes(),
-        &6u32.to_le_bytes(),
-        &1u32.to_le_bytes(),
-        &3u32.to_le_bytes(),
-        VIRTUAL_CONNECTION_COOKIE.as_bytes(),
-        &3u32.to_le_bytes(),
-        IN_CHANNEL_COOKIE.as_bytes(),
-        &3u32.to_le_bytes(),
-        successor_in_channel_cookie.as_bytes(),
-    ]
-    .concat();
-    assert_eq!(
+        let expected_in_a1 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &88u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &4u16.to_le_bytes(),
+            &4u16.to_le_bytes(),
+            &6u32.to_le_bytes(),
+            &1u32.to_le_bytes(),
+            &3u32.to_le_bytes(),
+            VIRTUAL_CONNECTION_COOKIE.as_bytes(),
+            &3u32.to_le_bytes(),
+            IN_CHANNEL_COOKIE.as_bytes(),
+            &3u32.to_le_bytes(),
+            successor_in_channel_cookie.as_bytes(),
+        ]
+        .concat();
+        assert_eq!(
+            recycling
+                .start_in_recycling(successor_in_channel_cookie)
+                .expect("IN_R1/A1"),
+            expected_in_a1
+        );
+        assert_eq!(recycling.in_state(), RpchInChannelRecycleState::AwaitingA4);
+
+        let in_a4 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &52u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &4u16.to_le_bytes(),
+            &13u32.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &6u32.to_le_bytes(),
+            &1u32.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &(8 * 1024u32).to_le_bytes(),
+            &2u32.to_le_bytes(),
+            &IN_RECYCLE_CONNECTION_TIMEOUT.to_le_bytes(),
+        ]
+        .concat();
+        let decoded_a4 = decode_rts_in_recycle_a4(&in_a4).expect("IN_R1/A4");
+        assert_eq!(decoded_a4.version(), 1);
+        assert_eq!(decoded_a4.receive_window_size(), 8 * 1024);
+        assert_eq!(decoded_a4.connection_timeout(), IN_RECYCLE_CONNECTION_TIMEOUT);
+
+        let expected_in_a5 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &40u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &1u16.to_le_bytes(),
+            &3u32.to_le_bytes(),
+            successor_in_channel_cookie.as_bytes(),
+        ]
+        .concat();
+        assert_eq!(
+            recycling.receive_in_recycle_a4(&in_a4).expect("IN_R1/A5"),
+            expected_in_a5
+        );
+        assert_eq!(recycling.in_state(), RpchInChannelRecycleState::AwaitingA5);
+        assert_eq!(recycling.default_in_channel_cookie(), successor_in_channel_cookie);
+        assert_eq!(recycling.peer_receive_window_size(), 8 * 1024);
         recycling
-            .start_in_recycling(successor_in_channel_cookie)
+            .finish_in_recycling(&mut flow_control, &mut ping_schedule)
+            .expect("IN_R1/A5 sent");
+        assert_eq!(recycling.in_state(), RpchInChannelRecycleState::Open);
+        flow_control
+            .sent_rpc_pdu(4 * 1024)
+            .expect("send on successor IN channel");
+        assert_eq!(
+            flow_control.receive_flow_control_ack(RtsFlowControlAck::new(
+                4 * 1024,
+                8 * 1024,
+                successor_in_channel_cookie,
+            )),
+            Ok(true)
+        );
+        assert!(!ping_schedule.ping_due(Duration::from_secs(239)));
+        assert!(ping_schedule.ping_due(Duration::from_secs(240)));
+
+        let out_a2 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &28u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &4u16.to_le_bytes(),
+            &1u16.to_le_bytes(),
+            &13u32.to_le_bytes(),
+            &0u32.to_le_bytes(),
+        ]
+        .concat();
+        decode_rts_out_recycle_a2(&out_a2).expect("OUT_R1/A2");
+        let expected_out_a3 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &96u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &4u16.to_le_bytes(),
+            &5u16.to_le_bytes(),
+            &6u32.to_le_bytes(),
+            &1u32.to_le_bytes(),
+            &3u32.to_le_bytes(),
+            VIRTUAL_CONNECTION_COOKIE.as_bytes(),
+            &3u32.to_le_bytes(),
+            OUT_CHANNEL_COOKIE.as_bytes(),
+            &3u32.to_le_bytes(),
+            successor_out_channel_cookie.as_bytes(),
+            &0u32.to_le_bytes(),
+            &RECEIVE_WINDOW_SIZE.to_le_bytes(),
+        ]
+        .concat();
+        assert_eq!(
+            recycling
+                .receive_out_recycle_a2(&out_a2, successor_out_channel_cookie)
+                .expect("OUT_R1/A3"),
+            expected_out_a3
+        );
+        assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA6);
+
+        let out_a6 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &44u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &0x10u16.to_le_bytes(),
+            &3u16.to_le_bytes(),
+            &13u32.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &6u32.to_le_bytes(),
+            &1u32.to_le_bytes(),
+            &2u32.to_le_bytes(),
+            &CONNECTION_TIMEOUT.to_le_bytes(),
+        ]
+        .concat();
+        let decoded_a6 = decode_rts_out_recycle_a6(&out_a6).expect("OUT_R1/A6");
+        assert_eq!(decoded_a6.version(), 1);
+        assert_eq!(decoded_a6.connection_timeout(), CONNECTION_TIMEOUT);
+
+        let expected_out_a7 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &48u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &0x10u16.to_le_bytes(),
+            &2u16.to_le_bytes(),
+            &13u32.to_le_bytes(),
+            &2u32.to_le_bytes(),
+            &3u32.to_le_bytes(),
+            successor_out_channel_cookie.as_bytes(),
+        ]
+        .concat();
+        assert_eq!(
+            recycling.receive_out_recycle_a6(&out_a6).expect("OUT_R1/A7"),
+            expected_out_a7
+        );
+        assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA10);
+
+        let out_a10 = [
+            [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &24u16.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &0u32.to_le_bytes(),
+            &0u16.to_le_bytes(),
+            &1u16.to_le_bytes(),
+            &10u32.to_le_bytes(),
+        ]
+        .concat();
+        decode_rts_out_recycle_a10(&out_a10).expect("OUT_R1/A10");
+        assert_eq!(
+            recycling.receive_out_recycle_a10(&out_a10).expect("OUT_R1/A11"),
+            out_a10
+        );
+        assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA11);
+        assert_eq!(recycling.default_out_channel_cookie(), successor_out_channel_cookie);
+        recycling
+            .finish_out_recycling(&mut flow_control)
+            .expect("OUT_R1/A11 sent");
+        assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::Open);
+        flow_control
+            .received_rpc_pdu(64 * 1024)
+            .expect("receive on successor OUT channel");
+        assert_eq!(
+            flow_control.consumed_rpc_pdu(64 * 1024),
+            Ok(Some(RtsFlowControlAck::new(
+                64 * 1024,
+                RECEIVE_WINDOW_SIZE,
+                successor_out_channel_cookie,
+            )))
+        );
+        assert_eq!(
+            encode_rts_in_recycle_a1(
+                VIRTUAL_CONNECTION_COOKIE,
+                IN_CHANNEL_COOKIE,
+                successor_in_channel_cookie,
+            )
             .expect("IN_R1/A1"),
-        expected_in_a1
-    );
-    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::AwaitingA4);
-
-    let in_a4 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &52u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &4u16.to_le_bytes(),
-        &13u32.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &6u32.to_le_bytes(),
-        &1u32.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &(8 * 1024u32).to_le_bytes(),
-        &2u32.to_le_bytes(),
-        &CONNECTION_TIMEOUT.to_le_bytes(),
-    ]
-    .concat();
-    let decoded_a4 = decode_rts_in_recycle_a4(&in_a4).expect("IN_R1/A4");
-    assert_eq!(decoded_a4.version(), 1);
-    assert_eq!(decoded_a4.receive_window_size(), 8 * 1024);
-    assert_eq!(decoded_a4.connection_timeout(), CONNECTION_TIMEOUT);
-
-    let expected_in_a5 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &40u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &1u16.to_le_bytes(),
-        &3u32.to_le_bytes(),
-        successor_in_channel_cookie.as_bytes(),
-    ]
-    .concat();
-    assert_eq!(
-        recycling.receive_in_recycle_a4(&in_a4).expect("IN_R1/A5"),
-        expected_in_a5
-    );
-    assert_eq!(recycling.in_state(), RpchInChannelRecycleState::Open);
-    assert_eq!(recycling.default_in_channel_cookie(), successor_in_channel_cookie);
-    assert_eq!(recycling.peer_receive_window_size(), 8 * 1024);
-
-    let out_a2 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &28u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &4u16.to_le_bytes(),
-        &1u16.to_le_bytes(),
-        &13u32.to_le_bytes(),
-        &0u32.to_le_bytes(),
-    ]
-    .concat();
-    decode_rts_out_recycle_a2(&out_a2).expect("OUT_R1/A2");
-    let expected_out_a3 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &96u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &4u16.to_le_bytes(),
-        &5u16.to_le_bytes(),
-        &6u32.to_le_bytes(),
-        &1u32.to_le_bytes(),
-        &3u32.to_le_bytes(),
-        VIRTUAL_CONNECTION_COOKIE.as_bytes(),
-        &3u32.to_le_bytes(),
-        OUT_CHANNEL_COOKIE.as_bytes(),
-        &3u32.to_le_bytes(),
-        successor_out_channel_cookie.as_bytes(),
-        &0u32.to_le_bytes(),
-        &RECEIVE_WINDOW_SIZE.to_le_bytes(),
-    ]
-    .concat();
-    assert_eq!(
-        recycling
-            .receive_out_recycle_a2(&out_a2, successor_out_channel_cookie)
+            expected_in_a1
+        );
+        assert_eq!(
+            encode_rts_in_recycle_a5(successor_in_channel_cookie).expect("IN_R1/A5"),
+            expected_in_a5
+        );
+        assert_eq!(
+            encode_rts_out_recycle_a3(
+                VIRTUAL_CONNECTION_COOKIE,
+                OUT_CHANNEL_COOKIE,
+                successor_out_channel_cookie,
+                RECEIVE_WINDOW_SIZE,
+            )
             .expect("OUT_R1/A3"),
-        expected_out_a3
-    );
-    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA6);
-
-    let out_a6 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &44u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &0x10u16.to_le_bytes(),
-        &3u16.to_le_bytes(),
-        &13u32.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &6u32.to_le_bytes(),
-        &1u32.to_le_bytes(),
-        &2u32.to_le_bytes(),
-        &CONNECTION_TIMEOUT.to_le_bytes(),
-    ]
-    .concat();
-    let decoded_a6 = decode_rts_out_recycle_a6(&out_a6).expect("OUT_R1/A6");
-    assert_eq!(decoded_a6.version(), 1);
-    assert_eq!(decoded_a6.connection_timeout(), CONNECTION_TIMEOUT);
-
-    let expected_out_a7 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &48u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &0x10u16.to_le_bytes(),
-        &2u16.to_le_bytes(),
-        &13u32.to_le_bytes(),
-        &2u32.to_le_bytes(),
-        &3u32.to_le_bytes(),
-        successor_out_channel_cookie.as_bytes(),
-    ]
-    .concat();
+            expected_out_a3
+        );
+        assert_eq!(
+            encode_rts_out_recycle_a7(successor_out_channel_cookie).expect("OUT_R1/A7"),
+            expected_out_a7
+        );
+        assert_eq!(encode_rts_out_recycle_a11().expect("OUT_R1/A11"), out_a10);
+    }
+    assert_eq!(setup.in_channel_ping_timeout(), Some(IN_RECYCLE_CONNECTION_TIMEOUT));
+    assert_eq!(setup.peer_receive_window_size(), Some(8 * 1024));
     assert_eq!(
-        recycling.receive_out_recycle_a6(&out_a6).expect("OUT_R1/A7"),
-        expected_out_a7
+        setup
+            .flow_control()
+            .expect("updated flow control")
+            .send_available_window(),
+        8 * 1024
     );
-    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::AwaitingA10);
-
-    let out_a10 = [
-        [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
-        &24u16.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &0u32.to_le_bytes(),
-        &0u16.to_le_bytes(),
-        &1u16.to_le_bytes(),
-        &10u32.to_le_bytes(),
-    ]
-    .concat();
-    decode_rts_out_recycle_a10(&out_a10).expect("OUT_R1/A10");
-    assert_eq!(
-        recycling.receive_out_recycle_a10(&out_a10).expect("OUT_R1/A11"),
-        out_a10
-    );
-    assert_eq!(recycling.out_state(), RpchOutChannelRecycleState::Open);
-    assert_eq!(recycling.default_out_channel_cookie(), successor_out_channel_cookie);
-
-    assert_eq!(
-        encode_rts_in_recycle_a1(
-            VIRTUAL_CONNECTION_COOKIE,
-            IN_CHANNEL_COOKIE,
-            successor_in_channel_cookie,
-        )
-        .expect("IN_R1/A1"),
-        expected_in_a1
-    );
-    assert_eq!(
-        encode_rts_in_recycle_a5(successor_in_channel_cookie).expect("IN_R1/A5"),
-        expected_in_a5
-    );
-    assert_eq!(
-        encode_rts_out_recycle_a3(
-            VIRTUAL_CONNECTION_COOKIE,
-            OUT_CHANNEL_COOKIE,
-            successor_out_channel_cookie,
-            RECEIVE_WINDOW_SIZE,
-        )
-        .expect("OUT_R1/A3"),
-        expected_out_a3
-    );
-    assert_eq!(
-        encode_rts_out_recycle_a7(successor_out_channel_cookie).expect("OUT_R1/A7"),
-        expected_out_a7
-    );
-    assert_eq!(encode_rts_out_recycle_a11().expect("OUT_R1/A11"), out_a10);
 }
 
 #[test]
 fn channel_recycling_rejects_invalid_order_and_destinations() {
-    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+    let mut setup = opened_setup(0);
+    let mut recycling = setup.channel_recycling().expect("open setup");
     let out_a2 = [
         [5, 0, PTYPE_RTS, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
         &28u16.to_le_bytes(),
@@ -465,7 +514,8 @@ fn channel_recycling_rejects_invalid_order_and_destinations() {
         })
     );
 
-    let mut recycling = opened_setup(0).channel_recycling().expect("open setup");
+    let mut setup = opened_setup(0);
+    let mut recycling = setup.channel_recycling().expect("open setup");
     assert_eq!(
         recycling.receive_in_recycle_a4(&[]),
         Err(ironrdp_mstsgu::rpc::RpchChannelRecycleError::InvalidInState {


### PR DESCRIPTION
Add wire codecs and ordering validation for v2 R1 recycling.

Retain canonical recycle state and reopen channels only after the final RTS action is sent. Keep transport execution separate, and use the typed output test channel required for workspace test compilation.