### PR TITLE
feat(mstsgu): add NTLM RPC association setup

### DIFF
--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
 - Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 - DCE/RPC common-header fragment codecs and response reassembly, without a live RPC-over-HTTP transport.
+- NTLM-authenticated DCE/RPC bind, bind_ack, and rpc_auth_3 association codecs without a live RPC-over-HTTP transport or authenticated request/response traffic.
 - Decode and expose tunnel-authorization policy fields (`redirFlags`, `idleTimeout`, and `SoHResponse`) without enforcing redirection restrictions or idle timeouts.
 - Decode gateway consent messages and let callers accept or decline them before tunnel authorization.
 

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -16,7 +16,7 @@ This crate
 - can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,
 - rejects unsupported `HTTP_EXTENDED_AUTH_SC` and PAA exchanges without a credential-provider UI,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,
-- encodes and decodes DCE/RPC common-header fragments and reassembles responses, without a live RPC-over-HTTP transport, and
+- encodes and decodes DCE/RPC common-header fragments plus the NTLM bind/bind_ack/rpc_auth_3 association exchange, but not live RPC-over-HTTP transport or authenticated request/response traffic, and
 - finishes write-side shutdown by closing the outbound WebSocket or ending the dual HTTP IN request body.
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -1,9 +1,9 @@
-//! DCE/RPC common-header, fragment, and RPCH v2 setup codecs.
+//! DCE/RPC common-header, fragment, NTLM association, and RPCH v2 setup codecs.
 //!
 //! This module frames connection-oriented DCE/RPC PDUs and the initial RPC-over-HTTP v2 RTS exchange.
 //! It is not a live RPC-over-HTTP transport.
 //! The staged TsProxy NDR control codecs do not provide a live RPC-over-HTTP transport.
-//! Packet-integrity signing and the RPCH client belong in later work.
+//! Authenticated request/response packet-integrity processing and the RPCH client belong in later work.
 //!
 //! [C706]: https://pubs.opengroup.org/onlinepubs/9629399/toc.htm
 //! [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
@@ -11,7 +11,13 @@
 
 use core::{fmt, time::Duration};
 
+use sspi::{
+    AuthIdentity, AuthIdentityBuffers, BufferType, ClientRequestFlags, CredentialUse, DataRepresentation,
+    InitializeSecurityContextResult, Ntlm, SecurityBuffer, SecurityStatus, Sspi as _, SspiImpl as _, Username,
+};
 use uuid::Uuid;
+
+use crate::{Error, GwErrorExt as _, GwErrorKind};
 
 /// DCE/RPC common-header size.
 ///
@@ -33,6 +39,8 @@ const RPC_REQUEST_HEADER_SIZE: usize =
 const RPC_RESPONSE_HEADER_SIZE: usize =
     4 /* alloc_hint */ + 2 /* p_cont_id */ + 1 /* cancel_count */ + 1 /* reserved */;
 const RPC_FAULT_HEADER_SIZE: usize = RPC_RESPONSE_HEADER_SIZE + 4 /* status */ + 4 /* reserved2 */;
+const RPC_SEC_TRAILER_SIZE: usize =
+    1 /* auth_type */ + 1 /* auth_level */ + 1 /* auth_pad_length */ + 1 /* auth_reserved */ + 4; /* auth_context_id */
 const RPC_BIND_HEADER_SIZE: usize =
     2 /* max_xmit_frag */ + 2 /* max_recv_frag */ + 4 /* assoc_group_id */ + 1 /* n_context_elem */ + 1 /* reserved */ + 2 /* reserved2 */;
 const RPC_BIND_ACK_HEADER_SIZE: usize =
@@ -54,6 +62,8 @@ pub const RPC_DREP_LITTLE_ENDIAN: [u8; 4] = [0x10, 0, 0, 0];
 pub const PFC_FIRST_FRAG: u8 = 0x01;
 /// Last fragment of a fragmented PDU ([C706] 12.6.2).
 pub const PFC_LAST_FRAG: u8 = 0x02;
+/// Security provider supports protecting PDU headers ([MS-RPCE] 2.2.2.3).
+pub const PFC_SUPPORT_HEADER_SIGN: u8 = 0x04;
 
 /// `response` PDU type ([C706] 12.6.4.9).
 ///
@@ -79,6 +89,10 @@ pub const PTYPE_BIND_ACK: u8 = 12;
 ///
 /// [C706]: https://pubs.opengroup.org/onlinepubs/9629399/toc.htm
 pub const PTYPE_BIND_NAK: u8 = 13;
+/// `rpc_auth_3` PDU type ([MS-RPCE] 2.2.2.10).
+///
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+pub const PTYPE_RPC_AUTH_3: u8 = 16;
 /// `rts` PDU type ([MS-RPCH] 2.2.3.2).
 pub const PTYPE_RTS: u8 = 20;
 
@@ -96,6 +110,9 @@ pub const DEFAULT_FRAGMENT_SIZE: u16 = 0x10b8;
 pub const MAX_PENDING_RPC_FRAGMENTS: usize = 16;
 
 const MAXIMUM_RESPONSE_ALLOC_HINT: usize = 0x7fff_ffff;
+const RPC_AUTH_TYPE_WINNT: u8 = 0x0a;
+const RPC_AUTH_LEVEL_PACKET_INTEGRITY: u8 = 0x05;
+const RPC_AUTH_CONTEXT_ID: u32 = 1;
 const RTS_HEADER_SIZE: usize = RPC_COMMON_HEADER_SIZE + 4 /* flags and command count */;
 const RTS_PFC_FLAGS: u8 = PFC_FIRST_FRAG | PFC_LAST_FRAG;
 const RTS_FLAG_NONE: u16 = 0;
@@ -134,6 +151,16 @@ pub enum RpcPduError {
     InvalidFragmentLength { fragment_length: u16 },
     IncompleteFragment { actual: usize, fragment_length: u16 },
     AuthenticationUnsupported { auth_length: u16 },
+    AuthenticationRequired,
+    MissingSupportHeaderSign,
+    InvalidSecurityTrailer { fragment_length: u16, auth_length: u16 },
+    InvalidAuthenticationPadding { actual: u8 },
+    NonZeroAuthenticationPadding,
+    NonZeroAuthenticationReserved { actual: u8 },
+    UnexpectedAuthenticationType { expected: u8, actual: u8 },
+    UnexpectedAuthenticationLevel { expected: u8, actual: u8 },
+    UnexpectedAuthenticationContextId { expected: u32, actual: u32 },
+    EmptyAuthenticationToken,
     UnexpectedPduType { expected: u8, actual: u8 },
     FragmentedPduUnsupported { flags: u8 },
     UnexpectedResponseFragment { flags: u8 },
@@ -193,6 +220,37 @@ impl fmt::Display for RpcPduError {
                     "rpc authentication verifier of length {auth_length} is not supported"
                 )
             }
+            Self::AuthenticationRequired => f.write_str("rpc authentication token is required"),
+            Self::MissingSupportHeaderSign => f.write_str("rpc pdu does not support header signing"),
+            Self::InvalidSecurityTrailer {
+                fragment_length,
+                auth_length,
+            } => {
+                write!(
+                    f,
+                    "invalid rpc security trailer for {fragment_length}-byte fragment and {auth_length}-byte token"
+                )
+            }
+            Self::InvalidAuthenticationPadding { actual } => {
+                write!(f, "rpc authentication padding {actual} exceeds the pdu body")
+            }
+            Self::NonZeroAuthenticationPadding => f.write_str("rpc authentication padding is not zero"),
+            Self::NonZeroAuthenticationReserved { actual } => {
+                write!(f, "nonzero rpc authentication reserved byte {actual}")
+            }
+            Self::UnexpectedAuthenticationType { expected, actual } => {
+                write!(f, "unexpected rpc authentication type {actual}, expected {expected}")
+            }
+            Self::UnexpectedAuthenticationLevel { expected, actual } => {
+                write!(f, "unexpected rpc authentication level {actual}, expected {expected}")
+            }
+            Self::UnexpectedAuthenticationContextId { expected, actual } => {
+                write!(
+                    f,
+                    "unexpected rpc authentication context id {actual}, expected {expected}"
+                )
+            }
+            Self::EmptyAuthenticationToken => f.write_str("empty rpc authentication token"),
             Self::UnexpectedPduType { expected, actual } => {
                 write!(f, "unexpected rpc pdu type {actual}, expected {expected}")
             }
@@ -398,6 +456,151 @@ pub struct RpcBindAck<'a> {
     pub association_group_id: u32,
     pub secondary_address: &'a [u8],
     pub results: Vec<RpcPresentationResult>,
+}
+
+/// An authenticated RPC bind acknowledgement and its server authentication token.
+///
+/// [MS-RPCE] 2.2.2.11 and 2.2.2.12.
+///
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpcAuthenticatedBindAck<'a> {
+    bind_ack: RpcBindAck<'a>,
+    token: &'a [u8],
+}
+
+impl RpcAuthenticatedBindAck<'_> {
+    /// The validated bind acknowledgement.
+    pub const fn bind_ack(&self) -> &RpcBindAck<'_> {
+        &self.bind_ack
+    }
+
+    /// The server authentication token from the DCE/RPC security trailer.
+    pub const fn token(&self) -> &[u8] {
+        self.token
+    }
+}
+
+/// Client-side NTLM association state for the DCE/RPC security context.
+///
+/// This state owns an independent NTLM package and credential handle.
+/// It must not be shared with the HTTP authentication context.
+///
+/// [MS-RPCE] 3.3.1.5.2.1 / [MS-NLMP] 3.1.5.1.
+///
+/// [MS-NLMP]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/a82d61d7-0851-48aa-93ed-5c534c075a40
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+pub struct RpcNtlmAuth {
+    ntlm: Ntlm,
+    credentials_handle: Option<AuthIdentityBuffers>,
+    state: RpcNtlmAuthState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RpcNtlmAuthState {
+    Initial,
+    AwaitingChallenge,
+    Established,
+}
+
+impl RpcNtlmAuth {
+    /// Creates a client-side NTLM security context for one DCE/RPC connection.
+    pub fn new(username: &str, password: &str) -> Result<Self, Error> {
+        let username = Username::parse(username)
+            .or_else(|_| Username::new(username, None))
+            .map_err(|error| Error::custom("parse rpc username", error))?;
+        let identity = AuthIdentity {
+            username,
+            password: password.to_owned().into(),
+        };
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|error| Error::custom("acquire rpc ntlm credentials", error))?
+            .credentials_handle;
+
+        Ok(Self {
+            ntlm,
+            credentials_handle,
+            state: RpcNtlmAuthState::Initial,
+        })
+    }
+
+    /// Produces the NTLM Type-1 token for an authenticated bind PDU.
+    pub fn initial_token(&mut self) -> Result<Vec<u8>, Error> {
+        if self.state != RpcNtlmAuthState::Initial {
+            return Err(Error::new("rpc ntlm initial token", GwErrorKind::Connect));
+        }
+
+        let token = self.next_token(None)?;
+        if self.state != RpcNtlmAuthState::AwaitingChallenge {
+            return Err(Error::new("rpc ntlm initial token", GwErrorKind::Connect));
+        }
+
+        Ok(token)
+    }
+
+    /// Consumes the bind_ack Type-2 token and produces the rpc_auth_3 Type-3 token.
+    pub fn continue_token(&mut self, challenge: &[u8]) -> Result<Vec<u8>, Error> {
+        if self.state != RpcNtlmAuthState::AwaitingChallenge || challenge.is_empty() {
+            return Err(Error::new("rpc ntlm continuation token", GwErrorKind::Connect));
+        }
+
+        let token = self.next_token(Some(challenge))?;
+        if self.state != RpcNtlmAuthState::Established {
+            return Err(Error::new("rpc ntlm continuation token", GwErrorKind::Connect));
+        }
+
+        Ok(token)
+    }
+
+    /// Whether the Type-3 token has completed this NTLM association.
+    pub fn is_complete(&self) -> bool {
+        self.state == RpcNtlmAuthState::Established
+    }
+
+    fn next_token(&mut self, input: Option<&[u8]>) -> Result<Vec<u8>, Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+        let mut builder = self
+            .ntlm
+            .initialize_security_context()
+            .with_credentials_handle(&mut self.credentials_handle)
+            .with_context_requirements(
+                ClientRequestFlags::USE_DCE_STYLE
+                    | ClientRequestFlags::INTEGRITY
+                    | ClientRequestFlags::REPLAY_DETECT
+                    | ClientRequestFlags::SEQUENCE_DETECT
+                    | ClientRequestFlags::ALLOCATE_MEMORY,
+            )
+            .with_target_data_representation(DataRepresentation::Native)
+            .with_input(&mut input_token)
+            .with_output(&mut output_token);
+
+        let InitializeSecurityContextResult { status, .. } = self
+            .ntlm
+            .initialize_security_context_impl(&mut builder)
+            .map_err(|error| Error::custom("initialize rpc ntlm security context", error))?
+            .resolve_to_result()
+            .map_err(|error| Error::custom("initialize rpc ntlm security context", error))?;
+
+        match status {
+            SecurityStatus::Ok => self.state = RpcNtlmAuthState::Established,
+            SecurityStatus::ContinueNeeded => self.state = RpcNtlmAuthState::AwaitingChallenge,
+            other => {
+                return Err(Error::new("rpc ntlm security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected ntlm status: {other:?}"))));
+            }
+        }
+
+        Ok(core::mem::take(&mut output_token[0].buffer))
+    }
 }
 
 /// An RPC runtime version advertised in a bind rejection.
@@ -860,6 +1063,39 @@ pub fn encode_rpc_bind(
     association_group_id: u32,
     presentation_contexts: &[RpcPresentationContext<'_>],
 ) -> Result<Vec<u8>, RpcPduError> {
+    let body = encode_rpc_bind_body(fragment_sizes, association_group_id, presentation_contexts)?;
+    ensure_fragment_fits(body.len(), fragment_sizes.max_xmit())?;
+    encode_unprotected_pdu(PTYPE_BIND, call_id, body)
+}
+
+/// Encodes one complete NTLM-authenticated RPC bind PDU.
+///
+/// The caller supplies the Type-1 token produced by [`RpcNtlmAuth::initial_token`].
+/// This configures packet-integrity authentication for the association but does not
+/// encode signed RPC request or response PDUs.
+///
+/// [MS-RPCE] 2.2.2.11, 2.2.2.12, and 4.2 / [C706] 12.6.4.3.
+///
+/// [C706]: https://pubs.opengroup.org/onlinepubs/9629399/toc.htm
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+pub fn encode_rpc_bind_with_ntlm_auth(
+    call_id: u32,
+    fragment_sizes: RpcFragmentSizes,
+    association_group_id: u32,
+    presentation_contexts: &[RpcPresentationContext<'_>],
+    type1_token: &[u8],
+) -> Result<Vec<u8>, RpcPduError> {
+    let body = encode_rpc_bind_body(fragment_sizes, association_group_id, presentation_contexts)?;
+    let pdu = encode_authenticated_pdu(PTYPE_BIND, call_id, body, type1_token)?;
+    ensure_encoded_fragment_fits(&pdu, fragment_sizes.max_xmit())?;
+    Ok(pdu)
+}
+
+fn encode_rpc_bind_body(
+    fragment_sizes: RpcFragmentSizes,
+    association_group_id: u32,
+    presentation_contexts: &[RpcPresentationContext<'_>],
+) -> Result<Vec<u8>, RpcPduError> {
     if presentation_contexts.is_empty() {
         return Err(RpcPduError::EmptyPresentationContexts);
     }
@@ -904,7 +1140,6 @@ pub fn encode_rpc_bind(
             })
             .ok_or(RpcPduError::LengthOverflow)?;
     }
-    ensure_fragment_fits(body_length, fragment_sizes.max_xmit())?;
 
     let mut body = Vec::with_capacity(body_length);
     body.extend_from_slice(&fragment_sizes.max_xmit().to_le_bytes());
@@ -923,7 +1158,7 @@ pub fn encode_rpc_bind(
         }
     }
 
-    encode_unprotected_pdu(PTYPE_BIND, call_id, body)
+    Ok(body)
 }
 
 /// Decodes one complete, unauthenticated RPC bind acknowledgement.
@@ -936,6 +1171,51 @@ pub fn decode_rpc_bind_ack(
     offered_fragment_sizes: RpcFragmentSizes,
 ) -> Result<RpcBindAck<'_>, RpcPduError> {
     let (header, body) = decode_unprotected_single_fragment(source, PTYPE_BIND_ACK, offered_fragment_sizes.max_recv())?;
+    decode_rpc_bind_ack_body(header, body, offered_fragment_sizes)
+}
+
+/// Decodes an NTLM-authenticated RPC bind acknowledgement and extracts its Type-2 token.
+///
+/// This validates the DCE/RPC security trailer and header-signing negotiation.
+/// This RD Gateway profile requires the server to acknowledge header-signing support.
+/// The caller passes the extracted token to [`RpcNtlmAuth::continue_token`].
+///
+/// [MS-RPCE] 2.2.2.3, 2.2.2.11, 2.2.2.12, and 4.2.
+///
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+pub fn decode_rpc_bind_ack_with_ntlm_auth(
+    source: &[u8],
+    offered_fragment_sizes: RpcFragmentSizes,
+) -> Result<RpcAuthenticatedBindAck<'_>, RpcPduError> {
+    let (header, body, token) =
+        decode_authenticated_single_fragment(source, PTYPE_BIND_ACK, offered_fragment_sizes.max_recv())?;
+    let bind_ack = decode_rpc_bind_ack_body(header, body, offered_fragment_sizes)?;
+    Ok(RpcAuthenticatedBindAck { bind_ack, token })
+}
+
+/// Encodes the NTLM Type-3 continuation token in an rpc_auth_3 PDU.
+///
+/// The caller supplies the Type-3 token produced by [`RpcNtlmAuth::continue_token`].
+/// It does not enable signed RPC request or response PDUs.
+///
+/// [MS-RPCE] 2.2.2.10, 2.2.2.11, 2.2.2.12, and 4.2.
+///
+/// [MS-RPCE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c8d
+pub fn encode_rpc_auth_3(
+    call_id: u32,
+    fragment_sizes: RpcFragmentSizes,
+    type3_token: &[u8],
+) -> Result<Vec<u8>, RpcPduError> {
+    let pdu = encode_authenticated_pdu(PTYPE_RPC_AUTH_3, call_id, vec![0; 4], type3_token)?;
+    ensure_encoded_fragment_fits(&pdu, fragment_sizes.max_xmit())?;
+    Ok(pdu)
+}
+
+fn decode_rpc_bind_ack_body<'a>(
+    header: RpcCommonHeader,
+    body: &'a [u8],
+    offered_fragment_sizes: RpcFragmentSizes,
+) -> Result<RpcBindAck<'a>, RpcPduError> {
     let fixed = body.get(..RPC_BIND_ACK_HEADER_SIZE).ok_or(RpcPduError::Truncated {
         actual: body.len(),
         required: RPC_BIND_ACK_HEADER_SIZE,
@@ -1298,6 +1578,139 @@ fn decode_unprotected_single_fragment(
     Ok((header, body))
 }
 
+fn encode_authenticated_pdu(ptype: u8, call_id: u32, mut body: Vec<u8>, token: &[u8]) -> Result<Vec<u8>, RpcPduError> {
+    if token.is_empty() {
+        return Err(RpcPduError::EmptyAuthenticationToken);
+    }
+
+    let auth_length = u16::try_from(token.len()).map_err(|_| RpcPduError::LengthOverflow)?;
+    let padding_length = (16 - body.len() % 16) % 16;
+    body.resize(
+        body.len()
+            .checked_add(padding_length)
+            .ok_or(RpcPduError::LengthOverflow)?,
+        0,
+    );
+    let header = RpcCommonHeader::encode(
+        ptype,
+        PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN,
+        call_id,
+        body.len(),
+        auth_length,
+    )?;
+    let mut pdu = Vec::with_capacity(
+        RPC_COMMON_HEADER_SIZE
+            .checked_add(body.len())
+            .and_then(|length| length.checked_add(RPC_SEC_TRAILER_SIZE))
+            .and_then(|length| length.checked_add(token.len()))
+            .ok_or(RpcPduError::LengthOverflow)?,
+    );
+    pdu.extend_from_slice(&header);
+    pdu.extend_from_slice(&body);
+    pdu.push(RPC_AUTH_TYPE_WINNT);
+    pdu.push(RPC_AUTH_LEVEL_PACKET_INTEGRITY);
+    pdu.push(u8::try_from(padding_length).map_err(|_| RpcPduError::LengthOverflow)?);
+    pdu.push(0); // auth_reserved
+    pdu.extend_from_slice(&RPC_AUTH_CONTEXT_ID.to_le_bytes());
+    pdu.extend_from_slice(token);
+    Ok(pdu)
+}
+
+fn decode_authenticated_single_fragment(
+    source: &[u8],
+    expected_ptype: u8,
+    maximum_fragment_size: u16,
+) -> Result<(RpcCommonHeader, &[u8], &[u8]), RpcPduError> {
+    let header = RpcCommonHeader::decode(source)?;
+    if header.ptype() != expected_ptype {
+        return Err(RpcPduError::UnexpectedPduType {
+            expected: expected_ptype,
+            actual: header.ptype(),
+        });
+    }
+    if header.pfc_flags() & PFC_SUPPORT_HEADER_SIGN == 0 {
+        return Err(RpcPduError::MissingSupportHeaderSign);
+    }
+    if header.fragment_length() > maximum_fragment_size {
+        return Err(RpcPduError::FragmentExceedsMaximum {
+            fragment_length: header.fragment_length(),
+            maximum: maximum_fragment_size,
+        });
+    }
+    if header.auth_length() == 0 {
+        return Err(RpcPduError::AuthenticationRequired);
+    }
+    validate_single_fragment(header)?;
+
+    let fragment_length = usize::from(header.fragment_length());
+    let trailer_offset = fragment_length
+        .checked_sub(usize::from(header.auth_length()))
+        .and_then(|offset| offset.checked_sub(RPC_SEC_TRAILER_SIZE))
+        .ok_or_else(|| RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length(),
+            auth_length: header.auth_length(),
+        })?;
+    if trailer_offset < RPC_COMMON_HEADER_SIZE {
+        return Err(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length(),
+            auth_length: header.auth_length(),
+        });
+    }
+
+    let trailer_end = trailer_offset
+        .checked_add(RPC_SEC_TRAILER_SIZE)
+        .ok_or(RpcPduError::LengthOverflow)?;
+    let trailer = source
+        .get(trailer_offset..trailer_end)
+        .ok_or_else(|| RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length(),
+            auth_length: header.auth_length(),
+        })?;
+    if trailer[0] != RPC_AUTH_TYPE_WINNT {
+        return Err(RpcPduError::UnexpectedAuthenticationType {
+            expected: RPC_AUTH_TYPE_WINNT,
+            actual: trailer[0],
+        });
+    }
+    if trailer[1] != RPC_AUTH_LEVEL_PACKET_INTEGRITY {
+        return Err(RpcPduError::UnexpectedAuthenticationLevel {
+            expected: RPC_AUTH_LEVEL_PACKET_INTEGRITY,
+            actual: trailer[1],
+        });
+    }
+    if trailer[3] != 0 {
+        return Err(RpcPduError::NonZeroAuthenticationReserved { actual: trailer[3] });
+    }
+    let auth_context_id = u32::from_le_bytes(trailer[4..8].try_into().map_err(|_| RpcPduError::LengthOverflow)?);
+    if auth_context_id != RPC_AUTH_CONTEXT_ID {
+        return Err(RpcPduError::UnexpectedAuthenticationContextId {
+            expected: RPC_AUTH_CONTEXT_ID,
+            actual: auth_context_id,
+        });
+    }
+
+    let body_with_padding = &source[RPC_COMMON_HEADER_SIZE..trailer_offset];
+    let padding_length = usize::from(trailer[2]);
+    // The gateway profile accepts canonical zero-filled padding and uses
+    // auth_pad_length rather than a fixed bind_ack layout.
+    let body_length = body_with_padding
+        .len()
+        .checked_sub(padding_length)
+        .ok_or(RpcPduError::InvalidAuthenticationPadding { actual: trailer[2] })?;
+    if body_with_padding[body_length..].iter().any(|&byte| byte != 0) {
+        return Err(RpcPduError::NonZeroAuthenticationPadding);
+    }
+
+    let token = source
+        .get(trailer_end..fragment_length)
+        .ok_or_else(|| RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length(),
+            auth_length: header.auth_length(),
+        })?;
+    debug_assert_eq!(token.len(), usize::from(header.auth_length()));
+    Ok((header, &body_with_padding[..body_length], token))
+}
+
 fn encode_unprotected_pdu(ptype: u8, call_id: u32, body: Vec<u8>) -> Result<Vec<u8>, RpcPduError> {
     encode_unprotected_pdu_with_flags(ptype, PFC_FIRST_FRAG | PFC_LAST_FRAG, call_id, body)
 }
@@ -1330,6 +1743,18 @@ fn ensure_fragment_fits(body_length: usize, maximum_fragment_size: u16) -> Resul
         .checked_add(body_length)
         .ok_or(RpcPduError::LengthOverflow)?;
     let fragment_length = u16::try_from(fragment_length).map_err(|_| RpcPduError::LengthOverflow)?;
+    if fragment_length > maximum_fragment_size {
+        return Err(RpcPduError::FragmentExceedsMaximum {
+            fragment_length,
+            maximum: maximum_fragment_size,
+        });
+    }
+
+    Ok(())
+}
+
+fn ensure_encoded_fragment_fits(pdu: &[u8], maximum_fragment_size: u16) -> Result<(), RpcPduError> {
+    let fragment_length = u16::try_from(pdu.len()).map_err(|_| RpcPduError::LengthOverflow)?;
     if fragment_length > maximum_fragment_size {
         return Err(RpcPduError::FragmentExceedsMaximum {
             fragment_length,

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -152,7 +152,6 @@ pub enum RpcPduError {
     IncompleteFragment { actual: usize, fragment_length: u16 },
     AuthenticationUnsupported { auth_length: u16 },
     AuthenticationRequired,
-    MissingSupportHeaderSign,
     InvalidSecurityTrailer { fragment_length: u16, auth_length: u16 },
     InvalidAuthenticationPadding { actual: u8 },
     NonZeroAuthenticationPadding,
@@ -221,7 +220,6 @@ impl fmt::Display for RpcPduError {
                 )
             }
             Self::AuthenticationRequired => f.write_str("rpc authentication token is required"),
-            Self::MissingSupportHeaderSign => f.write_str("rpc pdu does not support header signing"),
             Self::InvalidSecurityTrailer {
                 fragment_length,
                 auth_length,
@@ -467,6 +465,7 @@ pub struct RpcBindAck<'a> {
 pub struct RpcAuthenticatedBindAck<'a> {
     bind_ack: RpcBindAck<'a>,
     token: &'a [u8],
+    supports_header_signing: bool,
 }
 
 impl RpcAuthenticatedBindAck<'_> {
@@ -478,6 +477,11 @@ impl RpcAuthenticatedBindAck<'_> {
     /// The server authentication token from the DCE/RPC security trailer.
     pub const fn token(&self) -> &[u8] {
         self.token
+    }
+
+    /// Whether the server acknowledged header-signing support.
+    pub const fn supports_header_signing(&self) -> bool {
+        self.supports_header_signing
     }
 }
 
@@ -1177,7 +1181,7 @@ pub fn decode_rpc_bind_ack(
 /// Decodes an NTLM-authenticated RPC bind acknowledgement and extracts its Type-2 token.
 ///
 /// This validates the DCE/RPC security trailer and header-signing negotiation.
-/// This RD Gateway profile requires the server to acknowledge header-signing support.
+/// Use [`RpcAuthenticatedBindAck::supports_header_signing`] to retain the server result.
 /// The caller passes the extracted token to [`RpcNtlmAuth::continue_token`].
 ///
 /// [MS-RPCE] 2.2.2.3, 2.2.2.11, 2.2.2.12, and 4.2.
@@ -1190,7 +1194,12 @@ pub fn decode_rpc_bind_ack_with_ntlm_auth(
     let (header, body, token) =
         decode_authenticated_single_fragment(source, PTYPE_BIND_ACK, offered_fragment_sizes.max_recv())?;
     let bind_ack = decode_rpc_bind_ack_body(header, body, offered_fragment_sizes)?;
-    Ok(RpcAuthenticatedBindAck { bind_ack, token })
+    let supports_header_signing = header.pfc_flags() & PFC_SUPPORT_HEADER_SIGN != 0;
+    Ok(RpcAuthenticatedBindAck {
+        bind_ack,
+        token,
+        supports_header_signing,
+    })
 }
 
 /// Encodes the NTLM Type-3 continuation token in an rpc_auth_3 PDU.
@@ -1627,9 +1636,6 @@ fn decode_authenticated_single_fragment(
             expected: expected_ptype,
             actual: header.ptype(),
         });
-    }
-    if header.pfc_flags() & PFC_SUPPORT_HEADER_SIGN == 0 {
-        return Err(RpcPduError::MissingSupportHeaderSign);
     }
     if header.fragment_length() > maximum_fragment_size {
         return Err(RpcPduError::FragmentExceedsMaximum {

--- a/crates/ironrdp-mstsgu/tests/rpc_pdu.rs
+++ b/crates/ironrdp-mstsgu/tests/rpc_pdu.rs
@@ -1055,13 +1055,13 @@ fn authenticated_bind_ack_extracts_the_type2_token_and_validates_its_trailer() {
         RpcFragmentSizes::new(0x10b8, 0x10b8).expect("valid negotiated maxima")
     );
     assert_eq!(ack.bind_ack().results.len(), 1);
+    assert!(ack.supports_header_signing());
 
     let mut missing_header_sign = bind_ack.clone();
     missing_header_sign[3] &= !PFC_SUPPORT_HEADER_SIGN;
-    assert_eq!(
-        decode_rpc_bind_ack_with_ntlm_auth(&missing_header_sign, RpcFragmentSizes::DEFAULT),
-        Err(RpcPduError::MissingSupportHeaderSign)
-    );
+    let ack = decode_rpc_bind_ack_with_ntlm_auth(&missing_header_sign, RpcFragmentSizes::DEFAULT)
+        .expect("valid bind acknowledgement without header-signing support");
+    assert!(!ack.supports_header_signing());
 
     let mut wrong_auth_type = bind_ack.clone();
     wrong_auth_type[64] = 9;

--- a/crates/ironrdp-mstsgu/tests/rpc_pdu.rs
+++ b/crates/ironrdp-mstsgu/tests/rpc_pdu.rs
@@ -1,13 +1,15 @@
 #![allow(unused_crate_dependencies)]
 
 use ironrdp_mstsgu::rpc::{
-    DEFAULT_FRAGMENT_SIZE, MAX_PENDING_RPC_FRAGMENTS, PFC_FIRST_FRAG, PFC_LAST_FRAG, PTYPE_BIND, PTYPE_BIND_ACK,
-    PTYPE_BIND_NAK, PTYPE_FAULT, PTYPE_REQUEST, PTYPE_RESPONSE, RPC_COMMON_HEADER_SIZE, RPC_DREP_LITTLE_ENDIAN,
-    RPC_VERSION, RPC_VERSION_MINOR, RpcCommonHeader, RpcFault, RpcFragmentSizes, RpcPduError, RpcPduStream,
-    RpcPresentationContext, RpcReassembledResponse, RpcResponse, RpcResponseReassembler, RpcSyntaxIdentifier,
-    RpcSyntaxVersion, decode_rpc_bind_ack, decode_rpc_bind_nak, decode_rpc_fault, decode_rpc_fault_for_context,
-    decode_rpc_response, decode_rpc_response_for_context, decode_rpc_response_fragment, encode_rpc_bind,
-    encode_rpc_fault, encode_rpc_request_fragments, encode_rpc_response, encode_rpc_response_fragment,
+    DEFAULT_FRAGMENT_SIZE, MAX_PENDING_RPC_FRAGMENTS, PFC_FIRST_FRAG, PFC_LAST_FRAG, PFC_SUPPORT_HEADER_SIGN,
+    PTYPE_BIND, PTYPE_BIND_ACK, PTYPE_BIND_NAK, PTYPE_FAULT, PTYPE_REQUEST, PTYPE_RESPONSE, PTYPE_RPC_AUTH_3,
+    RPC_COMMON_HEADER_SIZE, RPC_DREP_LITTLE_ENDIAN, RPC_VERSION, RPC_VERSION_MINOR, RpcCommonHeader, RpcFault,
+    RpcFragmentSizes, RpcNtlmAuth, RpcPduError, RpcPduStream, RpcPresentationContext, RpcReassembledResponse,
+    RpcResponse, RpcResponseReassembler, RpcSyntaxIdentifier, RpcSyntaxVersion, decode_rpc_bind_ack,
+    decode_rpc_bind_ack_with_ntlm_auth, decode_rpc_bind_nak, decode_rpc_fault, decode_rpc_fault_for_context,
+    decode_rpc_response, decode_rpc_response_for_context, decode_rpc_response_fragment, encode_rpc_auth_3,
+    encode_rpc_bind, encode_rpc_bind_with_ntlm_auth, encode_rpc_fault, encode_rpc_request_fragments,
+    encode_rpc_response, encode_rpc_response_fragment,
 };
 use uuid::Uuid;
 
@@ -936,4 +938,216 @@ fn bind_and_request_codecs_match_connection_oriented_rpc_wire_layouts() {
             ],
         ]
     );
+}
+
+#[test]
+fn ntlm_association_codecs_match_dce_rpc_wire_layouts() {
+    let type1_token = [1, 2, 3, 4];
+    let abstract_syntax = RpcSyntaxIdentifier::new(
+        Uuid::from_u128(0x00112233_4455_6677_8899_aabbccddeeff),
+        RpcSyntaxVersion::new(1, 3),
+    );
+    let transfer_syntax = RpcSyntaxIdentifier::new(
+        Uuid::from_u128(0x8a885d04_1ceb_11c9_9fe8_08002b104860),
+        RpcSyntaxVersion::new(2, 0),
+    );
+    let presentation_context = RpcPresentationContext {
+        context_id: 7,
+        abstract_syntax,
+        transfer_syntaxes: &[transfer_syntax],
+    };
+    let bind = encode_rpc_bind_with_ntlm_auth(
+        0x7856_3412,
+        RpcFragmentSizes::DEFAULT,
+        0,
+        &[presentation_context],
+        &type1_token,
+    )
+    .expect("valid authenticated bind");
+    assert_eq!(
+        bind,
+        [
+            [
+                5,
+                0,
+                PTYPE_BIND,
+                PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN,
+                0x10,
+                0,
+                0,
+                0,
+            ]
+            .as_slice(),
+            &[92, 0, 4, 0, 0x12, 0x34, 0x56, 0x78],
+            &[
+                0xb8, 0x10, 0xb8, 0x10, 0, 0, 0, 0, 1, 0, 0, 0, 7, 0, 1, 0, 0x33, 0x22, 0x11, 0, 0x55, 0x44, 0x77,
+                0x66, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 1, 0, 3, 0, 4, 0x5d, 0x88, 0x8a, 0xeb, 0x1c,
+                0xc9, 0x11, 0x9f, 0xe8, 8, 0, 0x2b, 0x10, 0x48, 0x60, 2, 0, 0, 0,
+            ],
+            &[0; 8],
+            &[10, 5, 8, 0, 1, 0, 0, 0],
+            &type1_token,
+        ]
+        .concat()
+    );
+
+    let type3_token = [5, 6, 7, 8];
+    let auth3 = encode_rpc_auth_3(0x7856_3412, RpcFragmentSizes::DEFAULT, &type3_token).expect("valid auth3");
+    assert_eq!(
+        auth3,
+        [
+            [
+                5,
+                0,
+                PTYPE_RPC_AUTH_3,
+                PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN,
+                0x10,
+                0,
+                0,
+                0,
+            ]
+            .as_slice(),
+            &[44, 0, 4, 0, 0x12, 0x34, 0x56, 0x78],
+            &[0; 16],
+            &[10, 5, 12, 0, 1, 0, 0, 0],
+            &type3_token,
+        ]
+        .concat()
+    );
+    assert_eq!(
+        encode_rpc_auth_3(1, RpcFragmentSizes::DEFAULT, &[]),
+        Err(RpcPduError::EmptyAuthenticationToken)
+    );
+}
+
+#[test]
+fn authenticated_bind_ack_extracts_the_type2_token_and_validates_its_trailer() {
+    let type2_token = b"NTLMSSP\0\x02\0\0\0";
+    let bind_ack = [
+        [
+            5,
+            0,
+            PTYPE_BIND_ACK,
+            PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN,
+            0x10,
+            0,
+            0,
+            0,
+        ]
+        .as_slice(),
+        &[84, 0, 12, 0, 0x12, 0x34, 0x56, 0x78],
+        &[
+            0x00, 0x20, 0x00, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 4, 0x5d, 0x88, 0x8a, 0xeb, 0x1c,
+            0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60, 2, 0, 0, 0,
+        ],
+        &[0; 8],
+        &[10, 5, 8, 0, 1, 0, 0, 0],
+        type2_token.as_slice(),
+    ]
+    .concat();
+
+    let ack = decode_rpc_bind_ack_with_ntlm_auth(&bind_ack, RpcFragmentSizes::DEFAULT)
+        .expect("valid authenticated bind acknowledgement");
+    assert_eq!(ack.token(), type2_token);
+    assert_eq!(ack.bind_ack().call_id, 0x7856_3412);
+    assert_eq!(
+        ack.bind_ack().fragment_sizes,
+        RpcFragmentSizes::new(0x10b8, 0x10b8).expect("valid negotiated maxima")
+    );
+    assert_eq!(ack.bind_ack().results.len(), 1);
+
+    let mut missing_header_sign = bind_ack.clone();
+    missing_header_sign[3] &= !PFC_SUPPORT_HEADER_SIGN;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&missing_header_sign, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::MissingSupportHeaderSign)
+    );
+
+    let mut wrong_auth_type = bind_ack.clone();
+    wrong_auth_type[64] = 9;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&wrong_auth_type, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::UnexpectedAuthenticationType {
+            expected: 10,
+            actual: 9,
+        })
+    );
+
+    let mut wrong_auth_level = bind_ack.clone();
+    wrong_auth_level[65] = 2;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&wrong_auth_level, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::UnexpectedAuthenticationLevel { expected: 5, actual: 2 })
+    );
+
+    let mut nonzero_reserved = bind_ack.clone();
+    nonzero_reserved[67] = 1;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&nonzero_reserved, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::NonZeroAuthenticationReserved { actual: 1 })
+    );
+
+    let mut wrong_context = bind_ack.clone();
+    wrong_context[68..72].copy_from_slice(&0u32.to_le_bytes());
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&wrong_context, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::UnexpectedAuthenticationContextId { expected: 1, actual: 0 })
+    );
+
+    let mut nonzero_padding = bind_ack.clone();
+    nonzero_padding[63] = 1;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&nonzero_padding, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::NonZeroAuthenticationPadding)
+    );
+
+    let mut oversized_padding = bind_ack.clone();
+    oversized_padding[66] = 49;
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&oversized_padding, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::InvalidAuthenticationPadding { actual: 49 })
+    );
+
+    let mut invalid_trailer_bounds = bind_ack;
+    invalid_trailer_bounds[10..12].copy_from_slice(&69u16.to_le_bytes());
+    assert_eq!(
+        decode_rpc_bind_ack_with_ntlm_auth(&invalid_trailer_bounds, RpcFragmentSizes::DEFAULT),
+        Err(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: 84,
+            auth_length: 69,
+        })
+    );
+}
+
+#[test]
+fn rpc_ntlm_auth_requires_a_type1_type2_type3_sequence() {
+    let mut auth = RpcNtlmAuth::new(r"CONTOSO\alice", "secret").expect("valid credentials");
+    assert!(auth.continue_token(&[]).is_err());
+
+    let type1_token = auth.initial_token().expect("offline Type-1 token");
+    assert_eq!(&type1_token[..12], b"NTLMSSP\0\x01\0\0\0");
+    assert!(!auth.is_complete());
+    assert!(auth.initial_token().is_err());
+
+    let type2_token = [
+        b"NTLMSSP\0".as_slice(),
+        &[2, 0, 0, 0],
+        &[8, 0, 8, 0, 56, 0, 0, 0],
+        &0xe288_82b7u32.to_le_bytes(),
+        &[0x26, 0x6e, 0xcd, 0x75, 0xaa, 0x41, 0xe7, 0x6f],
+        &[0; 8],
+        &[64, 0, 64, 0, 64, 0, 0, 0],
+        &[6, 1, 0xb0, 0x1d, 0, 0, 0, 0x0f],
+        &[0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0],
+        &[
+            2, 0, 8, 0, 0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0, 1, 0, 8, 0, 0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0, 4, 0, 8, 0,
+            0x77, 0, 0x69, 0, 0x6e, 0, 0x37, 0, 3, 0, 8, 0, 0x77, 0, 0x69, 0, 0x6e, 0, 0x37, 0, 7, 0, 8, 0, 0xa9, 0x8d,
+            0x9b, 0x1a, 0x6c, 0xb0, 0xcb, 1, 0, 0, 0, 0,
+        ],
+    ]
+    .concat();
+    let type3_token = auth.continue_token(&type2_token).expect("valid Type-2 token");
+    assert_eq!(&type3_token[..12], b"NTLMSSP\0\x03\0\0\0");
+    assert!(auth.is_complete());
+    assert!(auth.continue_token(&type2_token).is_err());
 }

--- a/crates/ironrdp-mstsgu/tests/rpc_tsgu_stubs.rs
+++ b/crates/ironrdp-mstsgu/tests/rpc_tsgu_stubs.rs
@@ -1,4 +1,40 @@
 #![allow(dead_code, unreachable_pub, unused_crate_dependencies)]
 
+use core::fmt;
+
+type Error = ironrdp_error::Error<GwErrorKind>;
+
+#[derive(Debug)]
+enum GwErrorKind {
+    Connect,
+    Custom,
+}
+
+trait GwErrorExt {
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static;
+}
+
+impl GwErrorExt for Error {
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static,
+    {
+        Self::new(context, GwErrorKind::Custom).with_source(error)
+    }
+}
+
+impl fmt::Display for GwErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Connect => "connection error",
+            Self::Custom => "custom",
+        })
+    }
+}
+
+impl core::error::Error for GwErrorKind {}
+
 #[path = "../src/rpc.rs"]
 mod rpc;


### PR DESCRIPTION
Add DCE/RPC NTLM association setup for RD Gateway, including header-signing negotiation.
Keep its SSPI context independent from HTTP authentication contexts.

This excludes live RPC-over-HTTP transport and protected RPC traffic.