### PR TITLE
fix(pdu): retain unknown fast-path input eventFlags bits instead of dropping the session

### DIFF
--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -198,8 +198,13 @@ impl<'de> Decode<'de> for FastPathInputEvent {
             FastpathInputEventType::ScanCode => {
                 ensure_size!(in: src, size: 1);
                 let code = src.read_u8();
-                let flags = KeyboardFlags::from_bits(flags)
-                    .ok_or_else(|| invalid_field_err!("flags", "input keyboard flags unsupported", in: src))?;
+                // Retain unknown eventFlags bits (crate-wide policy since
+                // #1144): the slow-path decoder for the same keystroke
+                // already does (scan_code.rs), and a rejection here is
+                // session-fatal mid-use. [MS-RDPBCGR] 3.3.5.8.2's SHOULD-drop
+                // covers unknown event TYPES, which stays enforced above,
+                // not unknown flag bits.
+                let flags = KeyboardFlags::from_bits_retain(flags);
                 FastPathInputEvent::KeyboardEvent(flags, code)
             }
             FastpathInputEventType::Mouse => {
@@ -215,15 +220,16 @@ impl<'de> Decode<'de> for FastPathInputEvent {
                 FastPathInputEvent::MouseEventRel(mouse_event)
             }
             FastpathInputEventType::Sync => {
-                let flags = SynchronizeFlags::from_bits(flags)
-                    .ok_or_else(|| invalid_field_err!("flags", "input synchronize flags unsupported", in: src))?;
+                // Same rationale as ScanCode above; the slow-path sync
+                // decoder (sync.rs) already retains unknown toggle bits.
+                let flags = SynchronizeFlags::from_bits_retain(flags);
                 FastPathInputEvent::SyncEvent(flags)
             }
             FastpathInputEventType::Unicode => {
                 ensure_size!(in: src, size: 2);
                 let code = src.read_u16();
-                let flags = KeyboardFlags::from_bits(flags)
-                    .ok_or_else(|| invalid_field_err!("flags", "input keyboard flags unsupported", in: src))?;
+                // Same rationale as ScanCode above.
+                let flags = KeyboardFlags::from_bits_retain(flags);
                 FastPathInputEvent::UnicodeKeyboardEvent(flags, code)
             }
             FastpathInputEventType::QoeTimestamp => {

--- a/crates/ironrdp-testsuite-core/tests/input/fastpath_packets.rs
+++ b/crates/ironrdp-testsuite-core/tests/input/fastpath_packets.rs
@@ -361,3 +361,52 @@ fn wheel_rotations_out_of_range_is_clamped(#[case] rotation_units: i16, #[case] 
         })
     );
 }
+
+#[test]
+fn fastpath_keyboard_event_with_undefined_flag_bits_decodes_and_retains_them() {
+    // The 5-bit fast-path eventFlags field defines RELEASE, EXTENDED and
+    // EXTENDED1 for keyboard events ([MS-RDPBCGR] 2.2.8.1.2.2.1); an unknown
+    // bit must not kill a live session, and the slow-path decoder for the
+    // same keystroke already tolerates it. The bit is retained so
+    // re-encoding preserves the wire value.
+    const UNDEFINED_BIT: u8 = 0x10;
+
+    // eventCode = FASTPATH_INPUT_EVENT_SCANCODE (0) in bits 5..8,
+    // eventFlags = RELEASE | UNDEFINED_BIT in bits 0..5, then the scancode.
+    let buffer = [0x01 | UNDEFINED_BIT, 0x1d];
+
+    let event: FastPathInputEvent = ironrdp_core::decode(&buffer).expect("undefined flag bits are not fatal");
+
+    let FastPathInputEvent::KeyboardEvent(flags, code) = event else {
+        panic!("expected a keyboard event");
+    };
+    assert_eq!(code, 0x1d);
+    assert!(flags.contains(KeyboardFlags::RELEASE));
+    assert_ne!(flags.bits() & UNDEFINED_BIT, 0);
+    assert_eq!(
+        ironrdp_core::encode_vec(&FastPathInputEvent::KeyboardEvent(flags, code)).unwrap(),
+        buffer
+    );
+}
+
+#[test]
+fn fastpath_sync_event_with_undefined_flag_bits_decodes_and_retains_them() {
+    // [MS-RDPBCGR] 2.2.8.1.2.2.5 defines the four lock flags; bit 0x10 of
+    // the 5-bit eventFlags field is undefined and must not be fatal.
+    const UNDEFINED_BIT: u8 = 0x10;
+
+    // eventCode = FASTPATH_INPUT_EVENT_SYNC (3) in bits 5..8.
+    let buffer = [(3 << 5) | 0x01 | UNDEFINED_BIT];
+
+    let event: FastPathInputEvent = ironrdp_core::decode(&buffer).expect("undefined flag bits are not fatal");
+
+    let FastPathInputEvent::SyncEvent(flags) = event else {
+        panic!("expected a sync event");
+    };
+    assert!(flags.contains(SynchronizeFlags::SCROLL_LOCK));
+    assert_ne!(flags.bits() & UNDEFINED_BIT, 0);
+    assert_eq!(
+        ironrdp_core::encode_vec(&FastPathInputEvent::SyncEvent(flags)).unwrap(),
+        buffer
+    );
+}


### PR DESCRIPTION
The fast-path input decoder rejects the whole event stream when a keyboard or synchronize event carries an eventFlags bit outside the defined set, and a decode error there is session-fatal mid-use: input events arrive continuously, so a single unknown flag bit from a client drops a live session with work in progress.

The strictness is also internally inconsistent: the slow-path decoders for the very same events already tolerate unknown bits. Slow-path keyboard flags (scan_code.rs), synchronize toggle flags (sync.rs) and unicode keyboard flags (unicode.rs) all decode with from_bits_retain, so the identical keystroke is tolerated on one path and connection-fatal on the other.

The spec's only mandated strictness in this area is about event types, not flags: [MS-RDPBCGR] 3.3.5.8.2 says the server SHOULD drop the connection when an event structure does not match one of the known types. That check is the existing eventCode rejection, which stays exactly as it is. The eventFlags tables (2.2.8.1.2.2.1 and 2.2.8.1.2.2.5) carry no receiver-validation language.

All three flag sites (scancode, sync, unicode) switch to from_bits_retain, the crate-wide policy since #1144. The retained bits fit the 5-bit header field, so re-encoding reproduces the wire value, and the server-side consumers read these flags with contains(), so retained bits flow through harmlessly.

This continues the interop line of #1489, #1458, #1837, #1843, #1844, #1845 and #1846, and it is the last flag-site conversion of that series.

Tests: a keyboard event and a synchronize event, each with an undefined bit in the 5-bit field, decode successfully, retain the bit, and re-encode byte-identically. Both fail with the strict from_bits restored.

`cargo xtask check fmt/lints/tests/typos/locks` all pass.
