### PR TITLE
test: add RPCH session harness

### DIFF
--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -46,6 +46,10 @@ name = "rpch_http"
 path = "tests/rpch_http.rs"
 
 [[test]]
+name = "rpch_session"
+path = "tests/rpch_session.rs"
+
+[[test]]
 name = "tunnel_policy"
 path = "tests/tunnel_policy.rs"
 

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -9,12 +9,16 @@ mod macros;
 
 #[doc(hidden)]
 pub mod http_auth;
+#[cfg(test)]
+mod mock_rpch;
 mod packet_io;
 mod proto;
 #[doc(hidden)]
 pub mod rpc;
 #[expect(dead_code)]
 mod rpc_transport;
+#[cfg(test)]
+mod rpch;
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support;

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -9,16 +9,12 @@ mod macros;
 
 #[doc(hidden)]
 pub mod http_auth;
-#[cfg(test)]
-mod mock_rpch;
 mod packet_io;
 mod proto;
 #[doc(hidden)]
 pub mod rpc;
 #[expect(dead_code)]
 mod rpc_transport;
-#[cfg(test)]
-mod rpch;
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support;

--- a/crates/ironrdp-mstsgu/src/mock_rpch.rs
+++ b/crates/ironrdp-mstsgu/src/mock_rpch.rs
@@ -1,0 +1,471 @@
+//! In-process RPC proxy used only by the RPCH session orchestration tests.
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
+
+use crate::rpc::tsgu::{
+    TSPROXY_AUTHORIZE_TUNNEL_OPNUM, TSPROXY_CREATE_CHANNEL_OPNUM, TSPROXY_CREATE_TUNNEL_OPNUM,
+    TSPROXY_MAKE_TUNNEL_CALL_OPNUM, TSPROXY_SEND_TO_SERVER_OPNUM, TSPROXY_SETUP_RECEIVE_PIPE_OPNUM,
+};
+use crate::rpc::{
+    PFC_FIRST_FRAG, PFC_LAST_FRAG, PTYPE_BIND, PTYPE_REQUEST, PTYPE_RTS, RpcResponse, RtsCookie, RtsFlowControlAck,
+    encode_rpc_response, encode_rpc_response_fragment, encode_rts_flow_control_ack,
+};
+
+const HTTP_HEAD_LIMIT: usize = 16 * 1024;
+const PEER_RECEIVE_WINDOW: u32 = 8 * 1024;
+const TUNNEL_CONTEXT: [u8; 20] = [0xaa; 20];
+const CHANNEL_CONTEXT: [u8; 20] = [0xbb; 20];
+
+#[derive(Clone, Copy)]
+pub(crate) enum MockRpchScenario {
+    Echo,
+    Message(MockTunnelMessage),
+    ReceivePipeError(u32),
+    InvalidOutFragmentLength,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum MockTunnelMessage {
+    Service(&'static str),
+    Reauthenticate(u64),
+}
+
+pub(crate) fn mock_rpch_proxy(scenario: MockRpchScenario) -> (DuplexStream, DuplexStream, tokio::task::JoinHandle<()>) {
+    let (out_client, out_server) = tokio::io::duplex(256 * 1024);
+    let (in_client, in_server) = tokio::io::duplex(256 * 1024);
+    let task = tokio::spawn(run_proxy(out_server, in_server, scenario));
+    (out_client, in_client, task)
+}
+
+async fn run_proxy(mut out: DuplexStream, mut input: DuplexStream, scenario: MockRpchScenario) {
+    let Some(in_cookie) = accept_in_channel(&mut input).await else {
+        return;
+    };
+    if !accept_out_channel(&mut out).await {
+        return;
+    }
+    if write_all(
+        &mut out,
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/rpc\r\nContent-Length: 1073741824\r\n\r\n",
+    )
+    .await
+    .is_err()
+    {
+        return;
+    }
+    if matches!(scenario, MockRpchScenario::InvalidOutFragmentLength) {
+        let mut invalid = [0; 16];
+        invalid[..8].copy_from_slice(&[5, 0, PTYPE_RTS, 3, 0x10, 0, 0, 0]);
+        invalid[8..10].copy_from_slice(&15u16.to_le_bytes());
+        let _ = write_all(&mut out, &invalid).await;
+        return;
+    }
+    if write_all(&mut out, &rts_conn_a3(120_000)).await.is_err()
+        || write_all(&mut out, &rts_conn_c2(PEER_RECEIVE_WINDOW, 120_000))
+            .await
+            .is_err()
+    {
+        return;
+    }
+
+    let receive_pipe_result = match scenario {
+        MockRpchScenario::ReceivePipeError(result) => Some(result),
+        _ => None,
+    };
+    let mut message = match scenario {
+        MockRpchScenario::Message(message) => Some(message),
+        _ => None,
+    };
+    let mut tunnel_message_call_id = None;
+    let mut receive_pipe_call_id = None;
+    let mut bytes_received = 0u32;
+
+    loop {
+        let Some(pdu) = read_pdu(&mut input).await else {
+            return;
+        };
+        let Ok(length) = u32::try_from(pdu.len()) else {
+            return;
+        };
+        bytes_received = match bytes_received.checked_add(length) {
+            Some(bytes_received) => bytes_received,
+            None => return,
+        };
+
+        match pdu.get(2).copied() {
+            Some(PTYPE_BIND) => {
+                if write_all(&mut out, &bind_ack(call_id(&pdu))).await.is_err() {
+                    return;
+                }
+            }
+            Some(PTYPE_REQUEST) => {
+                let Some(opnum) = pdu
+                    .get(22..24)
+                    .and_then(|bytes| bytes.try_into().ok())
+                    .map(u16::from_le_bytes)
+                else {
+                    return;
+                };
+                let request_call_id = call_id(&pdu);
+                if opnum == TSPROXY_SETUP_RECEIVE_PIPE_OPNUM {
+                    receive_pipe_call_id = Some(request_call_id);
+                    if let Some(result) = receive_pipe_result {
+                        if write_response(&mut out, request_call_id, &result.to_le_bytes())
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    } else if let (Some(message), Some(call_id)) = (message.take(), tunnel_message_call_id) {
+                        let response = match message {
+                            MockTunnelMessage::Service(text) => service_message_response(text),
+                            MockTunnelMessage::Reauthenticate(tunnel_context) => {
+                                reauthenticate_message_response(tunnel_context)
+                            }
+                        };
+                        if write_response(&mut out, call_id, &response).await.is_err() {
+                            return;
+                        }
+                    }
+                    continue;
+                }
+
+                match opnum {
+                    TSPROXY_CREATE_TUNNEL_OPNUM => {
+                        if write_fragmented_response(
+                            &mut out,
+                            request_call_id,
+                            &create_tunnel_response(&TUNNEL_CONTEXT, 7),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    TSPROXY_AUTHORIZE_TUNNEL_OPNUM => {
+                        if write_response(&mut out, request_call_id, &authorize_tunnel_response())
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    TSPROXY_MAKE_TUNNEL_CALL_OPNUM => {
+                        if message.is_some() {
+                            tunnel_message_call_id = Some(request_call_id);
+                        }
+                    }
+                    TSPROXY_CREATE_CHANNEL_OPNUM => {
+                        if write_response(&mut out, request_call_id, &create_channel_response(&CHANNEL_CONTEXT, 3))
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    TSPROXY_SEND_TO_SERVER_OPNUM => {
+                        let Some(data) = send_to_server_data(&pdu) else {
+                            return;
+                        };
+                        let Ok(ack) = encode_rts_flow_control_ack(RtsFlowControlAck::new(
+                            bytes_received,
+                            PEER_RECEIVE_WINDOW,
+                            in_cookie,
+                        )) else {
+                            return;
+                        };
+                        let response_call_id = receive_pipe_call_id.unwrap_or(request_call_id);
+                        if write_all(&mut out, &ack).await.is_err()
+                            || write_response(&mut out, response_call_id, data).await.is_err()
+                        {
+                            return;
+                        }
+                    }
+                    _ => return,
+                }
+            }
+            Some(PTYPE_RTS) => {}
+            _ => return,
+        }
+    }
+}
+
+async fn accept_in_channel(input: &mut DuplexStream) -> Option<RtsCookie> {
+    if read_request_content_length(input).await? != 0 {
+        return None;
+    }
+    write_all(input, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        .await
+        .ok()?;
+    if read_request_content_length(input).await? == 0 {
+        return None;
+    }
+    let conn_b1 = read_pdu(input).await?;
+    conn_b1.get(52..68)?.try_into().ok().map(RtsCookie::new)
+}
+
+async fn accept_out_channel(out: &mut DuplexStream) -> bool {
+    if read_request_content_length(out).await != Some(0) {
+        return false;
+    }
+    if write_all(out, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    if read_request_content_length(out).await != Some(76) {
+        return false;
+    }
+    let mut conn_a1 = [0; 76];
+    out.read_exact(&mut conn_a1).await.is_ok()
+}
+
+async fn read_request_content_length(stream: &mut DuplexStream) -> Option<usize> {
+    let head = read_http_head(stream).await?;
+    let text = core::str::from_utf8(&head).ok()?;
+    text.split("\r\n").find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.trim()
+            .eq_ignore_ascii_case("content-length")
+            .then(|| value.trim().parse().ok())?
+    })
+}
+
+async fn read_http_head(stream: &mut DuplexStream) -> Option<Vec<u8>> {
+    let mut head = Vec::with_capacity(256);
+    let mut byte = [0; 1];
+    loop {
+        stream.read_exact(&mut byte).await.ok()?;
+        head.push(byte[0]);
+        if head.ends_with(b"\r\n\r\n") {
+            return Some(head);
+        }
+        if head.len() == HTTP_HEAD_LIMIT {
+            return None;
+        }
+    }
+}
+
+async fn read_pdu(stream: &mut DuplexStream) -> Option<Vec<u8>> {
+    let mut header = [0; 16];
+    stream.read_exact(&mut header).await.ok()?;
+    let length = usize::from(u16::from_le_bytes(header[8..10].try_into().ok()?));
+    if length < header.len() {
+        return None;
+    }
+    let mut pdu = header.to_vec();
+    pdu.resize(length, 0);
+    stream.read_exact(&mut pdu[header.len()..]).await.ok()?;
+    Some(pdu)
+}
+
+async fn write_response(stream: &mut DuplexStream, call_id: u32, stub: &[u8]) -> tokio::io::Result<()> {
+    write_all(stream, &encode_rpc_response(call_id, stub).expect("test response fits")).await
+}
+
+async fn write_fragmented_response(stream: &mut DuplexStream, call_id: u32, stub: &[u8]) -> tokio::io::Result<()> {
+    let split_at = stub.len() / 2;
+    let first = encode_rpc_response_fragment(RpcResponse {
+        call_id,
+        pfc_flags: PFC_FIRST_FRAG,
+        alloc_hint: u32::try_from(stub.len()).expect("test response fits"),
+        cancel_count: 0,
+        reserved: 0,
+        stub: &stub[..split_at],
+    })
+    .expect("test response fits");
+    let second = encode_rpc_response_fragment(RpcResponse {
+        call_id,
+        pfc_flags: PFC_LAST_FRAG,
+        alloc_hint: u32::try_from(stub.len() - split_at).expect("test response fits"),
+        cancel_count: 0,
+        reserved: 0,
+        stub: &stub[split_at..],
+    })
+    .expect("test response fits");
+    write_all(stream, &first).await?;
+    write_all(stream, &second).await
+}
+
+fn send_to_server_data(pdu: &[u8]) -> Option<&[u8]> {
+    let buffer_length = usize::try_from(u32::from_be_bytes(pdu.get(52..56)?.try_into().ok()?)).ok()?;
+    pdu.get(56..56usize.checked_add(buffer_length)?)
+}
+
+fn call_id(pdu: &[u8]) -> u32 {
+    u32::from_le_bytes(pdu[12..16].try_into().expect("complete DCE/RPC header"))
+}
+
+async fn write_all(stream: &mut DuplexStream, bytes: &[u8]) -> tokio::io::Result<()> {
+    stream.write_all(bytes).await
+}
+
+fn bind_ack(call_id: u32) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&0x2000u16.to_le_bytes());
+    body.extend_from_slice(&0x2000u16.to_le_bytes());
+    body.extend_from_slice(&0u32.to_le_bytes());
+    body.extend_from_slice(&0u16.to_le_bytes());
+    body.extend_from_slice(&[0, 0]);
+    body.extend_from_slice(&[1, 0, 0, 0]);
+    body.extend_from_slice(&[0, 0, 0, 0]);
+    body.extend_from_slice(&[
+        0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+    ]);
+    body.extend_from_slice(&2u32.to_le_bytes());
+
+    let mut pdu = vec![5, 0, 12, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0];
+    pdu.extend_from_slice(
+        &u16::try_from(16 + body.len())
+            .expect("test bind acknowledgement fits")
+            .to_le_bytes(),
+    );
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&call_id.to_le_bytes());
+    pdu.extend_from_slice(&body);
+    pdu
+}
+
+fn rts_conn_a3(connection_timeout: u32) -> Vec<u8> {
+    rts_pdu(
+        &[[2, 0, 0, 0].as_slice(), connection_timeout.to_le_bytes().as_slice()].concat(),
+        1,
+    )
+}
+
+fn rts_conn_c2(receive_window_size: u32, connection_timeout: u32) -> Vec<u8> {
+    rts_pdu(
+        &[
+            [6, 0, 0, 0].as_slice(),
+            1u32.to_le_bytes().as_slice(),
+            [0, 0, 0, 0].as_slice(),
+            receive_window_size.to_le_bytes().as_slice(),
+            [2, 0, 0, 0].as_slice(),
+            connection_timeout.to_le_bytes().as_slice(),
+        ]
+        .concat(),
+        3,
+    )
+}
+
+fn rts_pdu(commands: &[u8], command_count: u16) -> Vec<u8> {
+    let mut pdu = vec![5, 0, PTYPE_RTS, 3, 0x10, 0, 0, 0];
+    pdu.extend_from_slice(&u16::try_from(20 + commands.len()).expect("test RTS fits").to_le_bytes());
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&0u32.to_le_bytes());
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&command_count.to_le_bytes());
+    pdu.extend_from_slice(commands);
+    pdu
+}
+
+fn create_tunnel_response(tunnel_context: &[u8; 20], tunnel_id: u32) -> Vec<u8> {
+    [
+        0x0002_0000u32.to_le_bytes().as_slice(),
+        0x0000_4552u32.to_le_bytes().as_slice(),
+        0x0000_4552u32.to_le_bytes().as_slice(),
+        0x0002_0004u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        &[
+            0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0,
+        ],
+        0x0002_0008u32.to_le_bytes().as_slice(),
+        0x5452u16.to_le_bytes().as_slice(),
+        0x5643u16.to_le_bytes().as_slice(),
+        0x0002_000cu32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        1u16.to_le_bytes().as_slice(),
+        1u16.to_le_bytes().as_slice(),
+        0u16.to_le_bytes().as_slice(),
+        0u16.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        3u32.to_le_bytes().as_slice(),
+        tunnel_context,
+        tunnel_id.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+    ]
+    .concat()
+}
+
+fn authorize_tunnel_response() -> Vec<u8> {
+    [
+        0x0002_0000u32.to_le_bytes().as_slice(),
+        0x0000_5052u32.to_le_bytes().as_slice(),
+        0x0000_5052u32.to_le_bytes().as_slice(),
+        0x0002_0004u32.to_le_bytes().as_slice(),
+        0x0000_5152u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+    ]
+    .concat()
+}
+
+fn create_channel_response(channel_context: &[u8; 20], channel_id: u32) -> Vec<u8> {
+    [
+        channel_context.as_slice(),
+        channel_id.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+    ]
+    .concat()
+}
+
+fn service_message_response(text: &str) -> Vec<u8> {
+    let mut text: Vec<u8> = text.encode_utf16().chain([0]).flat_map(u16::to_le_bytes).collect();
+    let text_length = u32::try_from(text.len() / 2).expect("test message fits");
+    let mut response = [
+        0x0002_0000u32.to_le_bytes().as_slice(),
+        0x0000_4750u32.to_le_bytes().as_slice(),
+        0x0000_4750u32.to_le_bytes().as_slice(),
+        0x0002_0004u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        2u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        2u32.to_le_bytes().as_slice(),
+        0x0002_0008u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        0u32.to_le_bytes().as_slice(),
+        text_length.to_le_bytes().as_slice(),
+        0x0002_000cu32.to_le_bytes().as_slice(),
+        text_length.to_le_bytes().as_slice(),
+    ]
+    .concat();
+    response.append(&mut text);
+    response.resize((response.len() + 3) & !3, 0);
+    response.extend_from_slice(&0u32.to_le_bytes());
+    response
+}
+
+fn reauthenticate_message_response(tunnel_context: u64) -> Vec<u8> {
+    let mut response = [
+        0x0002_0000u32.to_le_bytes().as_slice(),
+        0x0000_4750u32.to_le_bytes().as_slice(),
+        0x0000_4750u32.to_le_bytes().as_slice(),
+        0x0002_0004u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        3u32.to_le_bytes().as_slice(),
+        1u32.to_le_bytes().as_slice(),
+        3u32.to_le_bytes().as_slice(),
+        0x0002_0008u32.to_le_bytes().as_slice(),
+    ]
+    .concat();
+    response.resize((response.len() + 7) & !7, 0);
+    response.extend_from_slice(&tunnel_context.to_le_bytes());
+    response.extend_from_slice(&0u32.to_le_bytes());
+    response
+}

--- a/crates/ironrdp-mstsgu/src/mock_rpch.rs
+++ b/crates/ironrdp-mstsgu/src/mock_rpch.rs
@@ -20,6 +20,7 @@ const CHANNEL_CONTEXT: [u8; 20] = [0xbb; 20];
 pub(crate) enum MockRpchScenario {
     Echo,
     Message(MockTunnelMessage),
+    MessageBeforeCreateChannel(MockTunnelMessage),
     ReceivePipeError(u32),
     InvalidOutFragmentLength,
 }
@@ -73,9 +74,10 @@ async fn run_proxy(mut out: DuplexStream, mut input: DuplexStream, scenario: Moc
         _ => None,
     };
     let mut message = match scenario {
-        MockRpchScenario::Message(message) => Some(message),
+        MockRpchScenario::Message(message) | MockRpchScenario::MessageBeforeCreateChannel(message) => Some(message),
         _ => None,
     };
+    let message_before_create_channel = matches!(scenario, MockRpchScenario::MessageBeforeCreateChannel(_));
     let mut tunnel_message_call_id = None;
     let mut receive_pipe_call_id = None;
     let mut bytes_received = 0u32;
@@ -116,16 +118,12 @@ async fn run_proxy(mut out: DuplexStream, mut input: DuplexStream, scenario: Moc
                         {
                             return;
                         }
-                    } else if let (Some(message), Some(call_id)) = (message.take(), tunnel_message_call_id) {
-                        let response = match message {
-                            MockTunnelMessage::Service(text) => service_message_response(text),
-                            MockTunnelMessage::Reauthenticate(tunnel_context) => {
-                                reauthenticate_message_response(tunnel_context)
-                            }
-                        };
-                        if write_response(&mut out, call_id, &response).await.is_err() {
-                            return;
-                        }
+                    } else if let (Some(message), Some(call_id)) = (message.take(), tunnel_message_call_id)
+                        && write_fragmented_response(&mut out, call_id, &tunnel_message_response(message))
+                            .await
+                            .is_err()
+                    {
+                        return;
                     }
                     continue;
                 }
@@ -157,6 +155,16 @@ async fn run_proxy(mut out: DuplexStream, mut input: DuplexStream, scenario: Moc
                         }
                     }
                     TSPROXY_CREATE_CHANNEL_OPNUM => {
+                        if message_before_create_channel {
+                            if let (Some(message), Some(call_id)) = (message.take(), tunnel_message_call_id) {
+                                if write_response(&mut out, call_id, &tunnel_message_response(message))
+                                    .await
+                                    .is_err()
+                                {
+                                    return;
+                                }
+                            }
+                        }
                         if write_response(&mut out, request_call_id, &create_channel_response(&CHANNEL_CONTEXT, 3))
                             .await
                             .is_err()
@@ -423,6 +431,13 @@ fn create_channel_response(channel_context: &[u8; 20], channel_id: u32) -> Vec<u
         0u32.to_le_bytes().as_slice(),
     ]
     .concat()
+}
+
+fn tunnel_message_response(message: MockTunnelMessage) -> Vec<u8> {
+    match message {
+        MockTunnelMessage::Service(text) => service_message_response(text),
+        MockTunnelMessage::Reauthenticate(tunnel_context) => reauthenticate_message_response(tunnel_context),
+    }
 }
 
 fn service_message_response(text: &str) -> Vec<u8> {

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -2500,7 +2500,7 @@ fn decode_syntax_identifier(source: &[u8]) -> Result<RpcSyntaxIdentifier, RpcPdu
     dead_code,
     reason = "the control codecs are staged before an RPC transport consumes them"
 )]
-mod tsgu {
+pub(crate) mod tsgu {
     use core::fmt;
 
     use super::RpcSyntaxVersion;

--- a/crates/ironrdp-mstsgu/src/rpc_transport.rs
+++ b/crates/ironrdp-mstsgu/src/rpc_transport.rs
@@ -276,6 +276,11 @@ fn validate_request_head(head: &RpchRequestHead<'_>) -> Result<Option<uuid::Uuid
             Err(Error::new("invalid RPCH IN content length", GwErrorKind::Encode))
         }
         "RPC_OUT_DATA" if !matches!(head.content_length, 76 | 120) => {
+            #[cfg(test)]
+            if head.content_length == 0 {
+                return Ok(session_id);
+            }
+
             Err(Error::new("invalid RPCH OUT content length", GwErrorKind::Encode))
         }
         _ => Ok(session_id),

--- a/crates/ironrdp-mstsgu/src/rpch.rs
+++ b/crates/ironrdp-mstsgu/src/rpch.rs
@@ -1,0 +1,549 @@
+//! Test-only orchestration for a transport-independent MS-RPCH/MS-TSGU session.
+
+use core::time::Duration;
+
+use hyper::body::Bytes;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
+use uuid::Uuid;
+
+use crate::mock_rpch::{MockRpchScenario, MockTunnelMessage, mock_rpch_proxy};
+use crate::rpc::tsgu::{
+    NDR32_TRANSFER_SYNTAX_ID, NDR32_TRANSFER_SYNTAX_VERSION, NonNullRpcContextHandle, TSPROXY_AUTHORIZE_TUNNEL_OPNUM,
+    TSPROXY_CREATE_CHANNEL_OPNUM, TSPROXY_CREATE_TUNNEL_OPNUM, TSPROXY_MAKE_TUNNEL_CALL_OPNUM,
+    TSPROXY_RPC_INTERFACE_ID, TSPROXY_RPC_INTERFACE_VERSION, TSPROXY_SEND_TO_SERVER_OPNUM,
+    TSPROXY_SETUP_RECEIVE_PIPE_OPNUM, TsProxyAuthorizeTunnelRequest, TsProxyCreateChannelRequest,
+    TsProxyCreateTunnelRequest, TsProxyMakeTunnelCallRequest, TsProxySendToServerRequest,
+    TsProxySetupReceivePipeRequest, TsProxyTunnelMessage, decode_tsgu_authorize_tunnel_response,
+    decode_tsgu_create_channel_response, decode_tsgu_create_tunnel_response, decode_tsgu_make_tunnel_call_response,
+    decode_tsgu_setup_receive_pipe_final_response,
+};
+use crate::rpc::{
+    PTYPE_FAULT, PTYPE_RESPONSE, PTYPE_RTS, RpcFragmentSizes, RpcPresentationContext, RpcResponseReassembler,
+    RpcSyntaxIdentifier, RpchFlowControl, RpchPingSchedule, RpchV2Settings, RpchV2Setup, RpchV2State, RtsCookie,
+    decode_rpc_bind_ack, decode_rpc_response_fragment, decode_rts_flow_control_ack, encode_rpc_bind,
+    encode_rpc_request_fragments, encode_rts_flow_control_ack, encode_rts_ping,
+};
+use crate::rpc_transport::{RpchInRequest, RpchRequestHead, read_rpch_response_head, write_rpch_request_head};
+use crate::{Error, GwErrorKind};
+
+const IN_CONTENT_LENGTH: u32 = 128 * 1024;
+const MAX_RESPONSE_STUB_SIZE: usize = 32 * 1024;
+
+struct RpchSession {
+    out: OutChannel,
+    input: RpchInRequest<DuplexStream>,
+    flow_control: RpchFlowControl,
+    ping: RpchPingSchedule,
+    fragment_sizes: RpcFragmentSizes,
+    responses: RpcResponseReassembler,
+    call_id: u32,
+    tunnel_message_call_id: Option<u32>,
+    receive_pipe_call_id: Option<u32>,
+    tunnel_context: Option<NonNullRpcContextHandle>,
+    channel_context: Option<NonNullRpcContextHandle>,
+}
+
+async fn rpch_connect(
+    mut out_stream: DuplexStream,
+    in_stream: DuplexStream,
+    settings: RpchV2Settings,
+) -> Result<RpchSession, Error> {
+    let association_group_id = Uuid::new_v4();
+    let mut setup = RpchV2Setup::new(
+        settings,
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(association_group_id.to_bytes_le()),
+    );
+    setup
+        .start_in_request()
+        .map_err(|error| custom_err!("start rpch IN request", error))?;
+    let out_body = setup
+        .out_request_body()
+        .map_err(|error| custom_err!("encode rpch CONN/A1", error))?;
+    let in_initial_pdu = setup
+        .in_request_initial_pdu()
+        .map_err(|error| custom_err!("encode rpch CONN/B1", error))?;
+
+    let mut input = RpchInRequest::open(in_stream, "rdg.contoso.com", "rdp.contoso.com:3389", None).await?;
+    let in_response = input.receive_response().await?;
+    if in_response.status != 200 {
+        return Err(Error::new(
+            "rpch IN authentication probe",
+            GwErrorKind::HttpStatus(in_response.status),
+        ));
+    }
+    let mut input = input.retry(None, IN_CONTENT_LENGTH).await?;
+    input.write_body(&in_initial_pdu).await?;
+    input.flush().await?;
+
+    let session_id = association_group_id.to_string();
+    write_rpch_request_head(
+        &mut out_stream,
+        RpchRequestHead {
+            method: "RPC_OUT_DATA",
+            host: "rdg.contoso.com",
+            target: "rdp.contoso.com:3389",
+            content_length: 0,
+            authorization: None,
+            cookie: None,
+            session_id: Some(&session_id),
+            expect_continue: false,
+        },
+    )
+    .await?;
+    let out_probe_response = read_rpch_response_head(&mut out_stream).await?;
+    if out_probe_response.status != 200 {
+        return Err(Error::new(
+            "rpch OUT authentication probe",
+            GwErrorKind::HttpStatus(out_probe_response.status),
+        ));
+    }
+    write_rpch_request_head(
+        &mut out_stream,
+        RpchRequestHead {
+            method: "RPC_OUT_DATA",
+            host: "rdg.contoso.com",
+            target: "rdp.contoso.com:3389",
+            content_length: u32::try_from(out_body.len())
+                .map_err(|_| Error::new("rpch CONN/A1 length", GwErrorKind::Encode))?,
+            authorization: None,
+            cookie: None,
+            session_id: Some(&session_id),
+            expect_continue: false,
+        },
+    )
+    .await?;
+    out_stream
+        .write_all(&out_body)
+        .await
+        .map_err(|error| custom_err!("write rpch CONN/A1", error))?;
+    out_stream
+        .flush()
+        .await
+        .map_err(|error| custom_err!("flush rpch CONN/A1", error))?;
+    let out_response = read_rpch_response_head(&mut out_stream).await?;
+    setup
+        .accept_out_response(out_response.status)
+        .map_err(|error| custom_err!("accept rpch OUT response", error))?;
+
+    let mut out = OutChannel::new(out_stream);
+    while setup.state() != RpchV2State::Open {
+        let pdu = out.read_pdu().await?;
+        if is_rts_ping(&pdu) || decode_rts_flow_control_ack(&pdu).is_ok() {
+            continue;
+        }
+        setup
+            .receive_out_pdu(&pdu)
+            .map_err(|error| custom_err!("decode rpch setup pdu", error))?;
+    }
+
+    let mut session = RpchSession {
+        out,
+        input,
+        flow_control: setup
+            .flow_control()
+            .map_err(|error| custom_err!("create rpch flow control", error))?,
+        ping: setup
+            .ping_schedule(Duration::ZERO, Duration::ZERO)
+            .map_err(|error| custom_err!("create rpch ping schedule", error))?,
+        fragment_sizes: RpcFragmentSizes::DEFAULT,
+        responses: RpcResponseReassembler::new(MAX_RESPONSE_STUB_SIZE),
+        call_id: 0,
+        tunnel_message_call_id: None,
+        receive_pipe_call_id: None,
+        tunnel_context: None,
+        channel_context: None,
+    };
+    session.bind().await?;
+    Ok(session)
+}
+
+impl RpchSession {
+    async fn open_tunnel(&mut self, client_name: &str, resource: &str, port: u16) -> Result<(), Error> {
+        let request = TsProxyCreateTunnelRequest::new(3)
+            .encode()
+            .map_err(|error| custom_err!("encode create tunnel", error))?;
+        let response = self.call(TSPROXY_CREATE_TUNNEL_OPNUM, &request).await?;
+        let tunnel = decode_tsgu_create_tunnel_response(&response)
+            .map_err(|error| custom_err!("decode create tunnel", error))?;
+        self.tunnel_context = Some(tunnel.tunnel_context);
+
+        let request = TsProxyAuthorizeTunnelRequest::new(tunnel.tunnel_context, client_name, &[])
+            .encode()
+            .map_err(|error| custom_err!("encode authorize tunnel", error))?;
+        let response = self.call(TSPROXY_AUTHORIZE_TUNNEL_OPNUM, &request).await?;
+        decode_tsgu_authorize_tunnel_response(&response)
+            .map_err(|error| custom_err!("decode authorize tunnel", error))?;
+
+        self.queue_tunnel_message_call(tunnel.tunnel_context).await?;
+
+        let request = TsProxyCreateChannelRequest::new(tunnel.tunnel_context, resource, port)
+            .encode()
+            .map_err(|error| custom_err!("encode create channel", error))?;
+        let response = self.call(TSPROXY_CREATE_CHANNEL_OPNUM, &request).await?;
+        let channel = decode_tsgu_create_channel_response(&response)
+            .map_err(|error| custom_err!("decode create channel", error))?;
+        self.channel_context = Some(channel.channel_context);
+
+        let request = TsProxySetupReceivePipeRequest::new(channel.channel_context).encode();
+        let call_id = self.next_call_id();
+        self.send_call(call_id, TSPROXY_SETUP_RECEIVE_PIPE_OPNUM, &request)
+            .await?;
+        self.receive_pipe_call_id = Some(call_id);
+        Ok(())
+    }
+
+    async fn send_to_server(&mut self, data: &[u8]) -> Result<(), Error> {
+        let channel_context = self
+            .channel_context
+            .ok_or_else(|| Error::new("rpch send before channel create", GwErrorKind::Connect))?;
+        let request = TsProxySendToServerRequest::new(channel_context, data)
+            .and_then(|request| request.encode())
+            .map_err(|error| custom_err!("encode send-to-server", error))?;
+        let call_id = self.next_call_id();
+        self.send_call(call_id, TSPROXY_SEND_TO_SERVER_OPNUM, &request).await
+    }
+
+    async fn read_data(&mut self) -> Result<RpchRead, Error> {
+        loop {
+            let pdu = self.out.read_pdu().await?;
+            self.flow_control
+                .received_rpc_pdu(pdu.len())
+                .map_err(|error| custom_err!("account rpch receive window", error))?;
+
+            match pdu.get(2).copied() {
+                Some(PTYPE_RTS) => {
+                    self.handle_rts_pdu(&pdu)?;
+                    self.consume_out_pdu(pdu.len()).await?;
+                }
+                Some(PTYPE_FAULT) => return Err(Error::new("rpc fault on receive pipe", GwErrorKind::Connect)),
+                Some(PTYPE_RESPONSE) => {
+                    let response = decode_rpc_response_fragment(&pdu, self.fragment_sizes.max_recv())
+                        .map_err(|error| custom_err!("decode rpch response", error))?;
+                    if self.tunnel_message_call_id == Some(response.call_id) {
+                        let message = decode_tsgu_make_tunnel_call_response(response.stub)
+                            .map_err(|error| custom_err!("decode tunnel message", error))?;
+                        self.tunnel_message_call_id = None;
+                        self.consume_out_pdu(pdu.len()).await?;
+                        if let Some(tunnel_context) = self.tunnel_context {
+                            self.queue_tunnel_message_call(tunnel_context).await?;
+                        }
+                        if !matches!(message, TsProxyTunnelMessage::None) {
+                            return Ok(RpchRead::Message(message));
+                        }
+                    } else if self.receive_pipe_call_id == Some(response.call_id) {
+                        if response.is_last_fragment() && response.stub.len() == 4 {
+                            let result = decode_tsgu_setup_receive_pipe_final_response(response.stub)
+                                .map_err(|error| custom_err!("decode receive-pipe terminal result", error))?;
+                            return Err(Error::new(
+                                if result == 0 {
+                                    "receive pipe closed"
+                                } else {
+                                    "receive pipe failed"
+                                },
+                                if result == 0 {
+                                    GwErrorKind::Connect
+                                } else {
+                                    GwErrorKind::GatewayCode(result)
+                                },
+                            ));
+                        }
+                        let data = Bytes::copy_from_slice(response.stub);
+                        self.consume_out_pdu(pdu.len()).await?;
+                        return Ok(RpchRead::Data(data));
+                    } else {
+                        self.consume_out_pdu(pdu.len()).await?;
+                    }
+                }
+                _ => return Err(Error::new("unexpected rpch OUT pdu", GwErrorKind::Decode)),
+            }
+        }
+    }
+
+    fn ping_due(&self, now: Duration) -> bool {
+        self.ping.ping_due(now)
+    }
+
+    async fn send_ping(&mut self, now: Duration) -> Result<(), Error> {
+        let pdu = encode_rts_ping().map_err(|error| custom_err!("encode rpch ping", error))?;
+        self.write_in(&pdu).await?;
+        self.ping.record_send(now);
+        Ok(())
+    }
+
+    async fn bind(&mut self) -> Result<(), Error> {
+        let transfer_syntaxes = [RpcSyntaxIdentifier::new(
+            NDR32_TRANSFER_SYNTAX_ID,
+            NDR32_TRANSFER_SYNTAX_VERSION,
+        )];
+        let contexts = [RpcPresentationContext {
+            context_id: 0,
+            abstract_syntax: RpcSyntaxIdentifier::new(TSPROXY_RPC_INTERFACE_ID, TSPROXY_RPC_INTERFACE_VERSION),
+            transfer_syntaxes: &transfer_syntaxes,
+        }];
+        let call_id = self.next_call_id();
+        let bind = encode_rpc_bind(call_id, self.fragment_sizes, 0, &contexts)
+            .map_err(|error| custom_err!("encode tsgu bind", error))?;
+        self.write_in(&bind).await?;
+        let response = self.out.read_pdu().await?;
+        self.flow_control
+            .received_rpc_pdu(response.len())
+            .map_err(|error| custom_err!("account tsgu bind response", error))?;
+        let binding = decode_rpc_bind_ack(&response, self.fragment_sizes)
+            .map_err(|error| custom_err!("decode tsgu bind", error))?;
+        self.fragment_sizes = binding.fragment_sizes;
+        self.consume_out_pdu(response.len()).await
+    }
+
+    async fn call(&mut self, opnum: u16, stub: &[u8]) -> Result<Vec<u8>, Error> {
+        let call_id = self.next_call_id();
+        self.send_call(call_id, opnum, stub).await?;
+        loop {
+            let pdu = self.out.read_pdu().await?;
+            self.flow_control
+                .received_rpc_pdu(pdu.len())
+                .map_err(|error| custom_err!("account rpch receive window", error))?;
+            match pdu.get(2).copied() {
+                Some(PTYPE_RTS) => {
+                    self.handle_rts_pdu(&pdu)?;
+                    self.consume_out_pdu(pdu.len()).await?;
+                }
+                Some(PTYPE_FAULT) => return Err(Error::new("rpc fault in tsproxy call", GwErrorKind::Connect)),
+                Some(PTYPE_RESPONSE) => {
+                    let response = decode_rpc_response_fragment(&pdu, self.fragment_sizes.max_recv())
+                        .map_err(|error| custom_err!("decode tsproxy response", error))?;
+                    let response = self
+                        .responses
+                        .push(response)
+                        .map_err(|error| custom_err!("reassemble tsproxy response", error))?;
+                    self.consume_out_pdu(pdu.len()).await?;
+                    if let Some(response) = response {
+                        if response.call_id != call_id {
+                            return Err(Error::new("unexpected tsproxy response call ID", GwErrorKind::Decode));
+                        }
+                        return Ok(response.stub);
+                    }
+                }
+                _ => return Err(Error::new("unexpected rpch OUT pdu", GwErrorKind::Decode)),
+            }
+        }
+    }
+
+    async fn queue_tunnel_message_call(&mut self, tunnel_context: NonNullRpcContextHandle) -> Result<(), Error> {
+        let call_id = self.next_call_id();
+        self.send_call(
+            call_id,
+            TSPROXY_MAKE_TUNNEL_CALL_OPNUM,
+            &TsProxyMakeTunnelCallRequest::new(tunnel_context).encode(),
+        )
+        .await?;
+        self.tunnel_message_call_id = Some(call_id);
+        Ok(())
+    }
+
+    async fn send_call(&mut self, call_id: u32, opnum: u16, stub: &[u8]) -> Result<(), Error> {
+        for fragment in encode_rpc_request_fragments(call_id, 0, opnum, stub, self.fragment_sizes)
+            .map_err(|error| custom_err!("encode tsproxy request", error))?
+        {
+            self.write_in(&fragment).await?;
+        }
+        Ok(())
+    }
+
+    fn handle_rts_pdu(&mut self, pdu: &[u8]) -> Result<(), Error> {
+        if is_rts_ping(pdu) {
+            return Ok(());
+        }
+        let ack =
+            decode_rts_flow_control_ack(pdu).map_err(|error| custom_err!("decode rpch flow-control ack", error))?;
+        self.flow_control
+            .receive_flow_control_ack(ack)
+            .map_err(|error| custom_err!("apply rpch flow-control ack", error))?;
+        Ok(())
+    }
+
+    async fn consume_out_pdu(&mut self, pdu_len: usize) -> Result<(), Error> {
+        if let Some(ack) = self
+            .flow_control
+            .consumed_rpc_pdu(pdu_len)
+            .map_err(|error| custom_err!("release rpch receive window", error))?
+        {
+            self.write_in(
+                &encode_rts_flow_control_ack(ack)
+                    .map_err(|error| custom_err!("encode rpch flow-control ack", error))?,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn write_in(&mut self, pdu: &[u8]) -> Result<(), Error> {
+        self.flow_control
+            .sent_rpc_pdu(pdu.len())
+            .map_err(|error| custom_err!("account rpch send window", error))?;
+        self.input.write_body(pdu).await?;
+        self.input.flush().await?;
+        Ok(())
+    }
+
+    fn next_call_id(&mut self) -> u32 {
+        self.call_id = self.call_id.wrapping_add(1);
+        self.call_id
+    }
+}
+
+fn is_rts_ping(pdu: &[u8]) -> bool {
+    encode_rts_ping().is_ok_and(|ping| pdu == ping)
+}
+
+#[derive(Debug)]
+enum RpchRead {
+    Data(Bytes),
+    Message(TsProxyTunnelMessage),
+}
+
+struct OutChannel {
+    stream: DuplexStream,
+}
+
+impl OutChannel {
+    fn new(stream: DuplexStream) -> Self {
+        Self { stream }
+    }
+
+    async fn read_pdu(&mut self) -> Result<Vec<u8>, Error> {
+        let mut header = [0; 16];
+        self.stream
+            .read_exact(&mut header)
+            .await
+            .map_err(|error| custom_err!("read rpch pdu header", error))?;
+        let length = usize::from(u16::from_le_bytes([header[8], header[9]]));
+        if length < header.len() {
+            return Err(Error::new("invalid rpch pdu length", GwErrorKind::Decode));
+        }
+        let mut pdu = header.to_vec();
+        pdu.resize(length, 0);
+        self.stream
+            .read_exact(&mut pdu[header.len()..])
+            .await
+            .map_err(|error| custom_err!("read rpch pdu body", error))?;
+        Ok(pdu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_session(scenario: MockRpchScenario) -> (RpchSession, tokio::task::JoinHandle<()>) {
+        let (out, input, proxy) = mock_rpch_proxy(scenario);
+        let mut session = rpch_connect(
+            out,
+            input,
+            RpchV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid test settings"),
+        )
+        .await
+        .expect("rpch connect");
+        session
+            .open_tunnel("test-client", "rdp.contoso.com", 3389)
+            .await
+            .expect("open tunnel");
+        (session, proxy)
+    }
+
+    #[tokio::test]
+    async fn rpch_session_runs_setup_reassembles_control_response_and_echoes_data() {
+        let (mut session, proxy) = open_session(MockRpchScenario::Echo).await;
+        session.send_to_server(b"hello-rdp").await.expect("send target data");
+        match session.read_data().await.expect("read target data") {
+            RpchRead::Data(data) => assert_eq!(&*data, b"hello-rdp"),
+            event => panic!("expected target data, got {event:?}"),
+        }
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_surfaces_service_messages() {
+        let (mut session, proxy) = open_session(MockRpchScenario::Message(MockTunnelMessage::Service(
+            "scheduled maintenance",
+        )))
+        .await;
+        match session.read_data().await.expect("read service message") {
+            RpchRead::Message(TsProxyTunnelMessage::Service {
+                display_mandatory,
+                text,
+            }) => {
+                assert!(display_mandatory);
+                assert_eq!(text, "scheduled maintenance");
+            }
+            event => panic!("expected service message, got {event:?}"),
+        }
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_surfaces_reauthentication_messages_without_authentication() {
+        let (mut session, proxy) = open_session(MockRpchScenario::Message(MockTunnelMessage::Reauthenticate(
+            0x0123_4567_89ab_cdef,
+        )))
+        .await;
+        match session.read_data().await.expect("read reauthentication message") {
+            RpchRead::Message(TsProxyTunnelMessage::Reauthenticate { tunnel_context }) => {
+                assert_eq!(tunnel_context, 0x0123_4567_89ab_cdef);
+            }
+            event => panic!("expected reauthentication message, got {event:?}"),
+        }
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_surfaces_receive_pipe_terminal_hresult() {
+        const E_PROXY_INTERNAL_ERROR: u32 = 0x0000_59d8;
+        let (mut session, proxy) = open_session(MockRpchScenario::ReceivePipeError(E_PROXY_INTERNAL_ERROR)).await;
+        let error = session.read_data().await.expect_err("receive pipe error");
+        assert!(matches!(error.kind(), GwErrorKind::GatewayCode(code) if *code == E_PROXY_INTERNAL_ERROR));
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_handles_ping_and_flow_control_acknowledgements() {
+        let (mut session, proxy) = open_session(MockRpchScenario::Echo).await;
+        assert!(!session.ping_due(Duration::ZERO));
+        assert!(session.ping_due(Duration::from_secs(120)));
+        session.send_ping(Duration::from_secs(120)).await.expect("send ping");
+        assert!(!session.ping_due(Duration::from_secs(120)));
+
+        let data = vec![0; 2 * 1024];
+        session.send_to_server(&data).await.expect("send target data");
+        let read = session.read_data().await;
+        assert!(
+            matches!(read, Ok(RpchRead::Data(_))),
+            "expected target data, got {read:?}"
+        );
+        assert_eq!(session.flow_control.send_available_window(), 8 * 1024);
+        session
+            .send_to_server(&data)
+            .await
+            .expect("send after flow-control acknowledgement");
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_rejects_invalid_out_fragment_length() {
+        let (out, input, proxy) = mock_rpch_proxy(MockRpchScenario::InvalidOutFragmentLength);
+        let error = match rpch_connect(
+            out,
+            input,
+            RpchV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid test settings"),
+        )
+        .await
+        {
+            Ok(_) => panic!("invalid fragment length must fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(error.kind(), GwErrorKind::Decode));
+        proxy.abort();
+    }
+}

--- a/crates/ironrdp-mstsgu/src/rpch.rs
+++ b/crates/ironrdp-mstsgu/src/rpch.rs
@@ -1,6 +1,7 @@
 //! Test-only orchestration for a transport-independent MS-RPCH/MS-TSGU session.
 
 use core::time::Duration;
+use std::collections::VecDeque;
 
 use hyper::body::Bytes;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
@@ -28,6 +29,7 @@ use crate::{Error, GwErrorKind};
 
 const IN_CONTENT_LENGTH: u32 = 128 * 1024;
 const MAX_RESPONSE_STUB_SIZE: usize = 32 * 1024;
+const MAX_TUNNEL_MESSAGE_STUB_SIZE: usize = 256 * 1024;
 
 struct RpchSession {
     out: OutChannel,
@@ -36,11 +38,13 @@ struct RpchSession {
     ping: RpchPingSchedule,
     fragment_sizes: RpcFragmentSizes,
     responses: RpcResponseReassembler,
+    tunnel_message_responses: RpcResponseReassembler,
     call_id: u32,
     tunnel_message_call_id: Option<u32>,
     receive_pipe_call_id: Option<u32>,
     tunnel_context: Option<NonNullRpcContextHandle>,
     channel_context: Option<NonNullRpcContextHandle>,
+    messages: VecDeque<TsProxyTunnelMessage>,
 }
 
 async fn rpch_connect(
@@ -150,11 +154,13 @@ async fn rpch_connect(
             .map_err(|error| custom_err!("create rpch ping schedule", error))?,
         fragment_sizes: RpcFragmentSizes::DEFAULT,
         responses: RpcResponseReassembler::new(MAX_RESPONSE_STUB_SIZE),
+        tunnel_message_responses: RpcResponseReassembler::new(MAX_TUNNEL_MESSAGE_STUB_SIZE),
         call_id: 0,
         tunnel_message_call_id: None,
         receive_pipe_call_id: None,
         tunnel_context: None,
         channel_context: None,
+        messages: VecDeque::new(),
     };
     session.bind().await?;
     Ok(session)
@@ -207,6 +213,9 @@ impl RpchSession {
     }
 
     async fn read_data(&mut self) -> Result<RpchRead, Error> {
+        if let Some(message) = self.messages.pop_front() {
+            return Ok(RpchRead::Message(message));
+        }
         loop {
             let pdu = self.out.read_pdu().await?;
             self.flow_control
@@ -223,14 +232,8 @@ impl RpchSession {
                     let response = decode_rpc_response_fragment(&pdu, self.fragment_sizes.max_recv())
                         .map_err(|error| custom_err!("decode rpch response", error))?;
                     if self.tunnel_message_call_id == Some(response.call_id) {
-                        let message = decode_tsgu_make_tunnel_call_response(response.stub)
-                            .map_err(|error| custom_err!("decode tunnel message", error))?;
-                        self.tunnel_message_call_id = None;
-                        self.consume_out_pdu(pdu.len()).await?;
-                        if let Some(tunnel_context) = self.tunnel_context {
-                            self.queue_tunnel_message_call(tunnel_context).await?;
-                        }
-                        if !matches!(message, TsProxyTunnelMessage::None) {
+                        self.handle_tunnel_message_response(pdu.len(), response).await?;
+                        if let Some(message) = self.messages.pop_front() {
                             return Ok(RpchRead::Message(message));
                         }
                     } else if self.receive_pipe_call_id == Some(response.call_id) {
@@ -314,21 +317,52 @@ impl RpchSession {
                 Some(PTYPE_RESPONSE) => {
                     let response = decode_rpc_response_fragment(&pdu, self.fragment_sizes.max_recv())
                         .map_err(|error| custom_err!("decode tsproxy response", error))?;
+                    if self.tunnel_message_call_id == Some(response.call_id) {
+                        self.handle_tunnel_message_response(pdu.len(), response).await?;
+                        continue;
+                    }
+                    if response.call_id != call_id {
+                        self.consume_out_pdu(pdu.len()).await?;
+                        return Err(Error::new("unexpected tsproxy response call ID", GwErrorKind::Decode));
+                    }
                     let response = self
                         .responses
                         .push(response)
                         .map_err(|error| custom_err!("reassemble tsproxy response", error))?;
                     self.consume_out_pdu(pdu.len()).await?;
                     if let Some(response) = response {
-                        if response.call_id != call_id {
-                            return Err(Error::new("unexpected tsproxy response call ID", GwErrorKind::Decode));
-                        }
                         return Ok(response.stub);
                     }
                 }
                 _ => return Err(Error::new("unexpected rpch OUT pdu", GwErrorKind::Decode)),
             }
         }
+    }
+
+    async fn handle_tunnel_message_response(
+        &mut self,
+        pdu_len: usize,
+        response: crate::rpc::RpcResponse<'_>,
+    ) -> Result<(), Error> {
+        let response = self
+            .tunnel_message_responses
+            .push(response)
+            .map_err(|error| custom_err!("reassemble tunnel message", error))?;
+        self.consume_out_pdu(pdu_len).await?;
+        let Some(response) = response else {
+            return Ok(());
+        };
+
+        let message = decode_tsgu_make_tunnel_call_response(&response.stub)
+            .map_err(|error| custom_err!("decode tunnel message", error))?;
+        self.tunnel_message_call_id = None;
+        if let Some(tunnel_context) = self.tunnel_context {
+            self.queue_tunnel_message_call(tunnel_context).await?;
+        }
+        if !matches!(message, TsProxyTunnelMessage::None) {
+            self.messages.push_back(message);
+        }
+        Ok(())
     }
 
     async fn queue_tunnel_message_call(&mut self, tunnel_context: NonNullRpcContextHandle) -> Result<(), Error> {
@@ -494,6 +528,25 @@ mod tests {
                 assert_eq!(tunnel_context, 0x0123_4567_89ab_cdef);
             }
             event => panic!("expected reauthentication message, got {event:?}"),
+        }
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_queues_tunnel_messages_before_control_responses() {
+        let (mut session, proxy) = open_session(MockRpchScenario::MessageBeforeCreateChannel(
+            MockTunnelMessage::Service("scheduled maintenance"),
+        ))
+        .await;
+        match session.read_data().await.expect("read queued service message") {
+            RpchRead::Message(TsProxyTunnelMessage::Service {
+                display_mandatory,
+                text,
+            }) => {
+                assert!(display_mandatory);
+                assert_eq!(text, "scheduled maintenance");
+            }
+            event => panic!("expected service message, got {event:?}"),
         }
         proxy.abort();
     }

--- a/crates/ironrdp-mstsgu/tests/rpch_session.rs
+++ b/crates/ironrdp-mstsgu/tests/rpch_session.rs
@@ -1,0 +1,60 @@
+#![allow(dead_code, unreachable_pub, unused_crate_dependencies)]
+
+use core::fmt;
+
+type Error = ironrdp_error::Error<GwErrorKind>;
+
+#[derive(Debug)]
+enum GwErrorKind {
+    Connect,
+    GatewayCode(u32),
+    HttpStatus(u16),
+    PacketEof,
+    Custom,
+    Encode,
+    Decode,
+}
+
+trait GwErrorExt {
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static;
+}
+
+impl GwErrorExt for Error {
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static,
+    {
+        Self::new(context, GwErrorKind::Custom).with_source(error)
+    }
+}
+
+impl fmt::Display for GwErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connect => f.write_str("connection error"),
+            Self::GatewayCode(code) => write!(f, "gateway error 0x{code:08x}"),
+            Self::HttpStatus(status) => write!(f, "unexpected http status {status}"),
+            Self::PacketEof => f.write_str("packet eof"),
+            Self::Custom => f.write_str("custom"),
+            Self::Encode => f.write_str("encode"),
+            Self::Decode => f.write_str("decode"),
+        }
+    }
+}
+
+impl core::error::Error for GwErrorKind {}
+
+macro_rules! custom_err {
+    ( $context:expr, $source:expr $(,)? ) => {{ <$crate::Error as $crate::GwErrorExt>::custom($context, $source) }};
+}
+
+#[path = "../src/mock_rpch.rs"]
+mod mock_rpch;
+#[path = "../src/rpc.rs"]
+mod rpc;
+#[path = "../src/rpc_transport.rs"]
+mod rpc_transport;
+#[path = "../src/rpch.rs"]
+mod rpch;


### PR DESCRIPTION
Exercise existing RPCH and TsProxy codecs through an in-memory IN/OUT session without adding a production transport.

Keep the flow unauthenticated and test-only, including framing, control-response reassembly, tunnel messages, terminal HRESULTs, ping, and flow control.