### PR TITLE
fix(pdu): retain unknown ClientInfoFlags bits instead of refusing the PDU

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -149,8 +149,13 @@ impl<'de> Decode<'de> for ClientInfo {
         let code_page = src.read_u32();
         let flags_with_compression_type = src.read_u32();
 
-        let flags = ClientInfoFlags::from_bits(flags_with_compression_type & !COMPRESSION_TYPE_MASK)
-            .ok_or_else(|| invalid_field_err!("flags", "invalid ClientInfoFlags", in: src))?;
+        // [MS-RDPBCGR] 3.3.5.3.11 asks the server to validate lengths and to
+        // test the UNICODE flag, never to validate this bit set, and the
+        // INFO_* list has grown several times; refusing unknown bits would
+        // reject newer clients at the login step. Retain them instead
+        // (crate-wide policy since #1144) so re-encoding preserves the wire
+        // value.
+        let flags = ClientInfoFlags::from_bits_retain(flags_with_compression_type & !COMPRESSION_TYPE_MASK);
         let compression_type = CompressionType::from_u32((flags_with_compression_type & COMPRESSION_TYPE_MASK) >> 9)
             .ok_or_else(|| invalid_field_err!("flags", "invalid CompressionType", in: src))?;
 

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -1,4 +1,5 @@
 use ironrdp_core::{Encode as _, decode, encode_vec};
+use ironrdp_pdu::rdp::client_info::ClientInfo;
 use ironrdp_testsuite_core::capsets::*;
 use ironrdp_testsuite_core::client_info::*;
 use ironrdp_testsuite_core::rdp::*;
@@ -306,6 +307,26 @@ fn from_buffer_correct_parses_client_info_pdu_unicode() {
         CLIENT_INFO_UNICODE.clone(),
         decode(CLIENT_INFO_BUFFER_UNICODE.as_ref()).unwrap()
     );
+}
+
+#[test]
+fn client_info_with_undefined_flag_bits_decodes_and_retains_them() {
+    // [MS-RDPBCGR] 2.2.1.11.1.1's INFO_* list keeps growing; a client setting
+    // a bit this library does not know yet must not be refused at the login
+    // step (3.3.5.3.11 mandates no validation of this field). The unknown bit
+    // is retained rather than dropped so re-encoding preserves the wire value.
+    const UNDEFINED_BIT: u32 = 0x0000_0004; // undefined in 2.2.1.11.1.1
+
+    let mut buffer = CLIENT_INFO_BUFFER_UNICODE.to_vec();
+    let flags = u32::from_le_bytes(buffer[4..8].try_into().unwrap()) | UNDEFINED_BIT;
+    buffer[4..8].copy_from_slice(&flags.to_le_bytes());
+
+    let client_info: ClientInfo = decode(buffer.as_slice()).expect("undefined INFO bits are not fatal");
+
+    assert_ne!(client_info.flags.bits() & UNDEFINED_BIT, 0);
+
+    let reencoded = encode_vec(&client_info).unwrap();
+    assert_eq!(reencoded, buffer);
 }
 
 #[test]


### PR DESCRIPTION
ClientInfo::decode rejects the whole Client Info PDU when the flags field carries a bit outside the twenty-one INFO_* flags this library defines. [MS-RDPBCGR] 3.3.5.3.11 asks the server to validate the embedded lengths and to test the UNICODE flag before reading character data; it never asks the server to validate the flags bit set. Microsoft has extended the INFO_* list several times (INFO_AUDIOCAPTURE, INFO_VIDEO_DISABLE and INFO_HIDEF_RAIL_SUPPORTED are all later additions), so a newer client setting a bit this list does not know yet is refused at the login step, after the connection sequence has otherwise succeeded.

The fix switches the site to from_bits_retain, the crate-wide policy since #1144: the unknown bits are kept rather than dropped, so re-encoding a decoded ClientInfo reproduces the wire value. The CompressionTypeMask bits are unaffected; they are masked out before the flags conversion and parsed separately, as before.

This continues the same interop line as #1489 (unknown GCC user-data blocks), #1458 (unknown security header flags), #1536/#1541 (under-declared lengths) and #1837 (undefined channel option bits).

Test: a Client Info fixture with an undefined flag bit decodes, the bit is retained, and re-encoding reproduces the exact input bytes. Verified to fail with the strict from_bits restored.

`cargo xtask check fmt/lints/tests/typos/locks` all pass.
