### PR TITLE
fix(tls): select native TLS for Windows gateways

### DIFF
--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 anyhow = "1"
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "location", "rdpdr", "rustls", "smartcard", "sound", "webauthn"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "location", "native-tls", "rdpdr", "smartcard", "sound", "webauthn"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-cliprdr-format = { path = "../ironrdp-cliprdr-format", version = "0.2.0" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -38,9 +38,9 @@ clap = { version = "4.6", features = ["derive", "cargo", "env"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", features = ["rustls"] }
 
 [target.'cfg(windows)'.dependencies]
+ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", features = ["native-tls"] }
 # Windows Sandbox control plane: gRPC/HTTP2 over a per-user named pipe.
 bytes = "1"
 h2 = "0.4"
@@ -52,6 +52,9 @@ windows = { version = "0.62", features = [
     "Win32_Security_Authorization",
     "Win32_System_Threading",
 ] }
+
+[target.'cfg(not(windows))'.dependencies]
+ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", features = ["rustls"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -51,6 +51,7 @@ Connect-time `ironrdp_smartcard:i:0` disables it for that session even when the 
 The daemon performs strict certificate and hostname validation by default.
 For an explicitly authorized test endpoint, start the daemon with `--skip-certificate-check`.
 This startup-only flag accepts any certificate and server name, so it is vulnerable to on-path attacks and is unavailable through `connect`.
+On Windows, daemon-backed RDP sessions and `gw-forward` select native TLS for RD Gateway connections; other targets select Rustls.
 
 ## Headless RemoteApp validation
 

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect", "gateway"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect", "gateway"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
@@ -40,8 +40,11 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 # WebAuthn redirection is Windows-only (webauthn.dll / WebAuthN* APIs).
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["webauthn"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["native-tls", "webauthn"] } # public
 ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
+
+[target.'cfg(not(windows))'.dependencies]
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls"] } # public
 
 [lints]
 workspace = true

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -49,7 +49,6 @@ ironrdp-rdpsnd-native = { path = "../ironrdp-rdpsnd-native", features = ["captur
 ironrdp-rpc = { path = "../ironrdp-rpc", features = ["__test"] }
 ironrdp-viewer.path = "../ironrdp-viewer"
 ironrdp-tokio.path = "../ironrdp-tokio"
-ironrdp-tls = { path = "../ironrdp-tls", features = ["rustls"] }
 ironrdp-vmconnect = { path = "../ironrdp-vmconnect", features = ["__test"] }
 rcgen = "0.14"
 semver = "1.0"
@@ -64,6 +63,10 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 ironrdp-rdpdr-native.path = "../ironrdp-rdpdr-native"
+ironrdp-tls = { path = "../ironrdp-tls", features = ["native-tls"] }
+
+[target.'cfg(not(windows))'.dev-dependencies]
+ironrdp-tls = { path = "../ironrdp-tls", features = ["rustls"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -1,5 +1,6 @@
 // FIXME: tests in this module can probably be rewritten to be much shorter using the ironrdp-client crate.
 
+#[cfg(not(windows))]
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 use std::path::Path;
@@ -382,7 +383,13 @@ async fn tls_validation_preserves_the_default_and_strict_is_explicit() {
     let address = listener.local_addr().expect("TLS test listener address");
 
     let server = tokio::spawn(async move {
-        for expected_success in [true, false, true] {
+        // native-tls reports strict validation failure after the server completes its TLS handshake.
+        #[cfg(windows)]
+        let expected_successes = &[true, true];
+        #[cfg(not(windows))]
+        let expected_successes = &[true, false, true];
+
+        for &expected_success in expected_successes {
             let (stream, _) = listener.accept().await.expect("accept TLS test connection");
             let result = acceptor.accept(stream).await;
             assert_eq!(result.is_ok(), expected_success);
@@ -408,22 +415,26 @@ async fn tls_validation_preserves_the_default_and_strict_is_explicit() {
         "strict validation must reject the self-signed test certificate"
     );
 
-    let callback_called = Arc::new(AtomicBool::new(false));
-    let callback_called_for_callback = Arc::clone(&callback_called);
-    let callback: ironrdp_tls::CertificateValidationCallback = Arc::new(move |certificate, server_name, reason| {
-        callback_called_for_callback.store(true, Ordering::Relaxed);
-        !certificate.is_empty() && server_name == "localhost" && !reason.is_empty()
-    });
-    let (tls_stream, _) = ironrdp_tls::upgrade_with_certificate_validation_callback(
-        TcpStream::connect(address).await.expect("connect callback TLS client"),
-        "localhost",
-        callback,
-    )
-    .await
-    .expect("TLS callback accepts the self-signed test certificate");
-    drop(tls_stream);
+    #[cfg(not(windows))]
+    {
+        let callback_called = Arc::new(AtomicBool::new(false));
+        let callback_called_for_callback = Arc::clone(&callback_called);
+        let callback: ironrdp_tls::CertificateValidationCallback = Arc::new(move |certificate, server_name, reason| {
+            callback_called_for_callback.store(true, Ordering::Relaxed);
+            !certificate.is_empty() && server_name == "localhost" && !reason.is_empty()
+        });
+        let (tls_stream, _) = ironrdp_tls::upgrade_with_certificate_validation_callback(
+            TcpStream::connect(address).await.expect("connect callback TLS client"),
+            "localhost",
+            callback,
+        )
+        .await
+        .expect("TLS callback accepts the self-signed test certificate");
+        drop(tls_stream);
 
-    assert!(callback_called.load(Ordering::Relaxed));
+        assert!(callback_called.load(Ordering::Relaxed));
+    }
+
     server.await.expect("TLS test server task");
 }
 

--- a/crates/ironrdp-tls/tests/native_tls.rs
+++ b/crates/ironrdp-tls/tests/native_tls.rs
@@ -1,3 +1,5 @@
+#![allow(unused_crate_dependencies)] // rustls verifier support is shared with RDPEUDP in native-TLS builds.
+
 use ironrdp_tls::{CertificateValidation, upgrade, upgrade_with_certificate_validation};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_native_tls::TlsAcceptor;

--- a/crates/ironrdp-viewer/Cargo.toml
+++ b/crates/ironrdp-viewer/Cargo.toml
@@ -21,7 +21,8 @@ name = "ironrdp-viewer"
 test = false
 
 [features]
-default = ["rustls"]
+# The target-specific dependencies below choose the default TLS backend.
+default = []
 rustls = ["ironrdp/rustls"]
 native-tls = ["ironrdp/native-tls"]
 qoi = ["ironrdp/qoi"]
@@ -61,7 +62,11 @@ raw-window-handle = "0.6"
 url = "2"
 
 [target.'cfg(windows)'.dependencies]
+ironrdp = { path = "../ironrdp", version = "0.17", features = ["native-tls"] }
 ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
+
+[target.'cfg(not(windows))'.dependencies]
+ironrdp = { path = "../ironrdp", version = "0.17", features = ["rustls"] }
 
 [lints]
 workspace = true

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -124,6 +124,29 @@ pub fn dependencies(sh: &Shell) -> anyhow::Result<()> {
         anyhow::bail!("forbidden dependency edge(s) detected, see output above");
     }
 
+    for &(target, expected_backend, unexpected_backend) in &[
+        ("x86_64-pc-windows-msvc", "native-tls", "rustls"),
+        ("x86_64-unknown-linux-gnu", "rustls", "native-tls"),
+    ] {
+        let graph = cmd!(sh, "{CARGO} tree --locked --workspace --target {target} -e features")
+            .read()
+            .with_context(|| format!("resolve ironrdp-agent TLS features for {target}"))?;
+
+        for package in ["ironrdp-client", "ironrdp-mstsgu"] {
+            let expected = format!("{package} feature \"{expected_backend}\"");
+            let unexpected = format!("{package} feature \"{unexpected_backend}\"");
+
+            if !graph.contains(&expected) {
+                anyhow::bail!("{target} must enable {expected_backend} for {package}");
+            }
+            if graph.contains(&unexpected) {
+                anyhow::bail!("{target} must not enable {unexpected_backend} for {package}");
+            }
+        }
+
+        println!("{target} resolves {expected_backend} only for workspace client/gateway TLS (good)");
+    }
+
     println!("All good!");
 
     Ok(())


### PR DESCRIPTION
Use native TLS for Windows RDP sessions and gateway forwards.
Keep Rustls on non-Windows targets and validate exclusive resolution.