### PR TITLE
feat(session): handle multitransport on message channel

### DIFF
--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -13,7 +13,7 @@ use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
 use ironrdp_pdu::rdp::capability_sets::WindowSupportLevel;
 use ironrdp_pdu::rdp::client_info::CompressionType;
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
-use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu};
 use ironrdp_pdu::rdp::refresh_rectangle::RefreshRectanglePdu;
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use ironrdp_pdu::rdp::suppress_output::SuppressOutputPdu;
@@ -423,6 +423,11 @@ impl ActiveStage {
     /// Send a pdu on the static global channel. Typically used to send input events
     pub fn encode_static(&self, output: &mut WriteBuf, pdu: ShareDataPdu) -> SessionResult<usize> {
         self.x224_processor.encode_static(output, pdu)
+    }
+
+    /// Encodes an Initiate Multitransport Response on the negotiated MCS message channel.
+    pub fn encode_multitransport_response(&self, response: &MultitransportResponsePdu) -> SessionResult<Vec<u8>> {
+        self.x224_processor.encode_multitransport_response(response)
     }
 
     pub fn get_svc_processor<T: SvcProcessor + 'static>(&mut self) -> Option<&T> {
@@ -917,6 +922,32 @@ mod tests {
 
         assert_eq!(stage.request_full_redraw(1024, 768, true, false).unwrap().len(), 1);
         assert!(stage.request_full_redraw(1024, 768, false, false).unwrap().is_empty());
+    }
+
+    #[test]
+    fn multitransport_response_encoder_is_exposed_through_active_stage() {
+        let stage = ActiveStageBuilder {
+            static_channels: StaticChannelSet::new(),
+            user_channel_id: 1001,
+            io_channel_id: 1003,
+            message_channel_id: Some(1004),
+            share_id: 1,
+            compression_type: None,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let response = MultitransportResponsePdu::success(42);
+
+        assert_eq!(
+            stage
+                .encode_multitransport_response(&response)
+                .expect("encode through ActiveStage"),
+            stage
+                .x224_processor
+                .encode_multitransport_response(&response)
+                .expect("encode through X.224 processor")
+        );
     }
 
     #[test]

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -9,7 +9,7 @@ use ironrdp_pdu::rdp::headers::{
     BasicSecurityHeader, BasicSecurityHeaderFlags, CompressionFlags, ShareDataCtx, ShareDataPdu,
 };
 use ironrdp_pdu::rdp::heartbeat::HeartbeatPdu;
-use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::rdp::session_info::{InfoData, SaveSessionInfoPdu, ServerAutoReconnect};
 use ironrdp_pdu::x224::X224;
@@ -40,7 +40,7 @@ pub enum ProcessorOutput {
     SaveSessionInfo { logon_complete: bool },
     /// Server Initiate Multitransport Request. The application should establish a
     /// sideband UDP transport using the request ID and security cookie, then send
-    /// a [`MultitransportResponsePdu`] back on the IO channel.
+    /// a [`MultitransportResponsePdu`] back on the message channel.
     ///
     /// See [\[MS-RDPBCGR\] 2.2.15.1].
     ///
@@ -261,10 +261,10 @@ impl Processor {
             ironrdp_pdu::rdp::headers::IoChannelPdu::Data(ctx) => Self::process_share_data(ctx, bulk_decompressor),
             ironrdp_pdu::rdp::headers::IoChannelPdu::MultitransportRequest(pdu) => {
                 debug!(
-                    "Received Initiate Multitransport Request: request_id={}",
-                    pdu.request_id
+                    request_id = pdu.request_id,
+                    "Ignoring Initiate Multitransport Request received outside the MCS message channel"
                 );
-                Ok(vec![ProcessorOutput::MultitransportRequest(pdu)])
+                Ok(Vec::new())
             }
             ironrdp_pdu::rdp::headers::IoChannelPdu::DeactivateAll(_) => Ok(vec![ProcessorOutput::DeactivateAll]),
         }
@@ -399,9 +399,10 @@ impl Processor {
     }
 
     /// Process a PDU received on the MCS message channel: auto-detect
-    /// ([MS-RDPBCGR] 2.2.14) or Heartbeat ([MS-RDPBCGR] 2.2.16.1).
+    /// ([MS-RDPBCGR] 2.2.14), multitransport ([MS-RDPBCGR] 2.2.15), or
+    /// Heartbeat ([MS-RDPBCGR] 2.2.16.1).
     ///
-    /// The two PDU families share the channel and are told apart by the
+    /// The PDU families share the channel and are told apart by the
     /// `BasicSecurityHeader` flags (masking off `SEC_RESET_SEQNO`/
     /// `SEC_IGNORE_SEQNO`, which the spec says MUST be ignored, before
     /// comparing), peeked here before committing to either decode. Any other
@@ -429,6 +430,15 @@ impl Processor {
                 "Received Heartbeat PDU"
             );
             return Ok(Vec::new());
+        }
+
+        if flags == BasicSecurityHeaderFlags::TRANSPORT_REQ {
+            let request = decode::<MultitransportRequestPdu>(data_ctx.user_data).map_err(SessionError::decode)?;
+            debug!(
+                request_id = request.request_id,
+                "Received Initiate Multitransport Request"
+            );
+            return Ok(vec![ProcessorOutput::MultitransportRequest(request)]);
         }
 
         if flags != BasicSecurityHeaderFlags::AUTODETECT_REQ {
@@ -461,6 +471,21 @@ impl Processor {
                 Ok(Vec::new())
             }
         }
+    }
+
+    /// Encodes an Initiate Multitransport Response on the MCS message channel.
+    ///
+    /// See [\[MS-RDPBCGR\] 2.2.15.2].
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
+    pub fn encode_multitransport_response(&self, response: &MultitransportResponsePdu) -> SessionResult<Vec<u8>> {
+        let message_channel_id = self
+            .message_channel_id
+            .ok_or_else(|| reason_err!("message channel", "no message channel negotiated"))?;
+        let mut frame = WriteBuf::new();
+        ironrdp_pdu::mcs::encode_send_data_request(self.user_channel_id, message_channel_id, response, &mut frame)
+            .map_err(SessionError::encode)?;
+        Ok(frame.into_inner())
     }
 
     /// Send a pdu on the static global channel. Typically used to send input events
@@ -507,9 +532,21 @@ mod tests {
     use ironrdp_pdu::gcc::MonitorFlags;
     use ironrdp_pdu::rdp::finalization_messages::MonitorLayoutPdu;
     use ironrdp_pdu::rdp::headers::ShareDataPduType;
+    use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
     use ironrdp_pdu::rdp::session_info::{InfoType, LogonExFlags, LogonInfoExtended};
 
     use super::*;
+
+    fn multitransport_request() -> MultitransportRequestPdu {
+        MultitransportRequestPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+            },
+            request_id: 42,
+            requested_protocol: RequestedProtocol::UdpFecR,
+            security_cookie: [0xAB; 16],
+        }
+    }
 
     #[test]
     fn processor_decompresses_slow_path_share_data() {
@@ -548,6 +585,79 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn processor_surfaces_multitransport_request_on_message_channel() {
+        let request = multitransport_request();
+        let encoded = encode_vec(&request).expect("encode multitransport request");
+        let processor = Processor::new(StaticChannelSet::new(), 1002, 1003, Some(1004), 0);
+
+        let outputs = processor
+            .process_message_channel(SendDataIndicationCtx {
+                initiator_id: 1002,
+                channel_id: 1004,
+                user_data: &encoded,
+            })
+            .expect("surface multitransport request");
+
+        assert!(matches!(
+            outputs.as_slice(),
+            [ProcessorOutput::MultitransportRequest(decoded)] if decoded == &request
+        ));
+    }
+
+    #[test]
+    fn processor_ignores_multitransport_request_on_io_channel() {
+        let request = multitransport_request();
+        let encoded = encode_vec(&request).expect("encode multitransport request");
+        let mut processor = Processor::new(StaticChannelSet::new(), 1002, 1003, Some(1004), 0);
+
+        let outputs = processor
+            .process_io_channel(
+                SendDataIndicationCtx {
+                    initiator_id: 1002,
+                    channel_id: 1003,
+                    user_data: &encoded,
+                },
+                &mut None,
+            )
+            .expect("ignore a misrouted optional multitransport request");
+
+        assert!(outputs.is_empty());
+    }
+
+    #[test]
+    fn processor_encodes_multitransport_response_on_message_channel() {
+        let processor = Processor::new(StaticChannelSet::new(), 1002, 1003, Some(1004), 0);
+        let response = MultitransportResponsePdu::success(42);
+
+        let frame = processor
+            .encode_multitransport_response(&response)
+            .expect("encode multitransport response");
+        let X224(McsMessage::SendDataRequest(request)) =
+            decode::<X224<McsMessage<'_>>>(&frame).expect("decode MCS Send Data Request")
+        else {
+            panic!("expected MCS Send Data Request");
+        };
+
+        assert_eq!(request.initiator_id, 1002);
+        assert_eq!(request.channel_id, 1004);
+        assert_eq!(
+            decode::<MultitransportResponsePdu>(&request.user_data).expect("decode multitransport response"),
+            response
+        );
+    }
+
+    #[test]
+    fn processor_rejects_multitransport_response_without_message_channel() {
+        let processor = Processor::new(StaticChannelSet::new(), 1002, 1003, None, 0);
+
+        let error = processor
+            .encode_multitransport_response(&MultitransportResponsePdu::success(42))
+            .expect_err("message channel is required");
+
+        assert!(error.to_string().contains("no message channel negotiated"));
     }
 
     #[test]

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -16,6 +16,8 @@ use ironrdp_pdu::rdp::headers::{
 use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
+use ironrdp_session::x224::{Processor, ProcessorOutput};
+use ironrdp_svc::StaticChannelSet;
 
 use ironrdp_testsuite_core::capsets::SERVER_DEMAND_ACTIVE;
 
@@ -401,6 +403,28 @@ fn multitransport_request_is_surfaced_without_waiting_for_another_pdu() {
         "the request must be surfaced on arrival, not held pending a following PDU"
     );
     assert_eq!(connector.multitransport_request().unwrap().request_id, 1);
+}
+
+#[test]
+fn active_processor_surfaces_multitransport_request_on_message_channel() {
+    let request = multitransport_request(42, RequestedProtocol::UdpFecR);
+    let frame = encode_server_multitransport_request(&request, MESSAGE_CHANNEL_ID);
+    let mut processor = Processor::new(
+        StaticChannelSet::new(),
+        USER_CHANNEL_ID,
+        IO_CHANNEL_ID,
+        Some(MESSAGE_CHANNEL_ID),
+        SHARE_ID,
+    );
+
+    let outputs = processor
+        .process(&frame, &mut None)
+        .expect("active processor should surface multitransport request");
+
+    assert!(matches!(
+        outputs.as_slice(),
+        [ProcessorOutput::MultitransportRequest(decoded)] if decoded == &request
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Route SEC_TRANSPORT_REQ through the negotiated MCS message channel and surface the decoded request to active-session consumers. Encode the client response on the same channel, expose that encoder through ActiveStage, and fail explicitly when the message channel was not negotiated.

Ignore a request received on the I/O channel because the specification does not require terminating the main session for this optional transport anomaly.