### PR TITLE
fix(pdu): ignore undefined channel option bits instead of refusing

### DIFF
--- a/crates/ironrdp-pdu/src/gcc/network_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/network_data.rs
@@ -279,8 +279,19 @@ impl<'de> Decode<'de> for ChannelDef {
         let name = src.read_array();
         let name = ChannelName::new(name);
 
-        let options = ChannelOptions::from_bits(src.read_u32())
-            .ok_or_else(|| invalid_field_err!("options", "invalid channel options", in: src))?;
+        // Undefined bits are dropped rather than rejected. [MS-RDPBCGR]
+        // 2.2.1.3.4.1 never asks a server to validate this field, and for five
+        // of the eleven flags it asks the opposite: CHANNEL_OPTION_INITIALIZED,
+        // ENCRYPT_RDP, ENCRYPT_SC and ENCRYPT_CS are each "unused and its value
+        // MUST be ignored by the server", and SHOW_PROTOCOL likewise.
+        //
+        // Rejecting is not only stricter than the protocol, it costs real
+        // sessions. rdesktop 1.9.0 writes this one field big-endian while the
+        // rest of the block is little-endian (secure.c:516 uses
+        // `out_uint32_be`), so every channel it registers arrives byte-swapped
+        // and every bit lands outside the mask -- and a server that rejects
+        // drops the connection at GCC, before any channel is joined.
+        let options = ChannelOptions::from_bits_truncate(src.read_u32());
 
         Ok(Self { name, options })
     }
@@ -301,5 +312,43 @@ bitflags! {
         const COMPRESS = 0x0040_0000;
         const SHOW_PROTOCOL = 0x0020_0000;
         const REMOTE_CONTROL_PERSISTENT = 0x0010_0000;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel_def(name: &[u8; 8], options: u32) -> Vec<u8> {
+        let mut bytes = name.to_vec();
+        bytes.extend_from_slice(&options.to_le_bytes());
+        bytes
+    }
+
+    /// [MS-RDPBCGR] 2.2.1.3.4.1 asks the server to ignore several of these
+    /// flags and never asks it to validate the field, so a bit the server does
+    /// not know is not a reason to refuse the connection.
+    #[test]
+    fn undefined_option_bits_are_dropped_rather_than_refused() {
+        let known = ChannelOptions::INITIALIZED | ChannelOptions::COMPRESS_RDP;
+        let bytes = channel_def(b"rdpdr\0\0\0", known.bits() | 0x0000_0044);
+
+        let decoded = ChannelDef::decode(&mut ReadCursor::new(&bytes)).expect("undefined bits are not fatal");
+
+        assert_eq!(decoded.options, known);
+    }
+
+    /// The value rdesktop 1.9.0 actually puts on the wire for its clipboard
+    /// channel: its flags written big-endian in a little-endian field, so every
+    /// set bit is undefined. Refusing it drops the connection at GCC, before a
+    /// single channel is joined.
+    #[test]
+    fn a_wholly_undefined_value_still_yields_a_channel() {
+        let bytes = channel_def(b"cliprdr\0", u32::from_le_bytes([0xc0, 0xa0, 0x00, 0x00]));
+
+        let decoded = ChannelDef::decode(&mut ReadCursor::new(&bytes)).expect("still a channel");
+
+        assert_eq!(decoded.name.as_str(), Some("cliprdr"));
+        assert_eq!(decoded.options, ChannelOptions::empty());
     }
 }


### PR DESCRIPTION
`ChannelDef::decode` rejects the whole PDU when `options` carries a bit outside the eleven defined flags. [MS-RDPBCGR] 2.2.1.3.4.1 does not ask a server to validate that field, and for several of the flags it asks the opposite — `CHANNEL_OPTION_INITIALIZED`, `ENCRYPT_RDP`, `ENCRYPT_SC` and `ENCRYPT_CS` are each *"unused and its value MUST be ignored by the server"*, and `CHANNEL_OPTION_SHOW_PROTOCOL` likewise.

So the strictness is not the protocol's, and it costs sessions.

### What it costs

**rdesktop 1.9.0 cannot connect to an IronRDP server at all.** It writes this one field big-endian while the rest of `TS_UD_CS_NET` is little-endian — `secure.c:516` uses `out_uint32_be` where every neighbouring field uses `out_uint32_le` — so each channel's flags arrive byte-swapped and every set bit lands outside the mask.

Captured from the wire against an IronRDP-based server:

```
GCC user-data header: 03 c0 44 00      type 0xC003 (CS_NET), blockLen 68 = 4 + 64
channelCount:         05 00 00 00      little-endian, correct
"cliprdr"  c0 a0 00 00   ->  read as 0x0000a0c0
"rdpsnd"   c0 00 00 00   ->  read as 0x000000c0
"snddbg"   c0 00 00 00
"rdpdr"    80 80 00 00   ->  read as 0x00008080
"drdynvc"  c0 00 00 00
```

Read big-endian those are exactly the constants rdesktop registers — `0xC0A00000`, `0xC0000000`, `0x80800000` — five channels for five. This is a client bug, not a vendor extension, but it is a client that has shipped for years, and the connection dies at GCC before a single channel is joined.

Two alternative explanations were checked against the same bytes and ruled out: the block is not misaligned (`4 + 5*12 = 64` is exactly `blockLen`, and each name lands on an 8-byte boundary as clean NUL-terminated ASCII), and `channelCount` is not misread.

### After

With the mask, the same client completes MCS Connect Response, Erect Domain, Attach User, all six channel joins (1002–1008), the Client Info PDU, licensing `StatusValidClient` and `ClientConfirmActive` with full capability sets, and holds a session. This single field was the whole obstacle.

### Why dropping the bits is safe

Nothing on the server side reads them: `ironrdp-acceptor`'s `connection.rs` matches channels by `name` alone, and the field it stores is still marked `// TODO: what about ChannelDef?`. `ChannelOptions` is consumed only by the client-side builder in `ironrdp-svc`.

Detecting the byte order and swapping would be the wrong repair — a conforming client's legitimate options can alias a byte-swapped value, so it would misparse correct input to accommodate incorrect input.

### Tests

Two, both verified to fail if the strict `from_bits` is put back: a value mixing known and unknown bits keeps the known ones, and the wholly-undefined value rdesktop actually sends still yields a channel. `cargo test -p ironrdp-pdu` — 422 passed.
