### PR TITLE
feat(driver): delegate multitransport setup

### DIFF
--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -85,7 +85,7 @@ where
 ///
 /// Returning `MultitransportResult::Failure` reports setup failure and continues connection finalization over TCP.
 /// Returning an error aborts connection finalization after attempting to report `E_ABORT` to the server.
-/// The handler owns any successfully established transport and must retain it for use after this function returns.
+/// Store each successfully established transport in application state that outlives this call.
 #[expect(
     clippy::too_many_arguments,
     reason = "extends the established connection-finalization API with a multitransport callback"

--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -6,7 +6,7 @@ use ironrdp_connector::{
     general_err,
 };
 use ironrdp_core::WriteBuf;
-use tracing::{debug, info, instrument, trace};
+use tracing::{debug, info, instrument, trace, warn};
 
 use crate::framed::{Framed, FramedRead, FramedWrite};
 use crate::{NetworkClient, single_sequence_step};
@@ -50,8 +50,8 @@ pub fn mark_as_upgraded(_: ShouldUpgrade, connector: &mut ClientConnector) -> Up
 
 #[instrument(skip_all)]
 pub async fn connect_finalize<S, N>(
-    _: Upgraded,
-    mut connector: ClientConnector,
+    upgraded: Upgraded,
+    connector: ClientConnector,
     framed: &mut Framed<S>,
     network_client: &mut N,
     server_name: ServerName,
@@ -61,6 +61,48 @@ pub async fn connect_finalize<S, N>(
 where
     S: FramedRead + FramedWrite,
     N: NetworkClient,
+{
+    connect_finalize_with_multitransport(
+        upgraded,
+        connector,
+        framed,
+        network_client,
+        server_name,
+        server_public_key,
+        kerberos_config,
+        |_, _| async {
+            Ok(ironrdp_connector::MultitransportResult::Failure(
+                ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu::E_ABORT,
+            ))
+        },
+    )
+    .await
+}
+
+/// Completes the connection sequence with application-owned multitransport setup.
+///
+/// The handler receives one Initiate Multitransport Request at a time and returns
+/// the result to send over the main RDP connection.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "extends the established connection-finalization API with a multitransport callback"
+)]
+#[instrument(skip_all)]
+pub async fn connect_finalize_with_multitransport<S, N, H, F>(
+    _: Upgraded,
+    mut connector: ClientConnector,
+    framed: &mut Framed<S>,
+    network_client: &mut N,
+    server_name: ServerName,
+    server_public_key: Vec<u8>,
+    kerberos_config: Option<KerberosConfig>,
+    mut multitransport_handler: H,
+) -> ConnectorResult<ConnectionResult>
+where
+    S: FramedRead + FramedWrite,
+    N: NetworkClient,
+    H: FnMut(ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu, bool) -> F,
+    F: Future<Output = ConnectorResult<ironrdp_connector::MultitransportResult>>,
 {
     let mut buf = WriteBuf::new();
 
@@ -79,20 +121,32 @@ where
 
     let result = loop {
         if connector.should_perform_multitransport() {
-            // Auto-skip multitransport bootstrapping: this driver does not own
-            // UDP transport setup, so it declines on the application's behalf
-            // and the connection continues TCP-only. Applications that want to
-            // participate in multitransport must drive the connector directly
-            // using `ClientConnector::complete_multitransport()` instead of
-            // calling `connect_finalize`.
-            buf.clear();
-            let written = connector.skip_multitransport(&mut buf)?;
-            if written.size().is_some() {
-                framed
-                    .write_all(buf.filled())
+            let request = connector
+                .multitransport_request()
+                .cloned()
+                .ok_or_else(|| general_err!("multitransport is pending without a request"))?;
+            let soft_sync = connector
+                .multitransport_soft_sync_negotiated()
+                .ok_or_else(|| general_err!("multitransport is pending without Soft-Sync state"))?;
+            let result = match multitransport_handler(request, soft_sync).await {
+                Ok(result) => result,
+                Err(error) => {
+                    if let Err(response_error) = complete_multitransport(
+                        &mut connector,
+                        framed,
+                        ironrdp_connector::MultitransportResult::Failure(
+                            ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu::E_ABORT,
+                        ),
+                    )
                     .await
-                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
-            }
+                    {
+                        warn!(%response_error, "Failed to send multitransport abort response");
+                    }
+
+                    return Err(error);
+                }
+            };
+            complete_multitransport(&mut connector, framed, result).await?;
             continue;
         }
 
@@ -106,6 +160,27 @@ where
     info!("Connected with success");
 
     Ok(result)
+}
+
+/// Sends the response for the connector's pending multitransport request.
+#[instrument(skip_all)]
+pub async fn complete_multitransport<S>(
+    connector: &mut ClientConnector,
+    framed: &mut Framed<S>,
+    result: ironrdp_connector::MultitransportResult,
+) -> ConnectorResult<()>
+where
+    S: FramedRead + FramedWrite,
+{
+    let mut buf = WriteBuf::new();
+    let written = connector.complete_multitransport(result, &mut buf)?;
+    if written.size().is_some() {
+        framed
+            .write_all(buf.filled())
+            .await
+            .map_err(|e| ironrdp_connector::custom_err!("write multitransport response", e))?;
+    }
+    Ok(())
 }
 
 async fn resolve_generator(

--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -62,7 +62,7 @@ where
     S: FramedRead + FramedWrite,
     N: NetworkClient,
 {
-    connect_finalize_with_multitransport(
+    Box::pin(connect_finalize_with_multitransport(
         upgraded,
         connector,
         framed,
@@ -75,20 +75,23 @@ where
                 ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu::E_ABORT,
             ))
         },
-    )
+    ))
     .await
 }
 
 /// Completes the connection sequence with application-owned multitransport setup.
 ///
-/// The handler receives one Initiate Multitransport Request at a time and returns
-/// the result to send over the main RDP connection.
+/// The handler receives one Initiate Multitransport Request at a time and returns the result to send over the main RDP connection.
+///
+/// Returning `MultitransportResult::Failure` reports setup failure and continues connection finalization over TCP.
+/// Returning an error aborts connection finalization after attempting to report `E_ABORT` to the server.
+/// The handler owns any successfully established transport and must retain it for use after this function returns.
 #[expect(
     clippy::too_many_arguments,
     reason = "extends the established connection-finalization API with a multitransport callback"
 )]
 #[instrument(skip_all)]
-pub async fn connect_finalize_with_multitransport<S, N, H, F>(
+pub async fn connect_finalize_with_multitransport<S, N, H>(
     _: Upgraded,
     mut connector: ClientConnector,
     framed: &mut Framed<S>,
@@ -101,8 +104,10 @@ pub async fn connect_finalize_with_multitransport<S, N, H, F>(
 where
     S: FramedRead + FramedWrite,
     N: NetworkClient,
-    H: FnMut(ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu, bool) -> F,
-    F: Future<Output = ConnectorResult<ironrdp_connector::MultitransportResult>>,
+    H: AsyncFnMut(
+        ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu,
+        bool,
+    ) -> ConnectorResult<ironrdp_connector::MultitransportResult>,
 {
     let mut buf = WriteBuf::new();
 

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -112,6 +112,30 @@ pub enum MultitransportResult {
     Failure(u32),
 }
 
+impl MultitransportResult {
+    const fn response_required(&self, soft_sync: bool) -> bool {
+        soft_sync || matches!(self, Self::Failure(_))
+    }
+
+    /// Builds the required response PDU for this outcome and request.
+    ///
+    /// Successful initiation without Soft-Sync does not require a response.
+    pub fn response_pdu(
+        &self,
+        request_id: u32,
+        soft_sync: bool,
+    ) -> Option<rdp::multitransport::MultitransportResponsePdu> {
+        if !self.response_required(soft_sync) {
+            return None;
+        }
+
+        Some(match self {
+            Self::Success => rdp::multitransport::MultitransportResponsePdu::success(request_id),
+            Self::Failure(hr) => multitransport_response(request_id, *hr),
+        })
+    }
+}
+
 /// Why a runtime-defined static virtual channel could not be registered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DynamicStaticChannelAttachError {
@@ -162,6 +186,13 @@ pub struct ConnectionResult {
     pub activation_factory: ConnectionActivationFactory,
     /// The bulk compression type that was negotiated, if any.
     pub compression_type: Option<rdp::client_info::CompressionType>,
+}
+
+impl ConnectionResult {
+    /// Whether both peers advertised Soft-Sync support for multitransport.
+    pub fn multitransport_soft_sync(&self) -> bool {
+        self.activation_factory.multitransport_soft_sync()
+    }
 }
 
 #[derive(Default, Debug)]
@@ -646,6 +677,16 @@ impl ClientConnector {
         }
     }
 
+    /// Returns whether both peers advertised Soft-Sync for the pending request.
+    ///
+    /// `None` means no multitransport request is pending.
+    pub fn multitransport_soft_sync_negotiated(&self) -> Option<bool> {
+        match &self.state {
+            ClientConnectorState::MultitransportPending { soft_sync, .. } => Some(*soft_sync),
+            _ => None,
+        }
+    }
+
     /// Report the outcome of the multitransport request currently surfaced by
     /// [`multitransport_request()`](Self::multitransport_request).
     ///
@@ -710,27 +751,26 @@ impl ClientConnector {
             return Ok(None);
         };
 
-        match (*soft_sync, result) {
+        if !result.response_required(*soft_sync) {
+            return Ok(None);
+        }
+
+        match *soft_sync {
             // Soft-Sync obliges a response either way, and presupposes the
             // message channel. Falling back to the I/O channel would put the
             // response somewhere the server is not reading, so its absence is an
             // error rather than a reason to improvise.
-            (true, _) => message_channel_id
+            true => message_channel_id
                 .ok_or_else(|| {
                     general_err!("Soft-Sync was negotiated but the server never offered an MCS message channel")
                 })
                 .map(Some),
-            // `S_OK` is the one value 2.2.15.2 forbids here, so success and only
-            // success is withheld. The outcome is still consumed and the
-            // handshake proceeds, so a caller that established the transport does
-            // not have to know which mode is in play.
-            (false, MultitransportResult::Success) => Ok(None),
             // A failure is still reported: 3.2.5.15.1 asks for it whenever the
             // client could not initiate the channel, with no Soft-Sync condition.
             // It is a SHOULD, so a missing message channel means staying silent
             // rather than failing a connection over an optional report. In
             // practice one exists, since 2.2.15.1 puts the request on it.
-            (false, MultitransportResult::Failure(_)) => Ok(*message_channel_id),
+            false => Ok(*message_channel_id),
         }
     }
 
@@ -756,7 +796,7 @@ impl ClientConnector {
             message_channel_id,
             request,
             requests_seen,
-            ..
+            soft_sync,
         } = &self.state
         else {
             return Err(reason_err!(
@@ -764,8 +804,13 @@ impl ClientConnector {
                 "{caller} called outside MultitransportPending state",
             ));
         };
-        let (io_channel_id, user_channel_id, message_channel_id, requests_seen) =
-            (*io_channel_id, *user_channel_id, *message_channel_id, *requests_seen);
+        let (io_channel_id, user_channel_id, message_channel_id, requests_seen, soft_sync) = (
+            *io_channel_id,
+            *user_channel_id,
+            *message_channel_id,
+            *requests_seen,
+            *soft_sync,
+        );
         let request_id = request.request_id;
 
         let response_channel = self.multitransport_response_channel(&result)?;
@@ -775,10 +820,9 @@ impl ClientConnector {
         // Soft-Sync. Either way the outcome is consumed and the handshake
         // proceeds.
         let total_written = if let Some(response_channel) = response_channel {
-            let response = match result {
-                MultitransportResult::Success => rdp::multitransport::MultitransportResponsePdu::success(request_id),
-                MultitransportResult::Failure(hr) => multitransport_response(request_id, hr),
-            };
+            let response = result
+                .response_pdu(request_id, soft_sync)
+                .ok_or_else(|| general_err!("multitransport response channel selected without a required response"))?;
 
             encode_send_data_request(user_channel_id, response_channel, &response, output)?
         } else {
@@ -1556,7 +1600,8 @@ impl Sequence for ClientConnector {
                                         self.config.clone(),
                                         connection_activation.io_channel_id(),
                                         connection_activation.user_channel_id(),
-                                    ),
+                                    )
+                                    .with_multitransport_soft_sync(self.soft_sync_negotiated()),
                                     compression_type: self.config.compression_type,
                                 },
                             }

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -82,6 +82,7 @@ pub struct ConnectionActivationFactory {
     config: Config,
     io_channel_id: u16,
     user_channel_id: u16,
+    multitransport_soft_sync: bool,
 }
 
 impl ConnectionActivationFactory {
@@ -90,7 +91,17 @@ impl ConnectionActivationFactory {
             config,
             io_channel_id,
             user_channel_id,
+            multitransport_soft_sync: false,
         }
+    }
+
+    pub(crate) fn with_multitransport_soft_sync(mut self, multitransport_soft_sync: bool) -> Self {
+        self.multitransport_soft_sync = multitransport_soft_sync;
+        self
+    }
+
+    pub(crate) fn multitransport_soft_sync(&self) -> bool {
+        self.multitransport_soft_sync
     }
 
     pub fn io_channel_id(&self) -> u16 {

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -582,7 +582,9 @@ fn skip_multitransport_declines_with_e_abort_under_soft_sync() {
     // MS-RDPBCGR 3.2.5.15.1 requires a response to every request once Soft-Sync
     // is mutually negotiated, whatever the outcome. Both the async and blocking
     // drivers skip automatically, so a silent skip leaves a compliant server
-    // waiting on a response it is entitled to.
+    // The blocking driver and the async compatibility entry point skip
+    // automatically, so a silent skip leaves a compliant server waiting on a
+    // response it is entitled to.
     let mut connector = multitransport_pending_connector(true, multitransport_request(1, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -505,6 +505,10 @@ fn should_perform_multitransport_reflects_pending_state() {
     let connector = multitransport_pending_connector(true, multitransport_request(1, RequestedProtocol::UdpFecR));
     assert!(connector.should_perform_multitransport());
     assert_eq!(connector.multitransport_request().unwrap().request_id, 1);
+    assert_eq!(connector.multitransport_soft_sync_negotiated(), Some(true));
+
+    let connector = multitransport_pending_connector(false, multitransport_request(2, RequestedProtocol::UdpFecR));
+    assert_eq!(connector.multitransport_soft_sync_negotiated(), Some(false));
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/async_framed.rs
+++ b/crates/ironrdp-testsuite-extra/tests/async_framed.rs
@@ -10,6 +10,7 @@
 //! sets `[lib] test = false`, so an inline `#[cfg(test)]` module would compile
 //! and never run.
 
+use core::future::{Ready, ready};
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 use core::time::Duration;
@@ -17,7 +18,16 @@ use std::collections::VecDeque;
 use std::io;
 
 use ironrdp_async::bytes::BytesMut;
-use ironrdp_async::{Framed, FramedRead, StreamWrapper};
+use ironrdp_async::{Framed, FramedRead, FramedWrite, NetworkClient, StreamWrapper};
+use ironrdp_core::decode;
+use ironrdp_pdu::mcs::McsMessage;
+use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
+use ironrdp_pdu::x224::X224;
+
+const USER_CHANNEL_ID: u16 = 1002;
+const IO_CHANNEL_ID: u16 = 1003;
+const MESSAGE_CHANNEL_ID: u16 = 1004;
 
 /// Drives a future to completion on the current thread. The mock below never
 /// yields, so polling in a loop is enough and saves pulling in a runtime.
@@ -35,6 +45,7 @@ fn block_on<F: Future>(fut: F) -> F::Output {
 /// decide exactly which PDUs share a socket read and which get their own.
 struct ChunkedStream {
     chunks: VecDeque<Vec<u8>>,
+    writes: Vec<u8>,
     /// Delay applied before each read completes, so consecutive reads land on
     /// distinguishable instants rather than relying on clock resolution.
     delay: Duration,
@@ -44,6 +55,7 @@ impl ChunkedStream {
     fn new(chunks: impl IntoIterator<Item = Vec<u8>>) -> Self {
         Self {
             chunks: chunks.into_iter().collect(),
+            writes: Vec::new(),
             delay: Duration::from_millis(5),
         }
     }
@@ -86,6 +98,29 @@ impl FramedRead for ChunkedStream {
                 None => Ok(0),
             }
         })
+    }
+}
+
+impl FramedWrite for ChunkedStream {
+    type WriteAllFut<'write>
+        = Ready<io::Result<()>>
+    where
+        Self: 'write;
+
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Self::WriteAllFut<'a> {
+        self.writes.extend_from_slice(buf);
+        ready(Ok(()))
+    }
+}
+
+struct UnusedNetworkClient;
+
+impl NetworkClient for UnusedNetworkClient {
+    async fn send(
+        &mut self,
+        _: &ironrdp::connector::sspi::generator::NetworkRequest,
+    ) -> ironrdp::connector::ConnectorResult<Vec<u8>> {
+        Err(ironrdp::connector::general_err!("unexpected network request"))
     }
 }
 
@@ -163,4 +198,66 @@ fn leftover_carried_into_a_new_framed_has_no_arrival_time() {
         framed.last_read_at().is_none(),
         "a frame served from leftover was never read by this Framed, so it has no arrival time"
     );
+}
+
+#[test]
+fn multitransport_handler_error_reports_abort_and_preserves_the_error() {
+    let mut connector = ironrdp::connector::ClientConnector::new(
+        crate::e2e::default_client_config(),
+        "127.0.0.1:3389".parse().unwrap(),
+    );
+    connector.state = ironrdp::connector::ClientConnectorState::EnhancedSecurityUpgrade {
+        selected_protocol: ironrdp_pdu::nego::SecurityProtocol::empty(),
+    };
+    let should_upgrade = ironrdp_async::skip_connect_begin(&mut connector);
+    let upgraded = ironrdp_async::mark_as_upgraded(should_upgrade, &mut connector);
+    connector.state = ironrdp::connector::ClientConnectorState::MultitransportPending {
+        io_channel_id: IO_CHANNEL_ID,
+        user_channel_id: USER_CHANNEL_ID,
+        message_channel_id: Some(MESSAGE_CHANNEL_ID),
+        request: MultitransportRequestPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+            },
+            request_id: 42,
+            requested_protocol: RequestedProtocol::UdpFecR,
+            security_cookie: [0; 16],
+        },
+        requests_seen: 1,
+        soft_sync: true,
+    };
+    let mut framed = Framed::<ChunkedStream>::new(ChunkedStream::new([]));
+    let mut network_client = UnusedNetworkClient;
+
+    let error = block_on(ironrdp_async::connect_finalize_with_multitransport(
+        upgraded,
+        connector,
+        &mut framed,
+        &mut network_client,
+        ironrdp::connector::ServerName::new("server"),
+        Vec::new(),
+        None,
+        |request: MultitransportRequestPdu, soft_sync: bool| async move {
+            assert_eq!(request.request_id, 42);
+            assert!(soft_sync);
+            Err(ironrdp::connector::general_err!("test multitransport setup failure"))
+        },
+    ))
+    .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "[test multitransport setup failure] general error",
+        "the handler error must win over abort reporting"
+    );
+
+    let (stream, _) = framed.get_inner();
+    let X224(McsMessage::SendDataRequest(request)) = decode(stream.writes.as_slice()).unwrap() else {
+        panic!("the handler error must send an abort response");
+    };
+    assert_eq!(request.channel_id, MESSAGE_CHANNEL_ID);
+
+    let response: MultitransportResponsePdu = decode(&request.user_data).unwrap();
+    assert_eq!(response.request_id, 42);
+    assert_eq!(response.hr_response, MultitransportResponsePdu::E_ABORT);
 }

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -1026,7 +1026,7 @@ async fn client_server_with_connector<F, Fut, C>(
         .await;
 }
 
-fn default_client_config() -> connector::Config {
+pub(super) fn default_client_config() -> connector::Config {
     connector::Config {
         desktop_size: DesktopSize {
             width: DESKTOP_WIDTH,


### PR DESCRIPTION
Let applications establish negotiated multitransport channels while the
async connector retains protocol sequencing and response ownership.

Expose Soft-Sync state to the setup callback, centralize response
construction, and report callback failures with E_ABORT when possible.
The existing finalizer still declines multitransport and uses TCP.