### PR TITLE
fix(mstsgu): use native SSPI for gateway auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
+ "windows",
 ]
 
 [[package]]

--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- HTTP multi-leg authentication for the WebSocket upgrade: Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, and Basic fallback.
+- HTTP multi-leg authentication for the WebSocket upgrade: portable Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, and Basic fallback.
+- Native Windows SSPI for HTTP Negotiate/NTLM when the native TLS transport supplies endpoint binding.
 - RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
 - Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 - DCE/RPC common-header fragment codecs and response reassembly, without a live RPC-over-HTTP transport.

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 [[test]]
 name = "http_auth"
 path = "tests/http_auth.rs"
-required-features = ["native-tls"]
+required-features = ["native-tls", "test-support"]
 
 [[test]]
 name = "udp"
@@ -72,7 +72,7 @@ required-features = ["native-tls", "test-support"]
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
-native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
+native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls", "dep:windows"]
 test-support = ["tokio/io-util"]
 smartcard = [
     "sspi/scard",
@@ -81,7 +81,6 @@ smartcard = [
     "dep:picky-asn1-der",
     "dep:picky-asn1-x509",
 ]
-
 [dependencies]
 base64 = "0.22"
 bitflags = "2.11"
@@ -112,4 +111,4 @@ tokio-native-tls = "0.3"
 workspace = true
 
 [target."cfg(windows)".dependencies]
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials"], optional = true }

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -110,3 +110,6 @@ tokio-native-tls = "0.3"
 
 [lints]
 workspace = true
+
+[target."cfg(windows)".dependencies]
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials"] }

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -13,6 +13,7 @@ This crate
 - lets applications inspect and accept or decline a consent message synchronously through [`GwClient::connect_with_consent`] or [`GwClient::connect_with_port_and_consent`],
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, Basic fallback, or MS-TSGU `SSPI_NTLM` extended authentication when negotiated,
+- uses native Windows SSPI for regular HTTP Negotiate/NTLM when the native TLS transport supplies endpoint binding and the portable backend otherwise,
 - can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,
 - rejects unsupported `HTTP_EXTENDED_AUTH_SC` and PAA exchanges without a credential-provider UI,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,

--- a/crates/ironrdp-mstsgu/src/http_auth/mod.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth/mod.rs
@@ -1,8 +1,11 @@
-//! HTTP authentication helpers for the MS-TSGU WebSocket upgrade.
+//! HTTP authentication helpers for MS-TSGU WebSocket upgrades.
 //!
 //! Corporate RD Gateways typically challenge with Negotiate and/or NTLM rather than Basic.
 //! Negotiate prefers Kerberos (via KDC / `SSPI_KDC_URL`) and falls back to NTLM inside SPNEGO.
 //! Pure NTLM is used when the server only offers the NTLM scheme.
+
+#[cfg(all(windows, feature = "native-tls"))]
+mod native_http_auth;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
@@ -14,6 +17,8 @@ use sspi::{
 };
 
 use crate::{Error, GwErrorExt as _, GwErrorKind};
+#[cfg(all(windows, feature = "native-tls"))]
+use native_http_auth::NativeHttpAuth;
 
 /// Result of consuming one HTTP auth challenge/response.
 #[derive(Debug)]
@@ -37,6 +42,8 @@ enum AuthBackend {
         negotiate: Negotiate,
         credentials_handle: Option<CredentialsBuffers>,
     },
+    #[cfg(all(windows, feature = "native-tls"))]
+    Native(NativeHttpAuth),
 }
 
 /// Multi-leg HTTP auth state for `Authorization: NTLM …` / `Negotiate …`.
@@ -53,7 +60,7 @@ pub struct GatewayHttpAuth {
 impl GatewayHttpAuth {
     /// Build SSPI state for the MS-TSGU NTLM extended-authentication exchange.
     pub(crate) fn new_extended_auth_ntlm(username: &str, password: &str) -> Result<Self, Error> {
-        Self::new_ntlm(username, password, None)
+        Self::new_ntlm(username, password, None, None)
     }
 
     /// Process one NTLM token from the MS-TSGU extended-authentication exchange.
@@ -74,6 +81,17 @@ impl GatewayHttpAuth {
         password: &str,
         smart_card: Option<&crate::GwSmartCardCredentials>,
         target_name: Option<String>,
+        challenges: &[&str],
+    ) -> Result<(Option<Self>, AuthStep), Error> {
+        Self::from_challenges_with_channel_binding(username, password, smart_card, target_name, None, challenges)
+    }
+
+    pub(crate) fn from_challenges_with_channel_binding(
+        username: &str,
+        password: &str,
+        smart_card: Option<&crate::GwSmartCardCredentials>,
+        target_name: Option<String>,
+        channel_binding: Option<&[u8]>,
         challenges: &[&str],
     ) -> Result<(Option<Self>, AuthStep), Error> {
         let challenges: Vec<&str> = iter_auth_challenges(challenges.iter().copied()).collect();
@@ -152,7 +170,7 @@ impl GatewayHttpAuth {
         }
 
         if saw_negotiate {
-            let mut auth = Self::new_negotiate(username, password, target_name.clone())?;
+            let mut auth = Self::new_negotiate(username, password, target_name.clone(), channel_binding)?;
             let input = negotiate_token.as_deref().filter(|t| !t.is_empty());
             // Kerberos SPNEGO can fail without a reachable KDC (for example a gateway SPN
             // with no ticket path); fall back to plain NTLM, which needs no network.
@@ -169,7 +187,7 @@ impl GatewayHttpAuth {
         }
 
         if saw_ntlm {
-            let mut auth = Self::new_ntlm(username, password, target_name)?;
+            let mut auth = Self::new_ntlm(username, password, target_name, channel_binding)?;
             let input = ntlm_token.as_deref().filter(|t| !t.is_empty());
             let token = auth.initialize(input)?;
             let header = auth.format_authorization(&token);
@@ -186,7 +204,19 @@ impl GatewayHttpAuth {
         ))
     }
 
-    fn new_ntlm(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+    fn new_ntlm(
+        username: &str,
+        password: &str,
+        target_name: Option<String>,
+        channel_binding: Option<&[u8]>,
+    ) -> Result<Self, Error> {
+        #[cfg(not(all(windows, feature = "native-tls")))]
+        let _ = channel_binding;
+        #[cfg(all(windows, feature = "native-tls"))]
+        if let (Some(target_name), Some(channel_binding)) = (target_name.as_deref(), channel_binding) {
+            return Self::new_native_http_auth(username, password, target_name, channel_binding, "NTLM");
+        }
+
         let identity = auth_identity(username, password)?;
         let mut ntlm = Ntlm::new();
         let credentials_handle = ntlm
@@ -209,7 +239,19 @@ impl GatewayHttpAuth {
         })
     }
 
-    fn new_negotiate(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+    fn new_negotiate(
+        username: &str,
+        password: &str,
+        target_name: Option<String>,
+        channel_binding: Option<&[u8]>,
+    ) -> Result<Self, Error> {
+        #[cfg(not(all(windows, feature = "native-tls")))]
+        let _ = channel_binding;
+        #[cfg(all(windows, feature = "native-tls"))]
+        if let (Some(target_name), Some(channel_binding)) = (target_name.as_deref(), channel_binding) {
+            return Self::new_native_http_auth(username, password, target_name, channel_binding, "Negotiate");
+        }
+
         let identity = auth_identity(username, password)?;
         let credentials = Credentials::AuthIdentity(identity);
         let client_computer_name = client_computer_name();
@@ -238,6 +280,25 @@ impl GatewayHttpAuth {
             },
             scheme: "Negotiate",
             target_name,
+            complete: false,
+            allow_basic_fallback: true,
+        })
+    }
+
+    #[cfg(all(windows, feature = "native-tls"))]
+    fn new_native_http_auth(
+        username: &str,
+        password: &str,
+        target_name: &str,
+        channel_binding: &[u8],
+        package: &'static str,
+    ) -> Result<Self, Error> {
+        let native = NativeHttpAuth::new(username, password, target_name, channel_binding, package)?;
+
+        Ok(Self {
+            backend: AuthBackend::Native(native),
+            scheme: package,
+            target_name: Some(target_name.to_owned()),
             complete: false,
             allow_basic_fallback: true,
         })
@@ -473,6 +534,12 @@ impl GatewayHttpAuth {
                     .resolve_with_default_network_client()
                     .map_err(|e| Error::custom("negotiate initialize security context", e))?;
                 status
+            }
+            #[cfg(all(windows, feature = "native-tls"))]
+            AuthBackend::Native(native) => {
+                let step = native.initialize(input)?;
+                self.complete = step.complete;
+                return Ok(step.token);
             }
         };
 

--- a/crates/ironrdp-mstsgu/src/http_auth/mod.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth/mod.rs
@@ -5,7 +5,7 @@
 //! Pure NTLM is used when the server only offers the NTLM scheme.
 
 #[cfg(all(windows, feature = "native-tls"))]
-mod native_http_auth;
+pub(crate) mod native_http_auth;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;

--- a/crates/ironrdp-mstsgu/src/http_auth/native_http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth/native_http_auth.rs
@@ -13,7 +13,7 @@ use crate::{Error, GwErrorExt as _, GwErrorKind};
 
 const MAX_NEGOTIATE_TOKEN_SIZE: usize = 64 * 1024;
 
-pub(super) struct NativeHttpAuth {
+pub(crate) struct NativeHttpAuth {
     credentials: SecHandle,
     context: Option<SecHandle>,
     target_name: Vec<u16>,
@@ -21,13 +21,13 @@ pub(super) struct NativeHttpAuth {
     request_mutual_auth: bool,
 }
 
-pub(super) struct InitializeStep {
-    pub(super) token: Vec<u8>,
-    pub(super) complete: bool,
+pub(crate) struct InitializeStep {
+    pub(crate) token: Vec<u8>,
+    pub(crate) complete: bool,
 }
 
 impl NativeHttpAuth {
-    pub(super) fn new(
+    pub(crate) fn new(
         username: &str,
         password: &str,
         target_name: &str,
@@ -64,7 +64,7 @@ impl NativeHttpAuth {
         })
     }
 
-    pub(super) fn initialize(&mut self, input_token: Option<&[u8]>) -> Result<InitializeStep, Error> {
+    pub(crate) fn initialize(&mut self, input_token: Option<&[u8]>) -> Result<InitializeStep, Error> {
         let has_context = self.context.is_some();
         let mut input_token = input_token.unwrap_or_default().to_vec();
         let mut input_buffers = Vec::with_capacity(2);

--- a/crates/ironrdp-mstsgu/src/http_auth/native_http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth/native_http_auth.rs
@@ -1,0 +1,279 @@
+use sspi::{Username, UsernameParts};
+use windows::Win32::Foundation::{SEC_E_OK, SEC_I_COMPLETE_AND_CONTINUE, SEC_I_COMPLETE_NEEDED, SEC_I_CONTINUE_NEEDED};
+use windows::Win32::Security::Authentication::Identity::{
+    AcquireCredentialsHandleW, CompleteAuthToken, DeleteSecurityContext, FreeCredentialsHandle, ISC_REQ_CONNECTION,
+    ISC_REQ_FLAGS, ISC_REQ_INTEGRITY, ISC_REQ_MUTUAL_AUTH, ISC_RET_INTEGRITY, InitializeSecurityContextW,
+    SECBUFFER_CHANNEL_BINDINGS, SECBUFFER_TOKEN, SECBUFFER_VERSION, SECPKG_CRED_OUTBOUND, SECURITY_NETWORK_DREP,
+    SecBuffer, SecBufferDesc, SspiEncodeStringsAsAuthIdentity, SspiFreeAuthIdentity,
+};
+use windows::Win32::Security::Credentials::SecHandle;
+use windows::core::PCWSTR;
+
+use crate::{Error, GwErrorExt as _, GwErrorKind};
+
+const MAX_NEGOTIATE_TOKEN_SIZE: usize = 64 * 1024;
+
+pub(super) struct NativeHttpAuth {
+    credentials: SecHandle,
+    context: Option<SecHandle>,
+    target_name: Vec<u16>,
+    channel_binding: Vec<u8>,
+    request_mutual_auth: bool,
+}
+
+pub(super) struct InitializeStep {
+    pub(super) token: Vec<u8>,
+    pub(super) complete: bool,
+}
+
+impl NativeHttpAuth {
+    pub(super) fn new(
+        username: &str,
+        password: &str,
+        target_name: &str,
+        channel_binding: &[u8],
+        package: &str,
+    ) -> Result<Self, Error> {
+        let credentials_buffers = CredentialsBuffers::new(username, password)?;
+        let identity = NativeAuthIdentity::new(&credentials_buffers)?;
+        let package_name: Vec<u16> = package.encode_utf16().chain(core::iter::once(0)).collect();
+        let mut credentials = SecHandle::default();
+
+        // SAFETY: `identity` and `package_name` remain valid for the call and `credentials` is writable.
+        unsafe {
+            AcquireCredentialsHandleW(
+                PCWSTR::null(),
+                PCWSTR::from_raw(package_name.as_ptr()),
+                SECPKG_CRED_OUTBOUND,
+                None,
+                Some(identity.as_ptr()),
+                None,
+                None,
+                &mut credentials,
+                None,
+            )
+        }
+        .map_err(|error| Error::custom("acquire native Windows HTTP credentials", error))?;
+
+        Ok(Self {
+            credentials,
+            context: None,
+            target_name: target_name.encode_utf16().chain(core::iter::once(0)).collect(),
+            channel_binding: channel_binding.to_owned(),
+            request_mutual_auth: package == "Negotiate",
+        })
+    }
+
+    pub(super) fn initialize(&mut self, input_token: Option<&[u8]>) -> Result<InitializeStep, Error> {
+        let has_context = self.context.is_some();
+        let mut input_token = input_token.unwrap_or_default().to_vec();
+        let mut input_buffers = Vec::with_capacity(2);
+        if has_context || !input_token.is_empty() {
+            input_buffers.push(SecBuffer {
+                cbBuffer: u32::try_from(input_token.len())
+                    .map_err(|_| Error::new("native HTTP auth input token is too large", GwErrorKind::Connect))?,
+                BufferType: SECBUFFER_TOKEN,
+                pvBuffer: input_token.as_mut_ptr().cast(),
+            });
+        }
+        input_buffers.push(SecBuffer {
+            cbBuffer: u32::try_from(self.channel_binding.len())
+                .map_err(|_| Error::new("native HTTP auth channel binding is too large", GwErrorKind::Connect))?,
+            BufferType: SECBUFFER_CHANNEL_BINDINGS,
+            pvBuffer: self.channel_binding.as_mut_ptr().cast(),
+        });
+        let input_desc = SecBufferDesc {
+            ulVersion: SECBUFFER_VERSION,
+            cBuffers: u32::try_from(input_buffers.len()).expect("fixed input buffer count fits in u32"),
+            pBuffers: input_buffers.as_mut_ptr(),
+        };
+
+        let mut output_token = vec![0; MAX_NEGOTIATE_TOKEN_SIZE];
+        let mut output_buffer = SecBuffer {
+            cbBuffer: u32::try_from(output_token.len()).expect("fixed token buffer fits in u32"),
+            BufferType: SECBUFFER_TOKEN,
+            pvBuffer: output_token.as_mut_ptr().cast(),
+        };
+        let mut output_desc = SecBufferDesc {
+            ulVersion: SECBUFFER_VERSION,
+            cBuffers: 1,
+            pBuffers: &mut output_buffer,
+        };
+        let mut context_attributes = 0u32;
+        let mut new_context = self.context.unwrap_or_default();
+        let mut context_requirements: ISC_REQ_FLAGS = ISC_REQ_CONNECTION | ISC_REQ_INTEGRITY;
+        if self.request_mutual_auth {
+            context_requirements |= ISC_REQ_MUTUAL_AUTH;
+        }
+
+        // SAFETY: descriptors and strings reference live data for the call, and the credential handle is valid.
+        let status = unsafe {
+            InitializeSecurityContextW(
+                Some(&self.credentials),
+                self.context.as_ref().map(core::ptr::from_ref),
+                Some(self.target_name.as_ptr()),
+                context_requirements,
+                0,
+                SECURITY_NETWORK_DREP,
+                (!input_buffers.is_empty()).then_some(&input_desc),
+                0,
+                Some(&mut new_context),
+                Some(&mut output_desc),
+                &mut context_attributes,
+                None,
+            )
+        };
+        self.context = Some(new_context);
+
+        let complete = match status {
+            SEC_E_OK => true,
+            SEC_I_CONTINUE_NEEDED => false,
+            SEC_I_COMPLETE_NEEDED => {
+                self.complete_auth_token(&output_desc)?;
+                true
+            }
+            SEC_I_COMPLETE_AND_CONTINUE => {
+                self.complete_auth_token(&output_desc)?;
+                false
+            }
+            error => {
+                return Err(Error::custom(
+                    "initialize native Windows HTTP security context",
+                    windows::core::Error::from_hresult(error),
+                ));
+            }
+        };
+
+        let output_length = usize::try_from(output_buffer.cbBuffer).map_err(|_| {
+            Error::new(
+                "native HTTP auth output token length does not fit usize",
+                GwErrorKind::Connect,
+            )
+        })?;
+        if output_length > output_token.len() {
+            return Err(Error::new(
+                "native Windows HTTP authentication returned an oversized output token",
+                GwErrorKind::Connect,
+            ));
+        }
+        output_token.truncate(output_length);
+
+        if complete && context_attributes & ISC_RET_INTEGRITY == 0 {
+            return Err(Error::new(
+                "native Windows HTTP security context lacks integrity",
+                GwErrorKind::Connect,
+            ));
+        }
+
+        Ok(InitializeStep {
+            token: output_token,
+            complete,
+        })
+    }
+
+    fn complete_auth_token(&self, output: &SecBufferDesc) -> Result<(), Error> {
+        let context = self
+            .context
+            .as_ref()
+            .ok_or_else(|| Error::new("native Windows HTTP security context is missing", GwErrorKind::Connect))?;
+
+        // SAFETY: this context and the output descriptor are valid for the current SSPI exchange.
+        unsafe { CompleteAuthToken(context, output) }
+            .map_err(|error| Error::custom("complete native Windows HTTP authentication token", error))
+    }
+}
+
+impl Drop for NativeHttpAuth {
+    fn drop(&mut self) {
+        if let Some(context) = self.context.as_ref() {
+            // SAFETY: this object owns the initialized security context.
+            let _ = unsafe { DeleteSecurityContext(context) };
+        }
+        // SAFETY: this object owns the acquired credential handle.
+        let _ = unsafe { FreeCredentialsHandle(&self.credentials) };
+    }
+}
+
+struct CredentialsBuffers {
+    username: Vec<u16>,
+    domain: Vec<u16>,
+    password: Vec<u16>,
+}
+
+impl CredentialsBuffers {
+    fn new(username: &str, password: &str) -> Result<Self, Error> {
+        let username = Username::parse(username)
+            .or_else(|_| Username::new(username, None))
+            .map_err(|error| Error::custom("parse gateway username", error))?;
+        let (username, domain) = match username.parts() {
+            UsernameParts::UserPrincipalName(parts) => (parts.upn(), None),
+            UsernameParts::DownLevelLogonName(parts) => (parts.account_name(), parts.netbios_domain()),
+        };
+
+        Ok(Self {
+            username: username.encode_utf16().chain(core::iter::once(0)).collect(),
+            domain: domain
+                .unwrap_or_default()
+                .encode_utf16()
+                .chain(core::iter::once(0))
+                .collect(),
+            password: password.encode_utf16().chain(core::iter::once(0)).collect(),
+        })
+    }
+}
+
+impl Drop for CredentialsBuffers {
+    fn drop(&mut self) {
+        for character in &mut self.password {
+            // SAFETY: each mutable reference points to an initialized password code unit.
+            unsafe { core::ptr::write_volatile(character, 0) };
+        }
+    }
+}
+
+struct NativeAuthIdentity {
+    value: *mut core::ffi::c_void,
+}
+
+impl NativeAuthIdentity {
+    fn new(credentials: &CredentialsBuffers) -> Result<Self, Error> {
+        let mut value = core::ptr::null_mut();
+
+        // SAFETY: each credential string is NUL-terminated and remains valid for the call, and `value` is writable.
+        let result = unsafe {
+            SspiEncodeStringsAsAuthIdentity(
+                PCWSTR::from_raw(credentials.username.as_ptr()),
+                PCWSTR::from_raw(credentials.domain.as_ptr()),
+                PCWSTR::from_raw(credentials.password.as_ptr()),
+                &mut value,
+            )
+        };
+        if let Err(error) = result {
+            if !value.is_null() {
+                // SAFETY: SSPI allocated this identity before returning an error.
+                unsafe { SspiFreeAuthIdentity(Some(value.cast_const())) };
+            }
+            return Err(Error::custom("encode native Windows HTTP credentials", error));
+        }
+
+        if value.is_null() {
+            return Err(Error::new(
+                "encode native Windows HTTP credentials returned no identity",
+                GwErrorKind::Connect,
+            ));
+        }
+
+        Ok(Self { value })
+    }
+
+    fn as_ptr(&self) -> *const core::ffi::c_void {
+        self.value.cast_const()
+    }
+}
+
+impl Drop for NativeAuthIdentity {
+    fn drop(&mut self) {
+        // SAFETY: this object owns the identity allocated by `SspiEncodeStringsAsAuthIdentity`.
+        unsafe { SspiFreeAuthIdentity(Some(self.value.cast_const())) };
+    }
+}

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -36,6 +36,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin + ?Sized> GatewayIo for T {}
 type GatewayStream = Box<dyn GatewayIo + Send>;
 type RdgBody = BoxBody<Bytes, Infallible>;
 
+struct GatewayTlsConnection {
+    stream: GatewayStream,
+    channel_binding: Option<Vec<u8>>,
+}
+
 const MAX_AUTH_RESPONSE_SIZE: usize = 16 * 1024;
 const MAX_PACKET_SIZE: usize = 16 * 1024 * 1024;
 const MAX_PROXY_RESPONSE_SIZE: usize = 16 * 1024;
@@ -138,7 +143,7 @@ struct RdgRequestContext<'a> {
     gw_host: &'a str,
     connection_id: &'a str,
     target: &'a GwConnectTarget,
-    websocket_upgrade: bool,
+    websocket_key: Option<&'a str>,
 }
 
 /// Session cookies returned by an RD Gateway or its load balancer.
@@ -330,7 +335,7 @@ async fn upgrade_gateway_tls(
     gw_endpoint: &str,
     certificate_validation: CertificateValidation,
     certificate_validation_callback: Option<CertificateValidationCallback>,
-) -> Result<GatewayStream, Error> {
+) -> Result<GatewayTlsConnection, Error> {
     let (stream, _) = match select_gateway_tls_upgrade(certificate_validation, certificate_validation_callback) {
         GatewayTlsUpgrade::CertificateValidation(certificate_validation) => {
             ironrdp_tls::upgrade_with_certificate_validation(stream, gw_host, certificate_validation).await
@@ -347,7 +352,16 @@ async fn upgrade_gateway_tls(
     }
     .map_err(|e| custom_err!("tls connect", e))?;
 
-    Ok(Box::new(stream))
+    #[cfg(all(windows, feature = "native-tls"))]
+    let channel_binding = ironrdp_tls::endpoint_channel_binding(&stream)
+        .map_err(|e| custom_err!("get TLS endpoint channel binding", e))?;
+    #[cfg(not(all(windows, feature = "native-tls")))]
+    let channel_binding = None;
+
+    Ok(GatewayTlsConnection {
+        stream: Box::new(stream),
+        channel_binding,
+    })
 }
 
 fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
@@ -818,7 +832,7 @@ fn select_gateway_tls_upgrade(
 }
 
 async fn open_transport_with_out_stream<F, Fut>(
-    out_stream: GatewayStream,
+    out_stream: GatewayTlsConnection,
     client_addr: core::net::SocketAddr,
     gw_host: &str,
     target: &GwConnectTarget,
@@ -826,9 +840,14 @@ async fn open_transport_with_out_stream<F, Fut>(
 ) -> Result<(GatewayTransport, core::net::SocketAddr), Error>
 where
     F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<GatewayStream, Error>>,
+    Fut: Future<Output = Result<GatewayTlsConnection, Error>>,
 {
+    let GatewayTlsConnection {
+        stream: out_stream,
+        channel_binding,
+    } = out_stream;
     let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
+    let websocket_key = generate_key();
     let spn = format!("HTTP/{gw_host}");
     let out_io = hyper_util::rt::tokio::TokioIo::new(out_stream);
     let (mut out_sender, out_conn) = hyper::client::conn::http1::handshake(out_io)
@@ -857,9 +876,17 @@ where
         gw_host,
         connection_id: &connection_id,
         target,
-        websocket_upgrade: true,
+        websocket_key: Some(&websocket_key),
     };
-    let authenticated = authenticated_rdg_request(&mut out_sender, &context, &spn, &mut cookies, None).await?;
+    let authenticated = authenticated_rdg_request(
+        &mut out_sender,
+        &context,
+        &spn,
+        &mut cookies,
+        channel_binding.as_deref(),
+        None,
+    )
+    .await?;
     let session_authentication = authenticated.session_authentication;
     let response = authenticated.response;
 
@@ -931,13 +958,18 @@ pub(crate) async fn open_test_transport(
         .parse()
         .map_err(|e| custom_err!("parse test client address", e))?;
     open_transport_with_out_stream(
-        Box::new(out_stream),
+        GatewayTlsConnection {
+            stream: Box::new(out_stream),
+            channel_binding: None,
+        },
         client_addr,
         "gateway.test",
         &target,
         move || async move {
-            let stream: GatewayStream = Box::new(in_stream);
-            Ok(stream)
+            Ok(GatewayTlsConnection {
+                stream: Box::new(in_stream),
+                channel_binding: None,
+            })
         },
     )
     .await
@@ -949,7 +981,7 @@ pub(crate) async fn open_test_transport(
     reason = "carries both established dual HTTP channel states"
 )]
 async fn open_in_channel(
-    in_stream: GatewayStream,
+    in_stream: GatewayTlsConnection,
     gw_host: &str,
     target: &GwConnectTarget,
     connection_id: &str,
@@ -961,6 +993,10 @@ async fn open_in_channel(
     out_conn: tokio::task::JoinHandle<()>,
     session_authentication: GwSessionAuthentication,
 ) -> Result<PacketIo, Error> {
+    let GatewayTlsConnection {
+        stream: in_stream,
+        channel_binding,
+    } = in_stream;
     let in_io = hyper_util::rt::tokio::TokioIo::new(in_stream);
     let (mut in_sender, in_conn) = hyper::client::conn::http1::handshake(in_io)
         .await
@@ -976,10 +1012,17 @@ async fn open_in_channel(
         gw_host,
         connection_id,
         target,
-        websocket_upgrade: false,
+        websocket_key: None,
     };
-    let authenticated =
-        authenticated_rdg_request(&mut in_sender, &context, spn, cookies, Some(session_authentication)).await?;
+    let authenticated = authenticated_rdg_request(
+        &mut in_sender,
+        &context,
+        spn,
+        cookies,
+        channel_binding.as_deref(),
+        Some(session_authentication),
+    )
+    .await?;
     let response = authenticated.response;
     if response.status() != http::StatusCode::OK {
         let status = response.status();
@@ -1020,12 +1063,14 @@ async fn authenticated_rdg_request(
     context: &RdgRequestContext<'_>,
     spn: &str,
     cookies: &mut GatewayCookies,
+    channel_binding: Option<&[u8]>,
     requested_session_authentication: Option<GwSessionAuthentication>,
 ) -> Result<AuthenticatedRdgResponse, Error> {
     let mut http_auth: Option<GatewayHttpAuth> = None;
     let mut session_authentication = requested_session_authentication.unwrap_or_default();
     let mut authorization =
         (session_authentication == GwSessionAuthentication::NtlmSspi).then(|| "SSPI_NTLM".to_owned());
+    let channel_binding = channel_binding.map(ToOwned::to_owned);
     let mut use_basic = false;
     const MAX_AUTH_ROUNDS: usize = 8;
 
@@ -1105,9 +1150,17 @@ async fn authenticated_rdg_request(
             http_auth = Some(auth);
             step
         } else {
+            let channel_binding = channel_binding.clone();
             let (auth, step) = run_http_auth(move || {
                 let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
-                GatewayHttpAuth::from_challenges(&user, &pass, smart_card.as_deref(), Some(target_name), &refs)
+                GatewayHttpAuth::from_challenges_with_channel_binding(
+                    &user,
+                    &pass,
+                    smart_card.as_deref(),
+                    Some(target_name),
+                    channel_binding.as_deref(),
+                    &refs,
+                )
             })
             .await?;
             http_auth = auth;
@@ -1157,12 +1210,12 @@ fn build_rdg_request(
     if let Some(cookie_header) = cookies.header_value() {
         request = request.header(hyper::header::COOKIE, cookie_header);
     }
-    if context.websocket_upgrade {
+    if let Some(websocket_key) = context.websocket_key {
         request = request
             .header(hyper::header::CONNECTION, "Upgrade")
             .header(hyper::header::UPGRADE, "websocket")
             .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
-            .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
+            .header(hyper::header::SEC_WEBSOCKET_KEY, websocket_key);
     }
     if use_basic {
         request = request.header(

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -4,6 +4,8 @@ use hyper::body::Bytes;
 use tokio::io::AsyncWriteExt as _;
 
 use crate::http_auth::basic_authorization;
+#[cfg(all(windows, feature = "native-tls"))]
+use crate::http_auth::native_http_auth::NativeHttpAuth as NativeHttpAuthInner;
 use crate::packet_io::{
     GatewayTransport as NetworkGatewayTransport, gateway_endpoint_is_valid as endpoint_is_valid,
     gateway_endpoint_summary as endpoint_summary, open_gateway_transport, open_test_transport, parse_proxy_url,
@@ -13,6 +15,24 @@ use crate::{ConsentFallback, Error, GwClient, GwConnectTarget, GwConsentCallback
 
 /// In-memory gateway transport used by the registered integration tests.
 pub struct GatewayTransport(NetworkGatewayTransport);
+
+/// Native Windows SSPI HTTP authentication test hook.
+#[cfg(all(windows, feature = "native-tls"))]
+pub struct NativeHttpAuth(NativeHttpAuthInner);
+
+#[cfg(all(windows, feature = "native-tls"))]
+impl NativeHttpAuth {
+    /// Create the native NTLM state machine with channel binding data.
+    pub fn ntlm(username: &str, password: &str, target_name: &str, channel_binding: &[u8]) -> Result<Self, Error> {
+        NativeHttpAuthInner::new(username, password, target_name, channel_binding, "NTLM").map(Self)
+    }
+
+    /// Initialize or continue the native SSPI exchange.
+    pub fn initialize(&mut self, input_token: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
+        let step = self.0.initialize(input_token)?;
+        Ok((step.token, step.complete))
+    }
+}
 
 impl GatewayTransport {
     /// Connect the client side of the mock OUT and IN HTTP connections.

--- a/crates/ironrdp-mstsgu/tests/http_auth.rs
+++ b/crates/ironrdp-mstsgu/tests/http_auth.rs
@@ -70,6 +70,72 @@ fn ntlm_type1_from_challenge() {
     }
 }
 
+#[cfg(windows)]
+#[test]
+fn native_ntlm_state_machine_accepts_channel_binding_on_every_exchange() {
+    let mut auth = ironrdp_mstsgu::test_support::NativeHttpAuth::ntlm(
+        r"CONTOSO\alice",
+        "secret",
+        "HTTP/rdg.contoso.com",
+        &channel_binding(),
+    )
+    .expect("create native NTLM auth");
+
+    let (type_one, complete) = auth.initialize(None).expect("initialize native NTLM auth");
+    assert!(!complete);
+    assert!(type_one.starts_with(b"NTLMSSP\0"));
+
+    let (type_three, _) = auth
+        .initialize(Some(&ntlm_type_two_challenge()))
+        .expect("continue native NTLM auth");
+    assert!(type_three.starts_with(b"NTLMSSP\0"));
+}
+
+#[cfg(windows)]
+fn channel_binding() -> Vec<u8> {
+    let application_data = [b"tls-server-end-point:".as_slice(), &[0xA5; 32]].concat();
+    let mut binding = vec![0; 32];
+    let application_data_length = u32::try_from(application_data.len()).expect("fixed channel binding length fits u32");
+    binding[24..28].copy_from_slice(&application_data_length.to_le_bytes());
+    binding[28..32].copy_from_slice(&32u32.to_le_bytes());
+    binding.extend_from_slice(&application_data);
+    binding
+}
+
+#[cfg(windows)]
+fn ntlm_type_two_challenge() -> Vec<u8> {
+    const NEGOTIATE_FLAGS: u32 = 0xE288_82B7;
+    const TARGET_NAME_OFFSET: u32 = 56;
+    const TARGET_INFO_OFFSET: u32 = 64;
+    const TARGET_NAME: &[u8] = &[b'W', 0, b'I', 0, b'N', 0, b'7', 0];
+    const TARGET_INFO: &[u8] = &[
+        0x02, 0x00, 0x08, 0x00, b'W', 0x00, b'I', 0x00, b'N', 0x00, b'7', 0x00, // MsvAvNbDomainName
+        0x01, 0x00, 0x08, 0x00, b'W', 0x00, b'I', 0x00, b'N', 0x00, b'7', 0x00, // MsvAvNbComputerName
+        0x04, 0x00, 0x08, 0x00, b'w', 0x00, b'i', 0x00, b'n', 0x00, b'7', 0x00, // MsvAvDnsDomainName
+        0x03, 0x00, 0x08, 0x00, b'w', 0x00, b'i', 0x00, b'n', 0x00, b'7', 0x00, // MsvAvDnsComputerName
+        0x07, 0x00, 0x08, 0x00, 0xA9, 0x8D, 0x9B, 0x1A, 0x6C, 0xB0, 0xCB, 0x01, // MsvAvTimestamp
+        0x00, 0x00, 0x00, 0x00, // MsvAvEOL
+    ];
+
+    let target_info_length = u16::try_from(TARGET_INFO.len()).expect("fixed target info length fits u16");
+    let mut challenge = Vec::with_capacity(128);
+    challenge.extend_from_slice(b"NTLMSSP\0");
+    challenge.extend_from_slice(&2u32.to_le_bytes());
+    challenge.extend_from_slice(&8u16.to_le_bytes()); // TargetNameLen
+    challenge.extend_from_slice(&8u16.to_le_bytes()); // TargetNameMaxLen
+    challenge.extend_from_slice(&TARGET_NAME_OFFSET.to_le_bytes());
+    challenge.extend_from_slice(&NEGOTIATE_FLAGS.to_le_bytes());
+    challenge.extend_from_slice(&[0x26, 0x6E, 0xCD, 0x75, 0xAA, 0x41, 0xE7, 0x6F]); // ServerChallenge
+    challenge.extend_from_slice(&[0; 8]); // Reserved
+    challenge.extend_from_slice(&target_info_length.to_le_bytes()); // TargetInfoLen
+    challenge.extend_from_slice(&target_info_length.to_le_bytes()); // TargetInfoMaxLen
+    challenge.extend_from_slice(&TARGET_INFO_OFFSET.to_le_bytes());
+    challenge.extend_from_slice(&[0x06, 0x01, 0xB0, 0x1D, 0x00, 0x00, 0x00, 0x0F]); // Version
+    challenge.extend_from_slice(TARGET_NAME);
+    challenge.extend_from_slice(TARGET_INFO);
+    challenge
+}
+
 #[test]
 fn try_basic_when_only_basic_offered() {
     let (auth, step) =

--- a/crates/ironrdp-mstsgu/tests/packet_io.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io.rs
@@ -100,32 +100,63 @@ async fn switching_protocols_keeps_websocket_transport() {
     let (out_client, out_server) = tokio::io::duplex(4096);
     let (in_client, _in_server) = tokio::io::duplex(4096);
     let (upgrade_tx, upgrade_rx) = oneshot::channel();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let websocket_key = Arc::new(Mutex::new(None));
+    let server_requests = Arc::clone(&requests);
+    let server_websocket_key = Arc::clone(&websocket_key);
 
     let server = tokio::spawn(async move {
         let upgrade_tx = Arc::new(Mutex::new(Some(upgrade_tx)));
+        let requests = server_requests;
+        let websocket_key = server_websocket_key;
         let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
-            let upgrade = hyper::upgrade::on(&mut request);
             let upgrade_tx = Arc::clone(&upgrade_tx);
+            let requests = Arc::clone(&requests);
+            let websocket_key = Arc::clone(&websocket_key);
             async move {
                 assert_eq!(request.method(), "RDG_OUT_DATA");
-                assert!(request.headers().get("authorization").is_none());
-                upgrade_tx
-                    .lock()
-                    .expect("upgrade sender lock")
-                    .take()
-                    .expect("one websocket request")
-                    .send(upgrade)
-                    .expect("send upgrade");
+                match requests.fetch_add(1, Ordering::SeqCst) {
+                    0 => {
+                        assert!(request.headers().get("authorization").is_none());
+                        *websocket_key.lock().expect("WebSocket key lock") =
+                            Some(request.headers()["sec-websocket-key"].clone());
+                        Ok::<_, Infallible>(response(
+                            StatusCode::UNAUTHORIZED,
+                            &[("www-authenticate", "Basic realm=\"RDG\"")],
+                            Bytes::new(),
+                        ))
+                    }
+                    1 => {
+                        assert_eq!(request.headers()["authorization"], "Basic dXNlcjpwYXNz");
+                        assert_eq!(
+                            request.headers()["sec-websocket-key"],
+                            websocket_key
+                                .lock()
+                                .expect("WebSocket key lock")
+                                .as_ref()
+                                .expect("initial WebSocket key")
+                        );
+                        let upgrade = hyper::upgrade::on(&mut request);
+                        upgrade_tx
+                            .lock()
+                            .expect("upgrade sender lock")
+                            .take()
+                            .expect("one websocket request")
+                            .send(upgrade)
+                            .expect("send upgrade");
 
-                let mut response = Response::new(Full::new(Bytes::new()).boxed());
-                *response.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
-                response
-                    .headers_mut()
-                    .insert("connection", "Upgrade".parse().expect("header"));
-                response
-                    .headers_mut()
-                    .insert("upgrade", "websocket".parse().expect("header"));
-                Ok::<_, Infallible>(response)
+                        let mut response = Response::new(Full::new(Bytes::new()).boxed());
+                        *response.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+                        response
+                            .headers_mut()
+                            .insert("connection", "Upgrade".parse().expect("header"));
+                        response
+                            .headers_mut()
+                            .insert("upgrade", "websocket".parse().expect("header"));
+                        Ok(response)
+                    }
+                    _ => panic!("unexpected WebSocket upgrade request"),
+                }
             }
         });
         http1::Builder::new()
@@ -169,6 +200,7 @@ async fn switching_protocols_keeps_websocket_transport() {
 
     transport.close().await.expect("close websocket");
     server.await.expect("server task");
+    assert_eq!(requests.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]

--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -38,6 +38,8 @@ compile_error!(
     "a TLS backend must be selected by enabling a single feature out of: `rustls`, `native-tls`, `stub` (the rustls crypto provider is chosen via `rustls`/`rustls-aws-lc-rs`/`rustls-ring`/`rustls-no-provider`)"
 );
 
+#[cfg(all(feature = "native-tls", windows))]
+pub use impl_::endpoint_channel_binding;
 #[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls-no-provider"))]
 pub use impl_::{
     TlsStream, negotiated, upgrade, upgrade_with_certificate_validation, upgrade_with_certificate_validation_callback,

--- a/crates/ironrdp-tls/src/native_tls.rs
+++ b/crates/ironrdp-tls/src/native_tls.rs
@@ -6,6 +6,38 @@ use crate::{CertificateValidation, CertificateValidationCallback};
 
 pub type TlsStream<S> = tokio_native_tls::TlsStream<S>;
 
+/// Returns the RFC 5929 endpoint channel binding encoded for a Windows SSPI `SECBUFFER_CHANNEL_BINDINGS` input buffer.
+#[cfg(windows)]
+pub fn endpoint_channel_binding<S>(stream: &TlsStream<S>) -> io::Result<Option<Vec<u8>>>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
+    let Some(endpoint) = stream.get_ref().tls_server_end_point().map_err(io::Error::other)? else {
+        return Ok(None);
+    };
+
+    const HEADER_SIZE: usize = 32;
+    const APPLICATION_DATA_LENGTH_OFFSET: usize = 24;
+    const APPLICATION_DATA_OFFSET_OFFSET: usize = 28;
+    const APPLICATION_DATA_OFFSET: u32 = 32;
+    const APPLICATION_DATA_PREFIX: &[u8] = b"tls-server-end-point:";
+
+    let application_data_length = APPLICATION_DATA_PREFIX
+        .len()
+        .checked_add(endpoint.len())
+        .ok_or_else(|| io::Error::other("endpoint channel binding is too large"))?;
+    let application_data_length_u32 = u32::try_from(application_data_length)
+        .map_err(|_| io::Error::other("endpoint channel binding is too large"))?;
+    let mut binding = vec![0; HEADER_SIZE + application_data_length];
+    binding[APPLICATION_DATA_LENGTH_OFFSET..APPLICATION_DATA_OFFSET_OFFSET]
+        .copy_from_slice(&application_data_length_u32.to_le_bytes());
+    binding[APPLICATION_DATA_OFFSET_OFFSET..HEADER_SIZE].copy_from_slice(&APPLICATION_DATA_OFFSET.to_le_bytes());
+    binding[HEADER_SIZE..HEADER_SIZE + APPLICATION_DATA_PREFIX.len()].copy_from_slice(APPLICATION_DATA_PREFIX);
+    binding[HEADER_SIZE + APPLICATION_DATA_PREFIX.len()..].copy_from_slice(&endpoint);
+
+    Ok(Some(binding))
+}
+
 pub async fn upgrade<S>(stream: S, server_name: &str) -> io::Result<(TlsStream<S>, x509_cert::Certificate)>
 where
     S: Unpin + AsyncRead + AsyncWrite,

--- a/crates/ironrdp-tls/tests/native_tls.rs
+++ b/crates/ironrdp-tls/tests/native_tls.rs
@@ -1,3 +1,5 @@
+#[cfg(windows)]
+use ironrdp_tls::endpoint_channel_binding;
 use ironrdp_tls::{CertificateValidation, upgrade, upgrade_with_certificate_validation};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_native_tls::TlsAcceptor;
@@ -34,6 +36,19 @@ async fn default_accepts_self_signed_certificates_and_strict_rejects_them() {
     )
     .await
     .expect("default validation accepts the self-signed test certificate");
+    #[cfg(windows)]
+    {
+        let channel_binding = endpoint_channel_binding(&tls_stream)
+            .expect("get TLS endpoint channel binding")
+            .expect("TLS endpoint channel binding");
+        assert!(channel_binding[..24].iter().all(|byte| *byte == 0));
+        assert_eq!(
+            &channel_binding[24..28],
+            &(u32::try_from(channel_binding.len() - 32).expect("channel binding length")).to_le_bytes()
+        );
+        assert_eq!(&channel_binding[28..32], &32u32.to_le_bytes());
+        assert!(channel_binding[32..].starts_with(b"tls-server-end-point:"));
+    }
     drop(tls_stream);
 
     let strict_result = upgrade_with_certificate_validation(

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -243,12 +243,17 @@ pub fn tests_compile(sh: &Shell) -> anyhow::Result<()> {
     .run()?;
     cmd!(
         sh,
-        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked --no-run"
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,test-support --locked --no-run"
     )
     .run()?;
     cmd!(
         sh,
-        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard --locked --no-run"
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard,test-support --locked --no-run"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test packet_io --features native-tls,test-support --locked --no-run"
     )
     .run()?;
     println!("All good!");
@@ -265,12 +270,17 @@ pub fn tests_run(sh: &Shell) -> anyhow::Result<()> {
     .run()?;
     cmd!(
         sh,
-        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked"
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,test-support --locked"
     )
     .run()?;
     cmd!(
         sh,
-        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard --locked"
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard,test-support --locked"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test packet_io --features native-tls,test-support --locked"
     )
     .run()?;
     println!("All good!");


### PR DESCRIPTION
Use native Windows SSPI with TLS endpoint binding for regular RD Gateway HTTP Negotiate and NTLM authentication.

Fall back to portable authentication when native TLS binding is unavailable.