### PR TITLE
fix(mstsgu): accept advertised extended auth

### DIFF
--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -14,7 +14,7 @@ This crate
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, Basic fallback, or MS-TSGU `SSPI_NTLM` extended authentication when negotiated,
 - can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,
-- rejects unsupported `HTTP_EXTENDED_AUTH_SC` and PAA exchanges without a credential-provider UI,
+- does not implement `HTTP_EXTENDED_AUTH_SC` or PAA exchanges without a credential-provider UI,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,
 - encodes and decodes DCE/RPC common-header fragments and reassembles responses, without a live RPC-over-HTTP transport, and
 - finishes write-side shutdown by closing the outbound WebSocket or ending the dual HTTP IN request body.

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -214,18 +214,6 @@ impl Display for GwErrorKind {
 
 impl core::error::Error for GwErrorKind {}
 
-fn extended_authentication_method(extended_auth: HttpExtendedAuth) -> GwExtendedAuthentication {
-    if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SC) {
-        GwExtendedAuthentication::SmartCard
-    } else if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_PAA) {
-        GwExtendedAuthentication::PluggableAuthentication
-    } else if extended_auth.contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM) {
-        GwExtendedAuthentication::NtlmSspi
-    } else {
-        GwExtendedAuthentication::Unknown(extended_auth.bits())
-    }
-}
-
 struct GwConn {
     client_name: String,
     target: GwConnectTarget,
@@ -690,12 +678,6 @@ impl GwConn {
         }
 
         match session_authentication {
-            GwSessionAuthentication::Http if !resp.extended_auth.is_empty() => {
-                return Err(Error::new(
-                    "Handshake",
-                    GwErrorKind::UnsupportedExtendedAuthentication(extended_authentication_method(resp.extended_auth)),
-                ));
-            }
             GwSessionAuthentication::NtlmSspi
                 if !resp
                     .extended_auth

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -295,28 +295,39 @@ async fn extended_sspi_ntlm_sends_an_initial_token_and_rejects_an_empty_challeng
 }
 
 #[tokio::test]
-async fn unsupported_extended_authentication_is_reported_precisely() {
+async fn ordinary_http_authentication_ignores_advertised_extended_authentication_capabilities() {
     let (out_client, out_server) = tokio::io::duplex(4096);
     let (in_client, in_server) = tokio::io::duplex(4096);
     let out_server = tokio::spawn(mock_out_server(
         out_server,
-        vec![packet(2, &handshake_response_with_extended_auth(0, 0x0001))],
+        vec![
+            packet(2, &handshake_response_with_extended_auth(0, 0x0003)),
+            packet(5, &tunnel_response(0, &[])),
+            packet(7, &control_response(0)),
+            packet(9, &control_response(0)),
+        ],
     ));
     let in_server = tokio::spawn(async move {
         let service = service_fn(move |mut request: Request<hyper::body::Incoming>| async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
             if request.headers().get("content-type").is_none() {
                 return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
             }
-            let handshake = request
-                .body_mut()
-                .frame()
-                .await
-                .expect("handshake frame")
-                .expect("handshake frame result")
-                .into_data()
-                .expect("handshake data frame");
-            assert_eq!(packet_type(&handshake), 1);
-            assert_eq!(&handshake[12..14], &0u16.to_le_bytes());
+
+            for expected_packet_type in [1, 4, 6, 8] {
+                let frame = request
+                    .body_mut()
+                    .frame()
+                    .await
+                    .expect("IN request frame")
+                    .expect("IN request frame result")
+                    .into_data()
+                    .expect("IN request data frame");
+                assert_eq!(packet_type(&frame), expected_packet_type);
+                if expected_packet_type == 1 {
+                    assert_eq!(&frame[12..14], &0u16.to_le_bytes());
+                }
+            }
             Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
         });
         http1::Builder::new()
@@ -328,14 +339,68 @@ async fn unsupported_extended_authentication_is_reported_precisely() {
     let transport = GatewayTransport::connect(out_client, in_client)
         .await
         .expect("connect transport");
-    let error = match transport.connect_tunnel(test_target(), "client.test", 3389, None).await {
-        Ok(_) => panic!("unsupported extended authentication"),
+    let client = transport
+        .connect_tunnel(test_target(), "client.test", 3389, None)
+        .await
+        .expect("connect tunnel");
+
+    drop(client);
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
+#[tokio::test]
+async fn extended_sspi_ntlm_requires_advertised_sspi_ntlm_capability() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let out_server = tokio::spawn(mock_out_server(
+        out_server,
+        vec![packet(2, &handshake_response_with_extended_auth(0, 0x0003))],
+    ));
+    let in_server = tokio::spawn(async move {
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+
+            let handshake = request
+                .body_mut()
+                .frame()
+                .await
+                .expect("handshake frame")
+                .expect("handshake frame result")
+                .into_data()
+                .expect("handshake data frame");
+            assert_eq!(packet_type(&handshake), 1);
+            assert_eq!(&handshake[12..14], &0x0004u16.to_le_bytes());
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let transport = GatewayTransport::connect(out_client, in_client)
+        .await
+        .expect("connect transport");
+    let error = match transport
+        .connect_tunnel_with_session_authentication(
+            test_target(),
+            "client.test",
+            3389,
+            GwSessionAuthentication::NtlmSspi,
+        )
+        .await
+    {
+        Ok(_) => panic!("missing SSPI_NTLM capability"),
         Err(error) => error,
     };
 
     assert!(matches!(
         error.kind(),
-        GwErrorKind::UnsupportedExtendedAuthentication(GwExtendedAuthentication::SmartCard)
+        GwErrorKind::UnsupportedExtendedAuthentication(GwExtendedAuthentication::NtlmSspi)
     ));
     out_server.await.expect("OUT task");
     in_server.await.expect("IN task");

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -118,10 +118,10 @@ fn reauth_message_roundtrip() {
 }
 
 #[test]
-fn handshake_response_preserves_advertised_extended_auth_flags() {
+fn handshake_response_preserves_advertised_extended_auth_capabilities() {
     assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE.bits(), 0);
 
-    for flags in [0x0000u16, 0x0007, 0x8004] {
+    for flags in [0x0000u16, 0x0003, 0x0004, 0x8000] {
         let mut bytes = [
             0x02, 0x00, // packetType
             0x00, 0x00, // reserved


### PR DESCRIPTION
Treat handshake ExtendedAuth bits as capabilities after HTTP authentication.

Require SSPI_NTLM and run its exchange when selected at transport setup.