### PR TITLE
feat(agent): add clipboard-get and clipboard-set operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2851,6 +2851,7 @@ dependencies = [
  "anyhow",
  "ironrdp-cfg",
  "ironrdp-client",
+ "ironrdp-cliprdr",
  "ironrdp-connector",
  "ironrdp-input",
  "ironrdp-pdu",

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -445,6 +445,10 @@ async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Reques
                 "RAIL audit endpoints are unavailable through ActiveX",
             )
         }
+        Request::ClipboardGet | Request::ClipboardSet { .. } => Response::typed_error(
+            AgentErrorCategory::Unavailable,
+            "clipboard access is unavailable through ActiveX",
+        ),
         Request::Resize { width, height } => {
             queue_command(shared, dispatcher, |response| Command::Resize {
                 width,

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -108,6 +108,13 @@ enum Command {
         #[arg(long, value_parser = parse_unicode_text)]
         text: String,
     },
+    /// Print the last text received from the remote clipboard, if any.
+    ClipboardGet,
+    /// Set the local clipboard text and advertise it to the remote (`CF_UNICODETEXT` only).
+    ClipboardSet {
+        #[arg(long)]
+        text: String,
+    },
     /// Send one MS-RDPEI touch contact sample (legal flag sets only).
     Touch {
         #[arg(long, default_value_t = 0)]
@@ -922,6 +929,8 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::KeyScancode { scancode, pressed } => Request::KeyScancode { scancode, pressed },
         Command::KeyUnicode { character, pressed } => Request::KeyUnicode { ch: character, pressed },
         Command::TypeUnicode { text } => Request::UnicodeText { text },
+        Command::ClipboardGet => Request::ClipboardGet,
+        Command::ClipboardSet { text } => Request::ClipboardSet { text },
         Command::Touch {
             contact_id,
             x,
@@ -2092,6 +2101,10 @@ fn print_payload(payload: Payload) {
         Payload::RailLaunch(launch) => {
             println!("queued RAIL launch {}: {}", launch.launch_id, launch.executable);
         }
+        Payload::ClipboardText(text) => match text {
+            Some(text) => println!("{text}"),
+            None => println!("(empty)"),
+        },
     }
 }
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -152,6 +152,16 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `dismiss-hovering [--contact-id N]`            Dismiss a hovering touch contact.
 - `resize --width W --height H`                  Resize the remote desktop.
 
+## Clipboard
+
+Plain Unicode text only (`CF_UNICODETEXT`); no files, no HTML, no images.
+
+- `clipboard-get`               Print the last text received from the remote clipboard, or
+                                 `(empty)` if none has arrived yet. Requires an active session.
+- `clipboard-set --text TEXT`   Set the local clipboard text and advertise it to the remote.
+                                 Works before a session connects too: the text is remembered and
+                                 advertised as soon as the clipboard channel initializes.
+
 ## NOW remote execution (requires an active, connected RDP session)
 
 The daemon allocates one private `Devolutions::Now::Agent` DVC endpoint for each RDP session. It

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,8 +13,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect", "gateway"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect", "gateway", "clipboard"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
+ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" } # public

--- a/crates/ironrdp-daemon/src/clipboard.rs
+++ b/crates/ironrdp-daemon/src/clipboard.rs
@@ -1,0 +1,151 @@
+//! In-memory `CLIPRDR` backend for the headless agent daemon.
+//!
+//! Bridges `CLIPRDR` to the `clipboard-get` / `clipboard-set` IPC operations. Plain Unicode text
+//! only (`CF_UNICODETEXT`); no file transfer, no HTML or image formats. A headless daemon has no
+//! host clipboard of its own, so this backend holds the last text pushed by `clipboard-set` as
+//! its local clipboard content and the last text received from the remote as its remote
+//! clipboard content, both behind a lock shared with the daemon's IPC handlers.
+
+use std::sync::{Arc, Mutex};
+
+use ironrdp_client::rdp::RdpInputSender;
+use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy, CliprdrBackend, CliprdrBackendFactory};
+use ironrdp_cliprdr::pdu::{
+    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
+    FormatDataRequest, FormatDataResponse, LockDataId,
+};
+use ironrdp_pdu::ironrdp_core::{IntoOwned as _, impl_as_any};
+use tracing::debug;
+
+/// Clipboard text shared between the `CLIPRDR` backend and the daemon's IPC handlers.
+#[derive(Debug, Default)]
+pub(crate) struct ClipboardState {
+    /// Set by `clipboard-set`; advertised to the remote as `CF_UNICODETEXT` and served on request.
+    pub(crate) local: Option<String>,
+    /// Set from the remote's last `CF_UNICODETEXT` response; read by `clipboard-get`.
+    pub(crate) remote: Option<String>,
+}
+
+/// Forwards `CLIPRDR` events into the session's bounded input channel.
+///
+/// Mirrors `ironrdp_client`'s own internal proxy, which is crate-private and so not reusable
+/// from here.
+#[derive(Clone, Debug)]
+struct AgentClipboardMessageProxy(RdpInputSender);
+
+impl ClipboardMessageProxy for AgentClipboardMessageProxy {
+    fn send_clipboard_message(&self, message: ClipboardMessage) {
+        if self.0.send_clipboard(message).is_err() {
+            debug!("Dropped clipboard message: session input channel is closed");
+        }
+    }
+}
+
+/// Builds a fresh [`AgentCliprdrBackend`] for each `CLIPRDR` channel initialization.
+///
+/// A new backend is required per connection (the channel is re-initialized on every reconnect),
+/// but the clipboard text itself is daemon-lifetime state that survives a reconnect.
+pub(crate) struct AgentCliprdrBackendFactory {
+    state: Arc<Mutex<ClipboardState>>,
+    input_tx: RdpInputSender,
+}
+
+impl AgentCliprdrBackendFactory {
+    pub(crate) fn new(state: Arc<Mutex<ClipboardState>>, input_tx: RdpInputSender) -> Self {
+        Self { state, input_tx }
+    }
+}
+
+impl CliprdrBackendFactory for AgentCliprdrBackendFactory {
+    fn build_cliprdr_backend(&self) -> Box<dyn CliprdrBackend> {
+        Box::new(AgentCliprdrBackend {
+            state: Arc::clone(&self.state),
+            proxy: AgentClipboardMessageProxy(self.input_tx.clone()),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct AgentCliprdrBackend {
+    state: Arc<Mutex<ClipboardState>>,
+    proxy: AgentClipboardMessageProxy,
+}
+
+impl_as_any!(AgentCliprdrBackend);
+
+impl CliprdrBackend for AgentCliprdrBackend {
+    fn temporary_directory(&self) -> &str {
+        ".cliprdr"
+    }
+
+    fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
+        // No file transfer support: no STREAM_FILECLIP_ENABLED, no CAN_LOCK_CLIPDATA.
+        ClipboardGeneralCapabilityFlags::empty()
+    }
+
+    fn on_ready(&mut self) {}
+
+    fn on_request_format_list(&mut self) {
+        let formats = if self.state.lock().expect("clipboard state poisoned").local.is_some() {
+            vec![ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]
+        } else {
+            Vec::new()
+        };
+        self.proxy
+            .send_clipboard_message(ClipboardMessage::SendInitiateCopy(formats));
+    }
+
+    fn on_process_negotiated_capabilities(&mut self, capabilities: ClipboardGeneralCapabilityFlags) {
+        debug!(?capabilities, "CLIPRDR capabilities negotiated");
+    }
+
+    fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
+        // The remote clipboard changed: whatever text was cached no longer reflects it.
+        self.state.lock().expect("clipboard state poisoned").remote = None;
+        if available_formats
+            .iter()
+            .any(|format| format.id() == ClipboardFormatId::CF_UNICODETEXT)
+        {
+            self.proxy
+                .send_clipboard_message(ClipboardMessage::SendInitiatePaste(ClipboardFormatId::CF_UNICODETEXT));
+        }
+    }
+
+    fn on_format_data_request(&mut self, request: FormatDataRequest) {
+        let response = if request.format == ClipboardFormatId::CF_UNICODETEXT {
+            match self.state.lock().expect("clipboard state poisoned").local.clone() {
+                Some(text) => FormatDataResponse::new_unicode_string(&text).into_owned(),
+                None => FormatDataResponse::new_error(),
+            }
+        } else {
+            FormatDataResponse::new_error()
+        };
+        self.proxy
+            .send_clipboard_message(ClipboardMessage::SendFormatData(response));
+    }
+
+    fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
+        if response.is_error() {
+            return;
+        }
+        if let Ok(text) = response.to_unicode_string() {
+            self.state.lock().expect("clipboard state poisoned").remote = Some(text);
+        }
+    }
+
+    fn on_file_contents_request(&mut self, request: FileContentsRequest) {
+        debug!(?request, "File contents request ignored: no file transfer support");
+    }
+
+    fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>) {
+        debug!(?response, "File contents response ignored: no file transfer support");
+    }
+
+    fn on_lock(&mut self, data_id: LockDataId) {
+        debug!(?data_id, "Clipboard lock ignored: no file transfer support");
+    }
+
+    fn on_unlock(&mut self, data_id: LockDataId) {
+        debug!(?data_id, "Clipboard unlock ignored: no file transfer support");
+    }
+}

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -20,6 +20,8 @@ use ironrdp_client::rdp::{
     RailExecuteFailureReason as ClientRailExecuteFailureReason, RdpClient, RdpInputEvent, RdpInputSender,
     RdpOutputEvent,
 };
+use ironrdp_cliprdr::backend::ClipboardMessage;
+use ironrdp_cliprdr::pdu::{ClipboardFormat, ClipboardFormatId};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
@@ -254,6 +256,10 @@ pub struct Daemon {
     smartcard_default: bool,
     #[cfg(windows)]
     rdpdr_backend_factory: Option<WindowsRdpdrBackendFactory>,
+    /// Clipboard text, daemon-lifetime so it survives a reconnect. Read and written by
+    /// `Request::ClipboardGet` / `Request::ClipboardSet`; read and written by the `CLIPRDR`
+    /// backend built fresh for each session (see `crate::clipboard`).
+    clipboard: Arc<Mutex<crate::clipboard::ClipboardState>>,
     /// Notifies an optional GUI frontend whenever retained live state changes.
     notification: Option<mpsc::Sender<()>>,
     shutdown: tokio::sync::watch::Sender<()>,
@@ -506,6 +512,7 @@ impl Daemon {
             smartcard_default,
             #[cfg(windows)]
             rdpdr_backend_factory,
+            clipboard: Arc::new(Mutex::new(crate::clipboard::ClipboardState::default())),
             notification: None,
             shutdown,
         })
@@ -570,6 +577,8 @@ impl Daemon {
                 DaemonResponse::Single(self.query_logs(substring.as_deref(), last))
             }
             Request::Screenshot => DaemonResponse::Single(self.screenshot()),
+            Request::ClipboardGet => DaemonResponse::Single(self.clipboard_get()),
+            Request::ClipboardSet { text } => DaemonResponse::Single(self.clipboard_set(text)),
             Request::MouseMove { x, y } => {
                 DaemonResponse::Single(self.input(Operation::MouseMove(MousePosition { x, y })))
             }
@@ -777,6 +786,10 @@ impl Daemon {
             None => client,
         };
         let input_tx = client.input_sender();
+        let client = client.with_cliprdr_backend_factory(Box::new(crate::clipboard::AgentCliprdrBackendFactory::new(
+            Arc::clone(&self.clipboard),
+            input_tx.clone(),
+        )));
 
         let rail_notify = Arc::new(tokio::sync::Notify::new());
         let live = Arc::new(Mutex::new(Live {
@@ -1088,6 +1101,36 @@ impl Daemon {
                 format!("failed to encode screenshot: {error:#}"),
             ),
         }
+    }
+
+    /// Returns the last text received from the remote clipboard, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_get(&self) -> Response {
+        let text = self.clipboard.lock().expect("clipboard state poisoned").remote.clone();
+        Response::Ok(Payload::ClipboardText(text))
+    }
+
+    /// Sets the local clipboard text and, if a session is connected, advertises it to the remote.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_set(&self, text: String) -> Response {
+        self.clipboard.lock().expect("clipboard state poisoned").local = Some(text);
+        // Only a connected session can advertise the change immediately; an unconnected daemon
+        // still remembers it and advertises it once `CLIPRDR` initializes on the next connect (see
+        // `AgentCliprdrBackend::on_request_format_list`).
+        if let Some(session) = self.state.lock().expect("daemon state poisoned").as_ref() {
+            let _ = session
+                .input_tx
+                .send_clipboard(ClipboardMessage::SendInitiateCopy(vec![ClipboardFormat::new(
+                    ClipboardFormatId::CF_UNICODETEXT,
+                )]));
+        }
+        Response::ok()
     }
 
     /// Requests that the active RDP session resize.

--- a/crates/ironrdp-daemon/src/lib.rs
+++ b/crates/ironrdp-daemon/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Reusable support for persistent RDP sessions hosted over local RPC.
 
+mod clipboard;
 pub mod daemon;
 pub mod logbuf;
 pub mod now;

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -438,8 +438,10 @@ pub enum Request {
     },
     /// Queue a validated RAIL Execute request.
     RailExecute(RailExecuteRequest),
-    // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
-    // set it, so an LLM can copy/paste to and from the session.
+    /// Return the last text received from the remote clipboard, if any.
+    ClipboardGet,
+    /// Set the local clipboard text and advertise it to the remote (`CF_UNICODETEXT` only).
+    ClipboardSet { text: String },
 }
 
 // Manual `Debug` so the `Connect` payload's property *values* (which may include a password before
@@ -555,6 +557,9 @@ impl fmt::Debug for Request {
                 .field("timeout_ms", timeout_ms)
                 .finish(),
             Self::RailExecute(request) => f.debug_tuple("RailExecute").field(request).finish(),
+            Self::ClipboardGet => f.write_str("ClipboardGet"),
+            // Never print clipboard contents.
+            Self::ClipboardSet { text } => f.debug_struct("ClipboardSet").field("text_len", &text.len()).finish(),
         }
     }
 }
@@ -631,6 +636,8 @@ pub enum Payload {
     RailEvents(RailEventDump),
     /// A locally assigned RAIL launch identifier.
     RailLaunch(RailLaunchInfo),
+    /// The remote clipboard's last `CF_UNICODETEXT` text, or `None` if unavailable.
+    ClipboardText(Option<String>),
 }
 
 impl fmt::Debug for Payload {
@@ -655,6 +662,11 @@ impl fmt::Debug for Payload {
             Self::RailStatus(status) => f.debug_tuple("RailStatus").field(status).finish(),
             Self::RailEvents(events) => f.debug_tuple("RailEvents").field(events).finish(),
             Self::RailLaunch(launch) => f.debug_tuple("RailLaunch").field(launch).finish(),
+            // Never print clipboard contents.
+            Self::ClipboardText(text) => f
+                .debug_tuple("ClipboardText")
+                .field(&text.as_ref().map(String::len))
+                .finish(),
         }
     }
 }
@@ -1973,6 +1985,10 @@ impl Encode for Payload {
                 dst.write_u8(12);
                 launch.encode(dst)?;
             }
+            Self::ClipboardText(text) => {
+                dst.write_u8(13);
+                write_opt_string(dst, text.as_deref())?;
+            }
         }
         Ok(())
     }
@@ -1997,6 +2013,7 @@ impl Encode for Payload {
                 Self::RailStatus(status) => status.size(),
                 Self::RailEvents(events) => events.size(),
                 Self::RailLaunch(launch) => launch.size(),
+                Self::ClipboardText(text) => opt_string_size(text.as_deref()),
             }
     }
 }
@@ -2040,6 +2057,7 @@ impl Decode<'_> for Payload {
             10 => Ok(Self::RailStatus(RailStatusInfo::decode(src)?)),
             11 => Ok(Self::RailEvents(RailEventDump::decode(src)?)),
             12 => Ok(Self::RailLaunch(RailLaunchInfo::decode(src)?)),
+            13 => Ok(Self::ClipboardText(read_opt_string(src)?)),
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag", in: src)),
         }
     }
@@ -2255,6 +2273,12 @@ impl Encode for Request {
                 dst.write_u8(28);
                 dst.write_u8(*contact_id);
             }
+            // Tags 29-30: free after DismissHoveringTouchContact (28).
+            Self::ClipboardGet => dst.write_u8(29),
+            Self::ClipboardSet { text } => {
+                dst.write_u8(30);
+                write_string(dst, text)?;
+            }
         }
         Ok(())
     }
@@ -2275,7 +2299,8 @@ impl Encode for Request {
                 | Self::NowCapabilities
                 | Self::NowList
                 | Self::NowDiagnostics
-                | Self::RailStatus => 0,
+                | Self::RailStatus
+                | Self::ClipboardGet => 0,
                 Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
                 Self::QueryLogs { substring, last } => {
                     opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
@@ -2314,6 +2339,7 @@ impl Encode for Request {
                             .sum::<usize>()
                 }
                 Self::DismissHoveringTouchContact { .. } => 1 /* contact_id */,
+                Self::ClipboardSet { text } => string_size(text),
             }
     }
 }
@@ -2504,6 +2530,10 @@ impl Decode<'_> for Request {
                     timeout_ms: src.read_u32(),
                 })
             }
+            29 => Ok(Self::ClipboardGet),
+            30 => Ok(Self::ClipboardSet {
+                text: read_string(src)?,
+            }),
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag", in: src)),
         }
     }


### PR DESCRIPTION
Resolves the TODO in ironrdp-rpc's Request enum for clipboard support: read the remote clipboard text and set it, so an LLM (or any daemon caller) can copy and paste to and from the session.

The backend is deliberately text only. A headless daemon has no host clipboard, so it holds the last text pushed by clipboard-set as its local content and the last text received from the remote as its remote content, both behind a lock shared with the daemon's IPC handlers. client_capabilities() advertises no file transfer flags, matching that scope.

The clipboard Cargo feature on ironrdp-daemon's ironrdp-client dependency was previously off, so the CLIPRDR channel fell back to StubClipboard on non-Windows and did nothing with remote clipboard content. This enables it and supplies a real backend factory.

Verified live against a running RDP server: clipboard-set text landed in the server's own OS clipboard, and a clipboard change made directly on the server side was correctly fetched by clipboard-get.