### PR TITLE
fix(daemon): construct test output channels via output_channel()

### DIFF
--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -2234,7 +2234,7 @@ mod tests {
     #[tokio::test]
     async fn connection_failure_status_preserves_gateway_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,
@@ -2271,7 +2271,7 @@ mod tests {
     #[tokio::test]
     async fn terminated_error_status_preserves_session_error_sources() {
         let (daemon, _, live, rail_notify) = active_rail_session(false);
-        let (output_tx, output_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = output_channel(1);
         let consumer = tokio::spawn(consume_output(
             output_rx,
             live,


### PR DESCRIPTION
`cargo check -p ironrdp-daemon --tests` currently fails on bare `master` with two
`E0308` errors at `daemon.rs:2239` and `:2276`: `expected OutputEventReceiver,
found tokio::sync::mpsc::Receiver<_>`.

`connection_failure_status_preserves_gateway_error_sources` and
`terminated_error_status_preserves_session_error_sources` (added by #1822,
merged after #1815 changed `consume_output`'s parameter type) construct
`output_rx` via the pre-#1815 `mpsc::channel(1)` pattern. Every other call site
in this file, five of them, already uses #1815's `output_channel(1)`
constructor; these two were missed. Swaps both to match.

No behavior change: `output_channel(1)` still yields an
`(OutputEventSender, OutputEventReceiver)` pair consumed identically by both
tests, both of which construct a `MustDeliver`-classified event
(`ConnectionFailure`, `Terminated`), unaffected by the drop-policy routing
#1815 introduced.
