### PR TITLE
feat: add camera channel protocol

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,11 @@ EGFX dynamic channel implemented as described in MS-RDPEGFX.
 
 AUDIO_INPUT dynamic channel for client microphone capture implemented as described in MS-RDPEAI.
 
+#### [`crates/ironrdp-rdpecam`](./crates/ironrdp-rdpecam)
+
+Video capture dynamic channel client and backend boundary implemented as described in MS-RDPECAM.
+The crate performs no camera I/O and advertises only devices explicitly supplied by its caller.
+
 #### [`crates/ironrdp-rdpel`](./crates/ironrdp-rdpel)
 
 Location dynamic channel client and PDU codecs implemented as described in MS-RDPEL.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpecam"
+version = "0.0.0"
+dependencies = [
+ "ironrdp-core 0.2.1",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-rdpei"
 version = "0.1.0"
 dependencies = [
@@ -3384,6 +3395,7 @@ dependencies = [
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
  "ironrdp-rdpeai",
+ "ironrdp-rdpecam",
  "ironrdp-rdpei",
  "ironrdp-rdpel",
  "ironrdp-rdpemt",

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -586,8 +586,9 @@ Each configuration exposes the friendly name, symbolic link, instance ID, parent
 Rescans preserve configuration identity and retain disconnected or explicitly added symbolic links with `DeviceExists` set to false.
 
 The collection is currently an enabling compatibility layer, not a camera redirection backend.
-IronRDP does not register the MS-RDPECAM enumeration channel or start camera capture, and attempts to enable `Redirected`, `RedirectByDefault`, or an enabled `AddConfig` entry return `E_NOTIMPL`.
-Encoding policy can be read or changed before connecting, but has no effect until an MS-RDPECAM capture backend is available.
+The `ironrdp-rdpecam` crate provides bounded version 1 codecs and DVC state machines, but the ActiveX worker neither registers the RDPECAM channels nor provides a native camera capture backend.
+Attempts to enable `Redirected`, `RedirectByDefault`, or an enabled `AddConfig` entry therefore return `E_NOTIMPL`, and no camera is advertised or activated.
+Encoding policy can be read or changed before connecting, but has no effect until the native backend is available.
 All collection mutations are rejected after connection settings are sealed.
 
 ### DVC COM plugins

--- a/crates/ironrdp-rdpecam/Cargo.toml
+++ b/crates/ironrdp-rdpecam/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ironrdp-rdpecam"
+version = "0.0.0"
+publish = false
+readme = "README.md"
+description = "Video capture dynamic channel client as described in MS-RDPECAM"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+ironrdp-core = { version = "0.2.1", path = "../ironrdp-core", features = ["alloc"] } # public
+ironrdp-dvc = { version = "0.8.0", path = "../ironrdp-dvc" } # public
+ironrdp-pdu = { version = "0.9.0", path = "../ironrdp-pdu", features = ["alloc"] } # public
+ironrdp-svc = { version = "0.8.0", path = "../ironrdp-svc" } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpecam/README.md
+++ b/crates/ironrdp-rdpecam/README.md
@@ -1,0 +1,18 @@
+# IronRDP RDPECAM
+
+`ironrdp-rdpecam` implements the client-side protocol layer for the Remote Desktop Protocol: Video Capture Virtual Channel Extension ([MS-RDPECAM]).
+It provides version 1 PDU codecs, the camera enumeration channel, per-device dynamic-channel listeners, and a backend contract for activation, media negotiation, and sample delivery.
+
+The crate performs no device I/O.
+An embedder explicitly supplies the redirected devices and implements `CameraBackend`; no camera is advertised or activated implicitly.
+The codecs and state machines validate media descriptions, stream indexes, state transitions, channel IDs, and sample sizes.
+
+The PDU codecs represent all version 1 media identifiers.
+The backend state machine accepts only uncompressed YUY2, NV12, I420, RGB24, and RGB32 samples with their exact packed frame size.
+H.264 and MJPEG capture are not enabled because this layer does not validate complete compressed pictures.
+Media-type lists are bounded to 4,096 entries and sample messages to 64 MiB.
+Version 2 camera-control properties and a native capture backend are not implemented.
+
+The IronRDP ActiveX control neither registers the RDPECAM channels nor provides a native capture backend, so camera redirection remains disabled there.
+
+[MS-RDPECAM]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/

--- a/crates/ironrdp-rdpecam/src/client.rs
+++ b/crates/ironrdp-rdpecam/src/client.rs
@@ -1,0 +1,664 @@
+//! Client state machines for the MS-RDPECAM dynamic virtual channels.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use ironrdp_core::{AsAny, decode, impl_as_any, invalid_field_err};
+use ironrdp_dvc::{DvcChannelListener, DvcClientProcessor, DvcMessage, DvcProcessor, encode_dvc_messages};
+use ironrdp_pdu::{PduResult, encode_err, pdu_other_err};
+use ironrdp_svc::{ChannelFlags, SvcMessage};
+use tracing::{debug, warn};
+
+use crate::ENUMERATION_CHANNEL_NAME;
+use crate::pdu::{
+    DeviceDescriptor, DevicePdu, EnumerationPdu, ErrorCode, MediaType, ProtocolVersion, StartStreamInfo,
+    StreamDescription,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnumerationState {
+    WaitingVersion,
+    Ready,
+}
+
+/// Shared redirection gate for an enumeration channel and its selected devices.
+#[derive(Debug, Clone)]
+pub struct CameraRedirectionSession {
+    identity: Arc<()>,
+}
+
+impl CameraRedirectionSession {
+    pub fn new() -> Self {
+        Self { identity: Arc::new(()) }
+    }
+
+    /// Creates one camera selection that may be advertised by this session.
+    pub fn select_device(&self, descriptor: DeviceDescriptor) -> ironrdp_core::EncodeResult<RedirectedDevice> {
+        descriptor.validate()?;
+        Ok(RedirectedDevice {
+            descriptor,
+            session_identity: Arc::clone(&self.identity),
+            advertised: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn enumeration_client(&self, devices: Vec<RedirectedDevice>) -> ironrdp_core::EncodeResult<EnumerationClient> {
+        EnumerationClient::new(Arc::clone(&self.identity), devices)
+    }
+}
+
+impl Default for CameraRedirectionSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One explicitly selected device shared by enumeration and device-channel processors.
+#[derive(Debug, Clone)]
+pub struct RedirectedDevice {
+    descriptor: DeviceDescriptor,
+    session_identity: Arc<()>,
+    advertised: Arc<AtomicBool>,
+}
+
+impl RedirectedDevice {
+    pub fn descriptor(&self) -> &DeviceDescriptor {
+        &self.descriptor
+    }
+
+    pub fn listener<B>(&self, backend: B) -> DeviceChannelListener<B>
+    where
+        B: CameraBackend,
+    {
+        DeviceChannelListener {
+            channel_name: self.descriptor.channel_name.clone(),
+            advertised: Arc::clone(&self.advertised),
+            backend: Some(backend),
+        }
+    }
+}
+
+/// Client processor for the RDPECAM device-enumeration channel.
+///
+/// Only descriptors explicitly supplied by the caller are advertised.
+#[derive(Debug)]
+pub struct EnumerationClient {
+    session_identity: Arc<()>,
+    devices: Vec<RedirectedDevice>,
+    state: EnumerationState,
+    channel_id: Option<u32>,
+}
+
+impl EnumerationClient {
+    fn new(session_identity: Arc<()>, devices: Vec<RedirectedDevice>) -> ironrdp_core::EncodeResult<Self> {
+        if devices.len() > usize::from(u8::MAX) {
+            return Err(invalid_field_err!(
+                "devices",
+                "at most 255 redirected cameras may be configured"
+            ));
+        }
+        for (index, device) in devices.iter().enumerate() {
+            device.descriptor.validate()?;
+            if !Arc::ptr_eq(&session_identity, &device.session_identity) {
+                return Err(invalid_field_err!(
+                    "devices",
+                    "redirected cameras must belong to the same redirection session"
+                ));
+            }
+            if devices[..index]
+                .iter()
+                .any(|existing| existing.descriptor.channel_name == device.descriptor.channel_name)
+            {
+                return Err(invalid_field_err!(
+                    "VirtualChannelName",
+                    "redirected camera channel names must be unique"
+                ));
+            }
+        }
+        Ok(Self {
+            session_identity,
+            devices,
+            state: EnumerationState::WaitingVersion,
+            channel_id: None,
+        })
+    }
+
+    pub fn ready(&self) -> bool {
+        self.state == EnumerationState::Ready
+    }
+
+    /// Advertises a newly selected camera after version negotiation.
+    pub fn add_device(&mut self, device: RedirectedDevice) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = self.active_channel_id("EnumerationClient::add_device")?;
+        if !Arc::ptr_eq(&self.session_identity, &device.session_identity) {
+            return Err(pdu_other_err!(
+                "EnumerationClient::add_device",
+                "redirected camera belongs to another redirection session"
+            ));
+        }
+        if self.devices.len() == usize::from(u8::MAX) {
+            return Err(pdu_other_err!(
+                "EnumerationClient::add_device",
+                "redirected camera limit has been reached"
+            ));
+        }
+        if self
+            .devices
+            .iter()
+            .any(|existing| existing.descriptor.channel_name == device.descriptor.channel_name)
+        {
+            return Err(pdu_other_err!(
+                "EnumerationClient::add_device",
+                "redirected camera channel name is already advertised"
+            ));
+        }
+        let pdu = EnumerationPdu::DeviceAdded {
+            version: ProtocolVersion::V1,
+            device: device.descriptor.clone(),
+        };
+        let messages = encode_dvc_messages(channel_id, vec![Box::new(pdu)], ChannelFlags::empty())
+            .map_err(|error| encode_err!(error))?;
+        device.advertised.store(true, Ordering::Release);
+        self.devices.push(device);
+        Ok(messages)
+    }
+
+    /// Removes an advertised camera without activating or touching another device.
+    pub fn remove_device(&mut self, channel_name: &str) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = self.active_channel_id("EnumerationClient::remove_device")?;
+        let index = self
+            .devices
+            .iter()
+            .position(|device| device.descriptor.channel_name == channel_name)
+            .ok_or_else(|| {
+                pdu_other_err!(
+                    "EnumerationClient::remove_device",
+                    "redirected camera channel name is not advertised"
+                )
+            })?;
+        self.devices[index].advertised.store(false, Ordering::Release);
+        let pdu = EnumerationPdu::DeviceRemoved {
+            version: ProtocolVersion::V1,
+            channel_name: String::from(channel_name),
+        };
+        let messages = encode_dvc_messages(channel_id, vec![Box::new(pdu)], ChannelFlags::empty())
+            .map_err(|error| encode_err!(error))?;
+        self.devices.remove(index);
+        Ok(messages)
+    }
+
+    fn active_channel_id(&self, context: &'static str) -> PduResult<u32> {
+        if !self.ready() {
+            return Err(pdu_other_err!(context, "camera enumeration channel is not ready"));
+        }
+        self.channel_id
+            .ok_or_else(|| pdu_other_err!(context, "camera enumeration channel has no assigned channel id"))
+    }
+}
+
+impl_as_any!(EnumerationClient);
+
+impl DvcProcessor for EnumerationClient {
+    fn channel_name(&self) -> &str {
+        ENUMERATION_CHANNEL_NAME
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        for device in &self.devices {
+            device.advertised.store(false, Ordering::Release);
+        }
+        self.channel_id = Some(channel_id);
+        self.state = EnumerationState::WaitingVersion;
+        debug!(channel_id, "Camera enumeration channel started");
+        Ok(vec![Box::new(EnumerationPdu::SelectVersionRequest(
+            ProtocolVersion::V1,
+        ))])
+    }
+
+    fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        if self.channel_id != Some(channel_id) {
+            return Err(pdu_other_err!(
+                "EnumerationClient::process",
+                "camera enumeration channel id does not match the active channel"
+            ));
+        }
+        let pdu: EnumerationPdu = match decode(payload) {
+            Ok(pdu) => pdu,
+            Err(error) => {
+                warn!(%error, "Ignoring malformed camera enumeration PDU");
+                return Ok(Vec::new());
+            }
+        };
+        match pdu {
+            EnumerationPdu::SelectVersionResponse(ProtocolVersion::V1)
+                if self.state == EnumerationState::WaitingVersion =>
+            {
+                for device in &self.devices {
+                    device.advertised.store(true, Ordering::Release);
+                }
+                self.state = EnumerationState::Ready;
+                debug!("Camera protocol version negotiated");
+                Ok(self
+                    .devices
+                    .iter()
+                    .map(|device| -> DvcMessage {
+                        Box::new(EnumerationPdu::DeviceAdded {
+                            version: ProtocolVersion::V1,
+                            device: device.descriptor.clone(),
+                        })
+                    })
+                    .collect())
+            }
+            _ => {
+                warn!("Ignoring out-of-sequence camera enumeration PDU");
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        if self.channel_id == Some(channel_id) {
+            for device in &self.devices {
+                device.advertised.store(false, Ordering::Release);
+            }
+            self.channel_id = None;
+            self.state = EnumerationState::WaitingVersion;
+            debug!("Camera enumeration channel closed");
+        }
+    }
+}
+
+impl DvcClientProcessor for EnumerationClient {}
+
+/// Backend boundary for one explicitly selected camera.
+///
+/// Implementations manage platform capture resources.
+/// Methods are synchronous and must not block indefinitely on device I/O.
+pub trait CameraBackend: Send + 'static {
+    fn activate(&mut self) -> Result<(), ErrorCode>;
+    fn deactivate(&mut self) -> Result<(), ErrorCode>;
+    fn streams(&mut self) -> Result<Vec<StreamDescription>, ErrorCode>;
+    fn media_types(&mut self, stream_index: u8) -> Result<Vec<MediaType>, ErrorCode>;
+    fn current_media_type(&mut self, stream_index: u8) -> Result<MediaType, ErrorCode>;
+    /// Atomically replaces the active stream selection.
+    ///
+    /// On error, any prior stream selection must remain active.
+    fn start_streams(&mut self, streams: &[StartStreamInfo]) -> Result<(), ErrorCode>;
+    fn stop_streams(&mut self) -> Result<(), ErrorCode>;
+    fn sample(&mut self, stream_index: u8) -> Result<Vec<u8>, ErrorCode>;
+}
+
+/// Per-device RDPECAM client processor.
+pub struct DeviceClient<B> {
+    channel_name: String,
+    advertised: Arc<AtomicBool>,
+    backend: B,
+    channel_id: Option<u32>,
+    activation_depth: u32,
+    streaming: Option<Vec<StartStreamInfo>>,
+}
+
+impl<B> DeviceClient<B>
+where
+    B: CameraBackend,
+{
+    pub fn new(device: &RedirectedDevice, backend: B) -> Self {
+        Self {
+            channel_name: device.descriptor.channel_name.clone(),
+            advertised: Arc::clone(&device.advertised),
+            backend,
+            channel_id: None,
+            activation_depth: 0,
+            streaming: None,
+        }
+    }
+
+    pub fn is_activated(&self) -> bool {
+        self.activation_depth != 0
+    }
+
+    pub fn is_streaming(&self) -> bool {
+        self.streaming.is_some()
+    }
+
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    pub fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
+    }
+
+    fn respond(&mut self, request: DevicePdu) -> DevicePdu {
+        if matches!(request, DevicePdu::ActivateDeviceRequest) {
+            return self.activate();
+        }
+        if self.activation_depth == 0 {
+            if let DevicePdu::SampleRequest(stream_index) = request {
+                return DevicePdu::SampleErrorResponse {
+                    stream_index,
+                    error: ErrorCode::NotInitialized,
+                };
+            }
+            return DevicePdu::ErrorResponse(ErrorCode::NotInitialized);
+        }
+        match request {
+            DevicePdu::DeactivateDeviceRequest => self.deactivate(),
+            DevicePdu::StreamListRequest => match self.backend.streams() {
+                Ok(streams) if valid_stream_count(streams.len()) && streams.iter().all(stream_is_valid) => {
+                    DevicePdu::StreamListResponse(streams)
+                }
+                Ok(_) => DevicePdu::ErrorResponse(ErrorCode::Unexpected),
+                Err(error) => DevicePdu::ErrorResponse(error),
+            },
+            DevicePdu::MediaTypeListRequest(stream_index) => match self.validate_stream_index(stream_index) {
+                Err(error) => DevicePdu::ErrorResponse(error),
+                Ok(()) => match self.backend.media_types(stream_index) {
+                    Ok(media_types)
+                        if valid_media_type_count(media_types.len()) && media_types.iter().all(media_type_is_valid) =>
+                    {
+                        DevicePdu::MediaTypeListResponse(media_types)
+                    }
+                    Ok(_) => DevicePdu::ErrorResponse(ErrorCode::InvalidMediaType),
+                    Err(error) => DevicePdu::ErrorResponse(error),
+                },
+            },
+            DevicePdu::CurrentMediaTypeRequest(stream_index) => match self.validate_stream_index(stream_index) {
+                Err(error) => DevicePdu::ErrorResponse(error),
+                Ok(()) => match self.backend.current_media_type(stream_index) {
+                    Ok(media_type) if media_type_is_valid(&media_type) => {
+                        DevicePdu::CurrentMediaTypeResponse(media_type)
+                    }
+                    Ok(_) => DevicePdu::ErrorResponse(ErrorCode::InvalidMediaType),
+                    Err(error) => DevicePdu::ErrorResponse(error),
+                },
+            },
+            DevicePdu::StartStreamsRequest(streams) => self.start_streams(streams),
+            DevicePdu::StopStreamsRequest => self.stop_streams(),
+            DevicePdu::SampleRequest(stream_index) => self.sample(stream_index),
+            _ => DevicePdu::ErrorResponse(ErrorCode::InvalidMessage),
+        }
+    }
+
+    fn activate(&mut self) -> DevicePdu {
+        if self.activation_depth == u32::MAX {
+            return DevicePdu::ErrorResponse(ErrorCode::InvalidRequest);
+        }
+        if self.activation_depth == 0 {
+            if let Err(error) = self.backend.activate() {
+                return DevicePdu::ErrorResponse(error);
+            }
+        }
+        self.activation_depth += 1;
+        DevicePdu::SuccessResponse
+    }
+
+    fn deactivate(&mut self) -> DevicePdu {
+        if self.streaming.is_some() {
+            if let Err(error) = self.backend.stop_streams() {
+                return DevicePdu::ErrorResponse(error);
+            }
+            self.streaming = None;
+        }
+        if self.activation_depth == 1 {
+            if let Err(error) = self.backend.deactivate() {
+                return DevicePdu::ErrorResponse(error);
+            }
+        }
+        self.activation_depth -= 1;
+        DevicePdu::SuccessResponse
+    }
+
+    fn start_streams(&mut self, streams: Vec<StartStreamInfo>) -> DevicePdu {
+        if !valid_stream_count(streams.len()) {
+            return DevicePdu::ErrorResponse(ErrorCode::InvalidRequest);
+        }
+        let available_streams = match self.backend.streams() {
+            Ok(available) if valid_stream_count(available.len()) && available.iter().all(stream_is_valid) => available,
+            Ok(_) => return DevicePdu::ErrorResponse(ErrorCode::Unexpected),
+            Err(error) => return DevicePdu::ErrorResponse(error),
+        };
+        for (index, stream) in streams.iter().enumerate() {
+            if streams[..index]
+                .iter()
+                .any(|previous| previous.stream_index == stream.stream_index)
+            {
+                return DevicePdu::ErrorResponse(ErrorCode::InvalidRequest);
+            }
+            if usize::from(stream.stream_index) >= available_streams.len() {
+                return DevicePdu::ErrorResponse(ErrorCode::InvalidStreamNumber);
+            }
+            let supported = match self.backend.media_types(stream.stream_index) {
+                Ok(supported) => supported,
+                Err(error) => return DevicePdu::ErrorResponse(error),
+            };
+            if !valid_media_type_count(supported.len())
+                || !supported.iter().all(media_type_is_valid)
+                || !supported.contains(&stream.media_type)
+            {
+                return DevicePdu::ErrorResponse(ErrorCode::InvalidMediaType);
+            }
+        }
+        if let Err(error) = self.backend.start_streams(&streams) {
+            return DevicePdu::ErrorResponse(error);
+        }
+        self.streaming = Some(streams);
+        DevicePdu::SuccessResponse
+    }
+
+    fn stop_streams(&mut self) -> DevicePdu {
+        if self.streaming.is_none() {
+            return DevicePdu::SuccessResponse;
+        }
+        if let Err(error) = self.backend.stop_streams() {
+            return DevicePdu::ErrorResponse(error);
+        }
+        self.streaming = None;
+        DevicePdu::SuccessResponse
+    }
+
+    fn sample(&mut self, stream_index: u8) -> DevicePdu {
+        let Some(media_type) = self.streaming.as_ref().and_then(|streams| {
+            streams
+                .iter()
+                .find(|stream| stream.stream_index == stream_index)
+                .map(|stream| stream.media_type)
+        }) else {
+            return DevicePdu::SampleErrorResponse {
+                stream_index,
+                error: if self.streaming.is_some() {
+                    ErrorCode::InvalidStreamNumber
+                } else {
+                    ErrorCode::InvalidRequest
+                },
+            };
+        };
+        match self.backend.sample(stream_index) {
+            Ok(sample) if media_type.validate_sample(&sample) => DevicePdu::SampleResponse { stream_index, sample },
+            Ok(_) => DevicePdu::SampleErrorResponse {
+                stream_index,
+                error: ErrorCode::InvalidMediaType,
+            },
+            Err(error) => DevicePdu::SampleErrorResponse { stream_index, error },
+        }
+    }
+
+    fn validate_stream_index(&mut self, stream_index: u8) -> Result<(), ErrorCode> {
+        let streams = self.backend.streams()?;
+        if !valid_stream_count(streams.len()) || !streams.iter().all(stream_is_valid) {
+            return Err(ErrorCode::Unexpected);
+        }
+        if usize::from(stream_index) >= streams.len() {
+            return Err(ErrorCode::InvalidStreamNumber);
+        }
+        Ok(())
+    }
+
+    fn shutdown(&mut self) {
+        if self.streaming.take().is_some()
+            && let Err(error) = self.backend.stop_streams()
+        {
+            warn!(?error, "Camera backend failed to stop while closing channel");
+        }
+        if self.activation_depth != 0
+            && let Err(error) = self.backend.deactivate()
+        {
+            warn!(?error, "Camera backend failed to deactivate while closing channel");
+        }
+        self.activation_depth = 0;
+    }
+}
+
+impl<B> AsAny for DeviceClient<B>
+where
+    B: CameraBackend,
+{
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+}
+
+impl<B> DvcProcessor for DeviceClient<B>
+where
+    B: CameraBackend,
+{
+    fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        if !self.advertised.load(Ordering::Acquire) {
+            return Err(pdu_other_err!(
+                "DeviceClient::start",
+                "camera device was not negotiated and advertised"
+            ));
+        }
+        self.shutdown();
+        self.channel_id = Some(channel_id);
+        debug!(channel_id, "Camera device channel started");
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        if !self.advertised.load(Ordering::Acquire) {
+            self.shutdown();
+            let response = match decode(payload) {
+                Ok(request) if is_client_response(&request) => return Ok(Vec::new()),
+                Ok(DevicePdu::SampleRequest(stream_index)) => DevicePdu::SampleErrorResponse {
+                    stream_index,
+                    error: ErrorCode::NotInitialized,
+                },
+                Ok(_) => DevicePdu::ErrorResponse(ErrorCode::NotInitialized),
+                Err(_) => DevicePdu::ErrorResponse(ErrorCode::InvalidMessage),
+            };
+            return Ok(vec![Box::new(response)]);
+        }
+        if self.channel_id != Some(channel_id) {
+            return Err(pdu_other_err!(
+                "DeviceClient::process",
+                "camera device channel id does not match the active channel"
+            ));
+        }
+        let response = match decode(payload) {
+            Ok(request) if is_client_response(&request) => {
+                warn!("Ignoring client-originated camera response PDU received from server");
+                return Ok(Vec::new());
+            }
+            Ok(request) => self.respond(request),
+            Err(error) => {
+                warn!(%error, "Rejecting malformed camera device PDU");
+                DevicePdu::ErrorResponse(ErrorCode::InvalidMessage)
+            }
+        };
+        Ok(vec![Box::new(response)])
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        if self.channel_id == Some(channel_id) {
+            self.shutdown();
+            self.channel_id = None;
+            debug!("Camera device channel closed");
+        }
+    }
+}
+
+impl<B> DvcClientProcessor for DeviceClient<B> where B: CameraBackend {}
+
+/// One-use DVC listener that creates a client for an explicitly selected camera.
+pub struct DeviceChannelListener<B> {
+    channel_name: String,
+    advertised: Arc<AtomicBool>,
+    backend: Option<B>,
+}
+
+impl<B> DvcChannelListener for DeviceChannelListener<B>
+where
+    B: CameraBackend,
+{
+    fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
+    fn create(&mut self, _channel_id: u32) -> Option<Box<dyn DvcClientProcessor>> {
+        if !self.advertised.load(Ordering::Acquire) {
+            return None;
+        }
+        let backend = self.backend.take()?;
+        Some(Box::new(DeviceClient {
+            channel_name: self.channel_name.clone(),
+            advertised: Arc::clone(&self.advertised),
+            backend,
+            channel_id: None,
+            activation_depth: 0,
+            streaming: None,
+        }))
+    }
+
+    fn is_available(&self) -> bool {
+        self.backend.is_some()
+    }
+}
+
+fn valid_stream_count(count: usize) -> bool {
+    (1..=usize::from(u8::MAX)).contains(&count)
+}
+
+fn valid_media_type_count(count: usize) -> bool {
+    (1..=crate::pdu::MAX_MEDIA_TYPES).contains(&count)
+}
+
+fn stream_is_valid(stream: &StreamDescription) -> bool {
+    stream.frame_source_types != 0
+        && stream.frame_source_types
+            & !(StreamDescription::COLOR | StreamDescription::INFRARED | StreamDescription::CUSTOM)
+            == 0
+}
+
+fn media_type_is_valid(media_type: &MediaType) -> bool {
+    if matches!(media_type.format, crate::MediaFormat::H264 | crate::MediaFormat::Mjpg) {
+        return false;
+    }
+    media_type.flags & !(MediaType::DECODING_REQUIRED | MediaType::BOTTOM_UP_IMAGE) == 0
+        && media_type.validate_for_backend().is_ok()
+}
+
+fn is_client_response(pdu: &DevicePdu) -> bool {
+    matches!(
+        pdu,
+        DevicePdu::SuccessResponse
+            | DevicePdu::ErrorResponse(_)
+            | DevicePdu::StreamListResponse(_)
+            | DevicePdu::MediaTypeListResponse(_)
+            | DevicePdu::CurrentMediaTypeResponse(_)
+            | DevicePdu::SampleResponse { .. }
+            | DevicePdu::SampleErrorResponse { .. }
+    )
+}

--- a/crates/ironrdp-rdpecam/src/client.rs
+++ b/crates/ironrdp-rdpecam/src/client.rs
@@ -280,6 +280,9 @@ impl DvcClientProcessor for EnumerationClient {}
 /// Methods are synchronous and must not block indefinitely on device I/O.
 pub trait CameraBackend: Send + 'static {
     fn activate(&mut self) -> Result<(), ErrorCode>;
+    /// Deactivates the device.
+    ///
+    /// On error, the device must remain activated and retryable.
     fn deactivate(&mut self) -> Result<(), ErrorCode>;
     fn streams(&mut self) -> Result<Vec<StreamDescription>, ErrorCode>;
     fn media_types(&mut self, stream_index: u8) -> Result<Vec<MediaType>, ErrorCode>;
@@ -288,8 +291,13 @@ pub trait CameraBackend: Send + 'static {
     ///
     /// On error, any prior stream selection must remain active.
     fn start_streams(&mut self, streams: &[StartStreamInfo]) -> Result<(), ErrorCode>;
+    /// Stops all active streams.
+    ///
+    /// On error, the current streams must remain active and retryable.
     fn stop_streams(&mut self) -> Result<(), ErrorCode>;
     fn sample(&mut self, stream_index: u8) -> Result<Vec<u8>, ErrorCode>;
+    /// Infallibly stops capture and releases device resources during channel teardown.
+    fn shutdown(&mut self);
 }
 
 /// Per-device RDPECAM client processor.
@@ -499,16 +507,10 @@ where
     }
 
     fn shutdown(&mut self) {
-        if self.streaming.take().is_some()
-            && let Err(error) = self.backend.stop_streams()
-        {
-            warn!(?error, "Camera backend failed to stop while closing channel");
+        if self.streaming.is_some() || self.activation_depth != 0 {
+            self.backend.shutdown();
         }
-        if self.activation_depth != 0
-            && let Err(error) = self.backend.deactivate()
-        {
-            warn!(?error, "Camera backend failed to deactivate while closing channel");
-        }
+        self.streaming = None;
         self.activation_depth = 0;
     }
 }

--- a/crates/ironrdp-rdpecam/src/lib.rs
+++ b/crates/ironrdp-rdpecam/src/lib.rs
@@ -1,0 +1,20 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+#![no_std]
+
+extern crate alloc;
+
+/// Device enumeration channel name from [2.1] Transport.
+///
+/// [2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/
+pub const ENUMERATION_CHANNEL_NAME: &str = "RDCamera_Device_Enumerator";
+
+pub mod client;
+pub mod pdu;
+
+pub use client::{
+    CameraBackend, CameraRedirectionSession, DeviceChannelListener, DeviceClient, EnumerationClient, RedirectedDevice,
+};
+pub use pdu::{
+    DeviceDescriptor, ErrorCode, MediaFormat, MediaType, ProtocolVersion, StartStreamInfo, StreamDescription,
+};

--- a/crates/ironrdp-rdpecam/src/pdu.rs
+++ b/crates/ironrdp-rdpecam/src/pdu.rs
@@ -815,7 +815,8 @@ fn decode_utf16z(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
 
 fn decode_ansiz(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
     let remaining = src.remaining();
-    let terminator = remaining
+    let search_len = remaining.len().min(MAX_CHANNEL_NAME_LEN + 1);
+    let terminator = remaining[..search_len]
         .iter()
         .position(|byte| *byte == 0)
         .ok_or_else(|| invalid_field_err!("VirtualChannelName", "channel name is not terminated", in: src))?;

--- a/crates/ironrdp-rdpecam/src/pdu.rs
+++ b/crates/ironrdp-rdpecam/src/pdu.rs
@@ -1,0 +1,909 @@
+//! Video Capture Virtual Channel Extension PDUs defined by [MS-RDPECAM].
+//!
+//! [MS-RDPECAM]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_size, invalid_field_err,
+};
+use ironrdp_dvc::DvcEncode;
+
+const HEADER_SIZE: usize = 1 /* Version */ + 1 /* MessageId */;
+const STREAM_DESCRIPTION_SIZE: usize =
+    2 /* FrameSourceTypes */ + 1 /* StreamCategory */ + 1 /* Selected */ + 1 /* CanBeShared */;
+const MEDIA_TYPE_SIZE: usize = 1 // Format
+    + 4 // Width
+    + 4 // Height
+    + 4 // FrameRateNumerator
+    + 4 // FrameRateDenominator
+    + 4 // PixelAspectRatioNumerator
+    + 4 // PixelAspectRatioDenominator
+    + 1; // Flags
+const START_STREAM_INFO_SIZE: usize = 1 /* StreamIndex */ + MEDIA_TYPE_SIZE;
+
+const MESSAGE_SUCCESS_RESPONSE: u8 = 0x01;
+const MESSAGE_ERROR_RESPONSE: u8 = 0x02;
+const MESSAGE_SELECT_VERSION_REQUEST: u8 = 0x03;
+const MESSAGE_SELECT_VERSION_RESPONSE: u8 = 0x04;
+const MESSAGE_DEVICE_ADDED_NOTIFICATION: u8 = 0x05;
+const MESSAGE_DEVICE_REMOVED_NOTIFICATION: u8 = 0x06;
+const MESSAGE_ACTIVATE_DEVICE_REQUEST: u8 = 0x07;
+const MESSAGE_DEACTIVATE_DEVICE_REQUEST: u8 = 0x08;
+const MESSAGE_STREAM_LIST_REQUEST: u8 = 0x09;
+const MESSAGE_STREAM_LIST_RESPONSE: u8 = 0x0A;
+const MESSAGE_MEDIA_TYPE_LIST_REQUEST: u8 = 0x0B;
+const MESSAGE_MEDIA_TYPE_LIST_RESPONSE: u8 = 0x0C;
+const MESSAGE_CURRENT_MEDIA_TYPE_REQUEST: u8 = 0x0D;
+const MESSAGE_CURRENT_MEDIA_TYPE_RESPONSE: u8 = 0x0E;
+const MESSAGE_START_STREAMS_REQUEST: u8 = 0x0F;
+const MESSAGE_STOP_STREAMS_REQUEST: u8 = 0x10;
+const MESSAGE_SAMPLE_REQUEST: u8 = 0x11;
+const MESSAGE_SAMPLE_RESPONSE: u8 = 0x12;
+const MESSAGE_SAMPLE_ERROR_RESPONSE: u8 = 0x13;
+
+/// Largest accepted width or height.
+pub const MAX_FRAME_DIMENSION: u32 = 8192;
+/// Largest accepted uncompressed frame or encoded Sample Response.
+pub const MAX_SAMPLE_SIZE: usize = 64 * 1024 * 1024;
+/// Largest accepted media-type list.
+pub const MAX_MEDIA_TYPES: usize = 4096;
+/// Largest accepted device display name, in UTF-16 code units.
+pub const MAX_DEVICE_NAME_LEN: usize = 1024;
+/// Largest accepted device channel name, excluding its terminator.
+pub const MAX_CHANNEL_NAME_LEN: usize = 256;
+
+/// MS-RDPECAM protocol versions supported by this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProtocolVersion {
+    V1 = 1,
+}
+
+impl TryFrom<u8> for ProtocolVersion {
+    type Error = ironrdp_core::DecodeError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::V1),
+            _ => Err(invalid_field_err!("Version", "unsupported RDPECAM protocol version")),
+        }
+    }
+}
+
+impl From<ProtocolVersion> for u8 {
+    fn from(value: ProtocolVersion) -> Self {
+        match value {
+            ProtocolVersion::V1 => 1,
+        }
+    }
+}
+
+/// Error codes from [2.2.3.2] Error Response.
+///
+/// [2.2.3.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ErrorCode {
+    Unexpected = 0x0000_0001,
+    InvalidMessage = 0x0000_0002,
+    NotInitialized = 0x0000_0003,
+    InvalidRequest = 0x0000_0004,
+    InvalidStreamNumber = 0x0000_0005,
+    InvalidMediaType = 0x0000_0006,
+    OutOfMemory = 0x0000_0007,
+}
+
+impl TryFrom<u32> for ErrorCode {
+    type Error = ironrdp_core::DecodeError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Unexpected),
+            2 => Ok(Self::InvalidMessage),
+            3 => Ok(Self::NotInitialized),
+            4 => Ok(Self::InvalidRequest),
+            5 => Ok(Self::InvalidStreamNumber),
+            6 => Ok(Self::InvalidMediaType),
+            7 => Ok(Self::OutOfMemory),
+            _ => Err(invalid_field_err!(
+                "ErrorCode",
+                "unsupported RDPECAM version 1 error code"
+            )),
+        }
+    }
+}
+
+impl From<ErrorCode> for u32 {
+    fn from(value: ErrorCode) -> Self {
+        match value {
+            ErrorCode::Unexpected => 1,
+            ErrorCode::InvalidMessage => 2,
+            ErrorCode::NotInitialized => 3,
+            ErrorCode::InvalidRequest => 4,
+            ErrorCode::InvalidStreamNumber => 5,
+            ErrorCode::InvalidMediaType => 6,
+            ErrorCode::OutOfMemory => 7,
+        }
+    }
+}
+
+/// Format values from [2.2.3.8.1] MEDIA_TYPE_DESCRIPTION.
+///
+/// [2.2.3.8.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MediaFormat {
+    H264 = 0x01,
+    Mjpg = 0x02,
+    Yuy2 = 0x03,
+    Nv12 = 0x04,
+    I420 = 0x05,
+    Rgb24 = 0x06,
+    Rgb32 = 0x07,
+}
+
+impl TryFrom<u8> for MediaFormat {
+    type Error = ironrdp_core::DecodeError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::H264),
+            2 => Ok(Self::Mjpg),
+            3 => Ok(Self::Yuy2),
+            4 => Ok(Self::Nv12),
+            5 => Ok(Self::I420),
+            6 => Ok(Self::Rgb24),
+            7 => Ok(Self::Rgb32),
+            _ => Err(invalid_field_err!("Format", "unknown RDPECAM media format")),
+        }
+    }
+}
+
+impl From<MediaFormat> for u8 {
+    fn from(value: MediaFormat) -> Self {
+        match value {
+            MediaFormat::H264 => 1,
+            MediaFormat::Mjpg => 2,
+            MediaFormat::Yuy2 => 3,
+            MediaFormat::Nv12 => 4,
+            MediaFormat::I420 => 5,
+            MediaFormat::Rgb24 => 6,
+            MediaFormat::Rgb32 => 7,
+        }
+    }
+}
+
+/// Description of a redirected device and its dedicated DVC listener.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceDescriptor {
+    pub display_name: String,
+    pub channel_name: String,
+}
+
+impl DeviceDescriptor {
+    pub fn new(display_name: String, channel_name: String) -> EncodeResult<Self> {
+        let descriptor = Self {
+            display_name,
+            channel_name,
+        };
+        descriptor.validate()?;
+        Ok(descriptor)
+    }
+
+    pub(crate) fn validate(&self) -> EncodeResult<()> {
+        validate_device_name(&self.display_name)?;
+        validate_channel_name(&self.channel_name)
+    }
+}
+
+/// Description of one camera stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamDescription {
+    /// Frame-source advertisement bits.
+    ///
+    /// Unknown bits are retained for forward-compatible round trips.
+    pub frame_source_types: u16,
+    pub selected: bool,
+    pub can_be_shared: bool,
+}
+
+impl StreamDescription {
+    pub const COLOR: u16 = 0x0001;
+    pub const INFRARED: u16 = 0x0002;
+    pub const CUSTOM: u16 = 0x0008;
+
+    pub fn color(selected: bool, can_be_shared: bool) -> Self {
+        Self {
+            frame_source_types: Self::COLOR,
+            selected,
+            can_be_shared,
+        }
+    }
+
+    fn validate(&self) -> EncodeResult<()> {
+        if self.frame_source_types == 0 {
+            return Err(invalid_field_err!(
+                "FrameSourceTypes",
+                "at least one frame source type is required"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Encode for StreamDescription {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.validate()?;
+        ensure_size!(in: dst, size: STREAM_DESCRIPTION_SIZE);
+        dst.write_u16(self.frame_source_types);
+        dst.write_u8(0x01);
+        dst.write_u8(u8::from(self.selected));
+        dst.write_u8(u8::from(self.can_be_shared));
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "STREAM_DESCRIPTION"
+    }
+
+    fn size(&self) -> usize {
+        STREAM_DESCRIPTION_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for StreamDescription {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: STREAM_DESCRIPTION_SIZE);
+        let frame_source_types = src.read_u16();
+        if frame_source_types == 0 {
+            return Err(invalid_field_err!(
+                "FrameSourceTypes",
+                "at least one frame source type is required",
+                in: src
+            ));
+        }
+        if src.read_u8() != 0x01 {
+            return Err(invalid_field_err!(
+                "StreamCategory",
+                "only capture streams are supported",
+                in: src
+            ));
+        }
+        let selected = decode_bool("Selected", src)?;
+        let can_be_shared = decode_bool("CanBeShared", src)?;
+        Ok(Self {
+            frame_source_types,
+            selected,
+            can_be_shared,
+        })
+    }
+}
+
+/// Stream format properties from [2.2.3.8.1] MEDIA_TYPE_DESCRIPTION.
+///
+/// [2.2.3.8.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpecam/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MediaType {
+    pub format: MediaFormat,
+    pub width: u32,
+    pub height: u32,
+    pub frame_rate_numerator: u32,
+    pub frame_rate_denominator: u32,
+    pub pixel_aspect_ratio_numerator: u32,
+    pub pixel_aspect_ratio_denominator: u32,
+    /// Media advertisement bits.
+    ///
+    /// Unknown bits are retained for forward-compatible round trips.
+    pub flags: u8,
+}
+
+impl MediaType {
+    pub const DECODING_REQUIRED: u8 = 0x01;
+    pub const BOTTOM_UP_IMAGE: u8 = 0x02;
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "arguments map directly to the wire description"
+    )]
+    pub fn new(
+        format: MediaFormat,
+        width: u32,
+        height: u32,
+        frame_rate_numerator: u32,
+        frame_rate_denominator: u32,
+        pixel_aspect_ratio_numerator: u32,
+        pixel_aspect_ratio_denominator: u32,
+        flags: u8,
+    ) -> EncodeResult<Self> {
+        let media_type = Self {
+            format,
+            width,
+            height,
+            frame_rate_numerator,
+            frame_rate_denominator,
+            pixel_aspect_ratio_numerator,
+            pixel_aspect_ratio_denominator,
+            flags,
+        };
+        media_type.validate_for_backend()?;
+        Ok(media_type)
+    }
+
+    /// Required sample length for an uncompressed format.
+    ///
+    /// Compressed H.264 and MJPEG formats return `None`.
+    pub fn uncompressed_sample_len(&self) -> Option<usize> {
+        let width = usize::try_from(self.width).ok()?;
+        let height = usize::try_from(self.height).ok()?;
+        let pixels = width.checked_mul(height)?;
+        match self.format {
+            MediaFormat::H264 | MediaFormat::Mjpg => None,
+            MediaFormat::Yuy2 => pixels.checked_mul(2),
+            MediaFormat::Nv12 | MediaFormat::I420 => pixels.checked_mul(3)?.checked_div(2),
+            MediaFormat::Rgb24 => pixels.checked_mul(3),
+            MediaFormat::Rgb32 => pixels.checked_mul(4),
+        }
+    }
+
+    pub fn validate_sample(&self, sample: &[u8]) -> bool {
+        match self.uncompressed_sample_len() {
+            Some(expected) => sample.len() == expected,
+            None => false,
+        }
+    }
+
+    pub(crate) fn validate_for_backend(&self) -> EncodeResult<()> {
+        if self.width == 0 || self.height == 0 || self.width > MAX_FRAME_DIMENSION || self.height > MAX_FRAME_DIMENSION
+        {
+            return Err(invalid_field_err!(
+                "Width/Height",
+                "frame dimensions must be between 1 and 8192 pixels"
+            ));
+        }
+        if self.frame_rate_numerator == 0 || self.frame_rate_denominator == 0 {
+            return Err(invalid_field_err!(
+                "FrameRate",
+                "frame rate numerator and denominator must be nonzero"
+            ));
+        }
+        if self.pixel_aspect_ratio_numerator == 0 || self.pixel_aspect_ratio_denominator == 0 {
+            return Err(invalid_field_err!(
+                "PixelAspectRatio",
+                "pixel aspect ratio numerator and denominator must be nonzero"
+            ));
+        }
+        if matches!(self.format, MediaFormat::Yuy2) && !self.width.is_multiple_of(2) {
+            return Err(invalid_field_err!("Width", "YUY2 width must be even"));
+        }
+        if matches!(self.format, MediaFormat::Nv12 | MediaFormat::I420)
+            && (!self.width.is_multiple_of(2) || !self.height.is_multiple_of(2))
+        {
+            return Err(invalid_field_err!(
+                "Width/Height",
+                "4:2:0 frame dimensions must be even"
+            ));
+        }
+        if self
+            .uncompressed_sample_len()
+            .is_some_and(|length| length > MAX_SAMPLE_SIZE)
+        {
+            return Err(invalid_field_err!(
+                "Width/Height",
+                "uncompressed frame exceeds the sample bound"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Encode for MediaType {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: MEDIA_TYPE_SIZE);
+        dst.write_u8(self.format.into());
+        dst.write_u32(self.width);
+        dst.write_u32(self.height);
+        dst.write_u32(self.frame_rate_numerator);
+        dst.write_u32(self.frame_rate_denominator);
+        dst.write_u32(self.pixel_aspect_ratio_numerator);
+        dst.write_u32(self.pixel_aspect_ratio_denominator);
+        dst.write_u8(self.flags);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "MEDIA_TYPE_DESCRIPTION"
+    }
+
+    fn size(&self) -> usize {
+        MEDIA_TYPE_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for MediaType {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: MEDIA_TYPE_SIZE);
+        Ok(Self {
+            format: MediaFormat::try_from(src.read_u8())?,
+            width: src.read_u32(),
+            height: src.read_u32(),
+            frame_rate_numerator: src.read_u32(),
+            frame_rate_denominator: src.read_u32(),
+            pixel_aspect_ratio_numerator: src.read_u32(),
+            pixel_aspect_ratio_denominator: src.read_u32(),
+            flags: src.read_u8(),
+        })
+    }
+}
+
+/// One selected stream and media type in a Start Streams Request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StartStreamInfo {
+    pub stream_index: u8,
+    pub media_type: MediaType,
+}
+
+impl Encode for StartStreamInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: START_STREAM_INFO_SIZE);
+        dst.write_u8(self.stream_index);
+        self.media_type.encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "START_STREAM_INFO"
+    }
+
+    fn size(&self) -> usize {
+        START_STREAM_INFO_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for StartStreamInfo {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: START_STREAM_INFO_SIZE);
+        Ok(Self {
+            stream_index: src.read_u8(),
+            media_type: MediaType::decode(src)?,
+        })
+    }
+}
+
+/// Messages exchanged on the RDPECAM device-enumeration channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnumerationPdu {
+    SelectVersionRequest(ProtocolVersion),
+    SelectVersionResponse(ProtocolVersion),
+    DeviceAdded {
+        version: ProtocolVersion,
+        device: DeviceDescriptor,
+    },
+    DeviceRemoved {
+        version: ProtocolVersion,
+        channel_name: String,
+    },
+}
+
+impl EnumerationPdu {
+    fn header(&self) -> (ProtocolVersion, u8) {
+        match self {
+            Self::SelectVersionRequest(version) => (*version, MESSAGE_SELECT_VERSION_REQUEST),
+            Self::SelectVersionResponse(version) => (*version, MESSAGE_SELECT_VERSION_RESPONSE),
+            Self::DeviceAdded { version, .. } => (*version, MESSAGE_DEVICE_ADDED_NOTIFICATION),
+            Self::DeviceRemoved { version, .. } => (*version, MESSAGE_DEVICE_REMOVED_NOTIFICATION),
+        }
+    }
+}
+
+impl Encode for EnumerationPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let (version, message_id) = self.header();
+        encode_header(dst, version, message_id);
+        match self {
+            Self::SelectVersionRequest(_) | Self::SelectVersionResponse(_) => {}
+            Self::DeviceAdded { device, .. } => {
+                validate_device_name(&device.display_name)?;
+                validate_channel_name(&device.channel_name)?;
+                for unit in device.display_name.encode_utf16() {
+                    dst.write_u16(unit);
+                }
+                dst.write_u16(0);
+                dst.write_slice(device.channel_name.as_bytes());
+                dst.write_u8(0);
+            }
+            Self::DeviceRemoved { channel_name, .. } => {
+                validate_channel_name(channel_name)?;
+                dst.write_slice(channel_name.as_bytes());
+                dst.write_u8(0);
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RDPECAM_ENUMERATION_PDU"
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::SelectVersionRequest(_) | Self::SelectVersionResponse(_) => HEADER_SIZE,
+            Self::DeviceAdded { device, .. } => {
+                HEADER_SIZE + device.display_name.encode_utf16().count() * 2 + 2 + device.channel_name.len() + 1
+            }
+            Self::DeviceRemoved { channel_name, .. } => HEADER_SIZE + channel_name.len() + 1,
+        }
+    }
+}
+
+impl<'de> Decode<'de> for EnumerationPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (version, message_id) = decode_header(src)?;
+        match message_id {
+            MESSAGE_SELECT_VERSION_REQUEST => {
+                ensure_empty(src)?;
+                Ok(Self::SelectVersionRequest(version))
+            }
+            MESSAGE_SELECT_VERSION_RESPONSE => {
+                ensure_empty(src)?;
+                Ok(Self::SelectVersionResponse(version))
+            }
+            MESSAGE_DEVICE_ADDED_NOTIFICATION => {
+                let display_name = decode_utf16z(src)?;
+                let channel_name = decode_ansiz(src)?;
+                ensure_empty(src)?;
+                Ok(Self::DeviceAdded {
+                    version,
+                    device: DeviceDescriptor {
+                        display_name,
+                        channel_name,
+                    },
+                })
+            }
+            MESSAGE_DEVICE_REMOVED_NOTIFICATION => {
+                let channel_name = decode_ansiz(src)?;
+                ensure_empty(src)?;
+                Ok(Self::DeviceRemoved { version, channel_name })
+            }
+            _ => Err(invalid_field_err!(
+                "MessageId",
+                "message is not valid on the enumeration channel",
+                in: src
+            )),
+        }
+    }
+}
+
+impl DvcEncode for EnumerationPdu {}
+
+/// Version 1 messages exchanged on a per-device RDPECAM channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DevicePdu {
+    SuccessResponse,
+    ErrorResponse(ErrorCode),
+    ActivateDeviceRequest,
+    DeactivateDeviceRequest,
+    StreamListRequest,
+    StreamListResponse(Vec<StreamDescription>),
+    MediaTypeListRequest(u8),
+    MediaTypeListResponse(Vec<MediaType>),
+    CurrentMediaTypeRequest(u8),
+    CurrentMediaTypeResponse(MediaType),
+    StartStreamsRequest(Vec<StartStreamInfo>),
+    StopStreamsRequest,
+    SampleRequest(u8),
+    SampleResponse { stream_index: u8, sample: Vec<u8> },
+    SampleErrorResponse { stream_index: u8, error: ErrorCode },
+}
+
+impl DevicePdu {
+    fn message_id(&self) -> u8 {
+        match self {
+            Self::SuccessResponse => MESSAGE_SUCCESS_RESPONSE,
+            Self::ErrorResponse(_) => MESSAGE_ERROR_RESPONSE,
+            Self::ActivateDeviceRequest => MESSAGE_ACTIVATE_DEVICE_REQUEST,
+            Self::DeactivateDeviceRequest => MESSAGE_DEACTIVATE_DEVICE_REQUEST,
+            Self::StreamListRequest => MESSAGE_STREAM_LIST_REQUEST,
+            Self::StreamListResponse(_) => MESSAGE_STREAM_LIST_RESPONSE,
+            Self::MediaTypeListRequest(_) => MESSAGE_MEDIA_TYPE_LIST_REQUEST,
+            Self::MediaTypeListResponse(_) => MESSAGE_MEDIA_TYPE_LIST_RESPONSE,
+            Self::CurrentMediaTypeRequest(_) => MESSAGE_CURRENT_MEDIA_TYPE_REQUEST,
+            Self::CurrentMediaTypeResponse(_) => MESSAGE_CURRENT_MEDIA_TYPE_RESPONSE,
+            Self::StartStreamsRequest(_) => MESSAGE_START_STREAMS_REQUEST,
+            Self::StopStreamsRequest => MESSAGE_STOP_STREAMS_REQUEST,
+            Self::SampleRequest(_) => MESSAGE_SAMPLE_REQUEST,
+            Self::SampleResponse { .. } => MESSAGE_SAMPLE_RESPONSE,
+            Self::SampleErrorResponse { .. } => MESSAGE_SAMPLE_ERROR_RESPONSE,
+        }
+    }
+}
+
+impl Encode for DevicePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        encode_header(dst, ProtocolVersion::V1, self.message_id());
+        match self {
+            Self::SuccessResponse
+            | Self::ActivateDeviceRequest
+            | Self::DeactivateDeviceRequest
+            | Self::StreamListRequest
+            | Self::StopStreamsRequest => {}
+            Self::ErrorResponse(error) => dst.write_u32((*error).into()),
+            Self::StreamListResponse(streams) => {
+                validate_u8_count("StreamDescriptions", streams.len())?;
+                for stream in streams {
+                    stream.encode(dst)?;
+                }
+            }
+            Self::MediaTypeListRequest(stream_index)
+            | Self::CurrentMediaTypeRequest(stream_index)
+            | Self::SampleRequest(stream_index) => dst.write_u8(*stream_index),
+            Self::MediaTypeListResponse(media_types) => {
+                validate_media_type_count(media_types.len())?;
+                for media_type in media_types {
+                    media_type.encode(dst)?;
+                }
+            }
+            Self::CurrentMediaTypeResponse(media_type) => media_type.encode(dst)?,
+            Self::StartStreamsRequest(streams) => {
+                validate_u8_count("StartStreamsInfo", streams.len())?;
+                for stream in streams {
+                    stream.encode(dst)?;
+                }
+            }
+            Self::SampleResponse { stream_index, sample } => {
+                if sample.len() > MAX_SAMPLE_SIZE {
+                    return Err(invalid_field_err!(
+                        "Sample",
+                        "sample length is outside the supported bound"
+                    ));
+                }
+                dst.write_u8(*stream_index);
+                dst.write_slice(sample);
+            }
+            Self::SampleErrorResponse { stream_index, error } => {
+                dst.write_u8(*stream_index);
+                dst.write_u32((*error).into());
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RDPECAM_DEVICE_PDU"
+    }
+
+    fn size(&self) -> usize {
+        HEADER_SIZE
+            + match self {
+                Self::SuccessResponse
+                | Self::ActivateDeviceRequest
+                | Self::DeactivateDeviceRequest
+                | Self::StreamListRequest
+                | Self::StopStreamsRequest => 0,
+                Self::ErrorResponse(_) => 4,
+                Self::StreamListResponse(streams) => streams.len() * STREAM_DESCRIPTION_SIZE,
+                Self::MediaTypeListRequest(_) | Self::CurrentMediaTypeRequest(_) | Self::SampleRequest(_) => 1,
+                Self::MediaTypeListResponse(media_types) => media_types.len() * MEDIA_TYPE_SIZE,
+                Self::CurrentMediaTypeResponse(_) => MEDIA_TYPE_SIZE,
+                Self::StartStreamsRequest(streams) => streams.len() * START_STREAM_INFO_SIZE,
+                Self::SampleResponse { sample, .. } => 1 + sample.len(),
+                Self::SampleErrorResponse { .. } => 1 + 4,
+            }
+    }
+}
+
+impl<'de> Decode<'de> for DevicePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (_version, message_id) = decode_header(src)?;
+        let pdu = match message_id {
+            MESSAGE_SUCCESS_RESPONSE => Self::SuccessResponse,
+            MESSAGE_ERROR_RESPONSE => {
+                ensure_size!(in: src, size: 4);
+                Self::ErrorResponse(ErrorCode::try_from(src.read_u32())?)
+            }
+            MESSAGE_ACTIVATE_DEVICE_REQUEST => Self::ActivateDeviceRequest,
+            MESSAGE_DEACTIVATE_DEVICE_REQUEST => Self::DeactivateDeviceRequest,
+            MESSAGE_STREAM_LIST_REQUEST => Self::StreamListRequest,
+            MESSAGE_STREAM_LIST_RESPONSE => {
+                let count = ensure_array(src, STREAM_DESCRIPTION_SIZE, usize::from(u8::MAX))?;
+                let mut streams = Vec::with_capacity(count);
+                while !src.is_empty() {
+                    streams.push(StreamDescription::decode(src)?);
+                }
+                Self::StreamListResponse(streams)
+            }
+            MESSAGE_MEDIA_TYPE_LIST_REQUEST => {
+                ensure_size!(in: src, size: 1);
+                Self::MediaTypeListRequest(src.read_u8())
+            }
+            MESSAGE_MEDIA_TYPE_LIST_RESPONSE => {
+                let count = ensure_array(src, MEDIA_TYPE_SIZE, MAX_MEDIA_TYPES)?;
+                let mut media_types = Vec::with_capacity(count);
+                while !src.is_empty() {
+                    media_types.push(MediaType::decode(src)?);
+                }
+                Self::MediaTypeListResponse(media_types)
+            }
+            MESSAGE_CURRENT_MEDIA_TYPE_REQUEST => {
+                ensure_size!(in: src, size: 1);
+                Self::CurrentMediaTypeRequest(src.read_u8())
+            }
+            MESSAGE_CURRENT_MEDIA_TYPE_RESPONSE => Self::CurrentMediaTypeResponse(MediaType::decode(src)?),
+            MESSAGE_START_STREAMS_REQUEST => {
+                let count = ensure_array(src, START_STREAM_INFO_SIZE, usize::from(u8::MAX))?;
+                let mut streams = Vec::with_capacity(count);
+                while !src.is_empty() {
+                    streams.push(StartStreamInfo::decode(src)?);
+                }
+                Self::StartStreamsRequest(streams)
+            }
+            MESSAGE_STOP_STREAMS_REQUEST => Self::StopStreamsRequest,
+            MESSAGE_SAMPLE_REQUEST => {
+                ensure_size!(in: src, size: 1);
+                Self::SampleRequest(src.read_u8())
+            }
+            MESSAGE_SAMPLE_RESPONSE => {
+                ensure_size!(in: src, size: 1);
+                if src.len() - 1 > MAX_SAMPLE_SIZE {
+                    return Err(invalid_field_err!("Sample", "sample exceeds the supported bound", in: src));
+                }
+                let stream_index = src.read_u8();
+                let sample = src.read_remaining().to_vec();
+                Self::SampleResponse { stream_index, sample }
+            }
+            MESSAGE_SAMPLE_ERROR_RESPONSE => {
+                ensure_size!(in: src, size: 5);
+                let stream_index = src.read_u8();
+                let error = ErrorCode::try_from(src.read_u32())?;
+                Self::SampleErrorResponse { stream_index, error }
+            }
+            _ => {
+                return Err(invalid_field_err!(
+                    "MessageId",
+                    "message is not supported by RDPECAM version 1",
+                    in: src
+                ));
+            }
+        };
+        ensure_empty(src)?;
+        Ok(pdu)
+    }
+}
+
+impl DvcEncode for DevicePdu {}
+
+fn encode_header(dst: &mut WriteCursor<'_>, version: ProtocolVersion, message_id: u8) {
+    dst.write_u8(version.into());
+    dst.write_u8(message_id);
+}
+
+fn decode_header(src: &mut ReadCursor<'_>) -> DecodeResult<(ProtocolVersion, u8)> {
+    ensure_size!(in: src, size: HEADER_SIZE);
+    Ok((ProtocolVersion::try_from(src.read_u8())?, src.read_u8()))
+}
+
+fn decode_bool(field: &'static str, src: &mut ReadCursor<'_>) -> DecodeResult<bool> {
+    match src.read_u8() {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(invalid_field_err!(field, "boolean field must be zero or one", in: src)),
+    }
+}
+
+fn decode_utf16z(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
+    let mut units = Vec::new();
+    loop {
+        ensure_size!(in: src, size: 2);
+        let unit = src.read_u16();
+        if unit == 0 {
+            break;
+        }
+        if units.len() == MAX_DEVICE_NAME_LEN {
+            return Err(invalid_field_err!("DeviceName", "device name exceeds the supported bound", in: src));
+        }
+        units.push(unit);
+    }
+    let value = String::from_utf16(&units)
+        .map_err(|_| invalid_field_err!("DeviceName", "device name is not valid UTF-16", in: src))?;
+    if value.is_empty() {
+        return Err(invalid_field_err!("DeviceName", "device name must not be empty", in: src));
+    }
+    Ok(value)
+}
+
+fn decode_ansiz(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
+    let remaining = src.remaining();
+    let terminator = remaining
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or_else(|| invalid_field_err!("VirtualChannelName", "channel name is not terminated", in: src))?;
+    if terminator == 0 || terminator > MAX_CHANNEL_NAME_LEN {
+        return Err(invalid_field_err!(
+            "VirtualChannelName",
+            "channel name length is outside the supported bound",
+            in: src
+        ));
+    }
+    if !remaining[..terminator].is_ascii() {
+        return Err(invalid_field_err!(
+            "VirtualChannelName",
+            "channel name must be ANSI-compatible ASCII",
+            in: src
+        ));
+    }
+    let bytes = src.read_slice(terminator);
+    let value = core::str::from_utf8(bytes)
+        .map_err(|_| invalid_field_err!("VirtualChannelName", "channel name is not valid ASCII", in: src))?;
+    let value = String::from(value);
+    let _terminator = src.read_u8();
+    Ok(value)
+}
+
+fn validate_device_name(value: &str) -> EncodeResult<()> {
+    let len = value.encode_utf16().count();
+    if len == 0 || len > MAX_DEVICE_NAME_LEN || value.encode_utf16().any(|unit| unit == 0) {
+        return Err(invalid_field_err!(
+            "DeviceName",
+            "device name must be nonempty, bounded, and contain no null"
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_channel_name(value: &str) -> EncodeResult<()> {
+    if value.is_empty() || value.len() > MAX_CHANNEL_NAME_LEN || !value.is_ascii() || value.as_bytes().contains(&0) {
+        return Err(invalid_field_err!(
+            "VirtualChannelName",
+            "channel name must be nonempty bounded ASCII without null"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_u8_count(field: &'static str, count: usize) -> EncodeResult<()> {
+    if !(1..=u8::MAX.into()).contains(&count) {
+        return Err(invalid_field_err!(
+            field,
+            "array must contain between 1 and 255 entries"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_media_type_count(count: usize) -> EncodeResult<()> {
+    if !(1..=MAX_MEDIA_TYPES).contains(&count) {
+        return Err(invalid_field_err!(
+            "MediaTypeDescriptions",
+            "media-type array is empty or exceeds the supported bound"
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_array(src: &ReadCursor<'_>, item_size: usize, max_count: usize) -> DecodeResult<usize> {
+    if src.is_empty() || !src.len().is_multiple_of(item_size) {
+        return Err(invalid_field_err!(
+            "MessageLength",
+            "message body is not a nonempty array of fixed-size entries",
+            in: src
+        ));
+    }
+    let count = src.len() / item_size;
+    if count > max_count {
+        return Err(invalid_field_err!(
+            "MessageLength",
+            "message array exceeds the supported entry count",
+            in: src
+        ));
+    }
+    Ok(count)
+}
+
+fn ensure_empty(src: &ReadCursor<'_>) -> DecodeResult<()> {
+    if !src.is_empty() {
+        return Err(invalid_field_err!("MessageLength", "message contains trailing bytes", in: src));
+    }
+    Ok(())
+}

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -55,6 +55,7 @@ ironrdp-input.path = "../ironrdp-input"
 ironrdp-rdcleanpath.path = "../ironrdp-rdcleanpath"
 ironrdp-rdpdr.path = "../ironrdp-rdpdr"
 ironrdp-rdpeai.path = "../ironrdp-rdpeai"
+ironrdp-rdpecam = { path = "../ironrdp-rdpecam" }
 ironrdp-rdpel.path = "../ironrdp-rdpel"
 ironrdp-rdpemt = { path = "../ironrdp-rdpemt", features = ["std"] }
 ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", features = ["std"] }

--- a/crates/ironrdp-testsuite-core/tests/main.rs
+++ b/crates/ironrdp-testsuite-core/tests/main.rs
@@ -29,6 +29,7 @@ mod propertyset;
 mod rdcleanpath;
 mod rdpdr;
 mod rdpeai;
+mod rdpecam;
 mod rdpei;
 mod rdpel;
 mod rdpemt;

--- a/crates/ironrdp-testsuite-core/tests/rdpecam/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpecam/mod.rs
@@ -88,6 +88,11 @@ impl CameraBackend for FakeCamera {
         self.sample_count += 1;
         Ok(vec![0x55; 12])
     }
+
+    fn shutdown(&mut self) {
+        self.stop_count += 1;
+        self.deactivate_count += 1;
+    }
 }
 
 #[test]
@@ -277,6 +282,94 @@ fn decoder_bounds_arrays_before_allocating_and_retains_unknown_advertisement_bit
     assert_eq!(decode::<DevicePdu>(&encoded).unwrap(), pdu);
 }
 
+#[test]
+fn wire_fixtures_match_ms_rdpecam_version_1_layouts() {
+    let descriptor = DeviceDescriptor::new("A".into(), "C".into()).unwrap();
+    let enumeration_fixtures = [
+        (EnumerationPdu::SelectVersionRequest(ProtocolVersion::V1), vec![1, 3]),
+        (EnumerationPdu::SelectVersionResponse(ProtocolVersion::V1), vec![1, 4]),
+        (
+            EnumerationPdu::DeviceAdded {
+                version: ProtocolVersion::V1,
+                device: descriptor,
+            },
+            vec![1, 5, b'A', 0, 0, 0, b'C', 0],
+        ),
+        (
+            EnumerationPdu::DeviceRemoved {
+                version: ProtocolVersion::V1,
+                channel_name: "C".into(),
+            },
+            vec![1, 6, b'C', 0],
+        ),
+    ];
+    for (pdu, expected) in enumeration_fixtures {
+        assert_eq!(encode_vec(&pdu).unwrap(), expected);
+        assert_eq!(decode::<EnumerationPdu>(&expected).unwrap(), pdu);
+    }
+
+    let media_type = media_type();
+    let media = media_type_fixture();
+    let mut stream_list = vec![1, 10];
+    stream_list.extend_from_slice(&[1, 0, 1, 1, 0]);
+    let mut media_list = vec![1, 12];
+    media_list.extend_from_slice(&media);
+    let mut current_media = vec![1, 14];
+    current_media.extend_from_slice(&media);
+    let mut start_streams = vec![1, 15, 2];
+    start_streams.extend_from_slice(&media);
+    let device_fixtures = [
+        (DevicePdu::SuccessResponse, vec![1, 1]),
+        (
+            DevicePdu::ErrorResponse(ErrorCode::InvalidRequest),
+            vec![1, 2, 4, 0, 0, 0],
+        ),
+        (DevicePdu::ActivateDeviceRequest, vec![1, 7]),
+        (DevicePdu::DeactivateDeviceRequest, vec![1, 8]),
+        (DevicePdu::StreamListRequest, vec![1, 9]),
+        (
+            DevicePdu::StreamListResponse(vec![StreamDescription::color(true, false)]),
+            stream_list,
+        ),
+        (DevicePdu::MediaTypeListRequest(2), vec![1, 11, 2]),
+        (DevicePdu::MediaTypeListResponse(vec![media_type]), media_list),
+        (DevicePdu::CurrentMediaTypeRequest(2), vec![1, 13, 2]),
+        (DevicePdu::CurrentMediaTypeResponse(media_type), current_media),
+        (
+            DevicePdu::StartStreamsRequest(vec![StartStreamInfo {
+                stream_index: 2,
+                media_type,
+            }]),
+            start_streams,
+        ),
+        (DevicePdu::StopStreamsRequest, vec![1, 16]),
+        (DevicePdu::SampleRequest(2), vec![1, 17, 2]),
+        (
+            DevicePdu::SampleResponse {
+                stream_index: 2,
+                sample: vec![0xAA, 0xBB],
+            },
+            vec![1, 18, 2, 0xAA, 0xBB],
+        ),
+        (
+            DevicePdu::SampleErrorResponse {
+                stream_index: 2,
+                error: ErrorCode::InvalidStreamNumber,
+            },
+            vec![1, 19, 2, 5, 0, 0, 0],
+        ),
+    ];
+    for (pdu, expected) in device_fixtures {
+        assert_eq!(encode_vec(&pdu).unwrap(), expected);
+        assert_eq!(decode::<DevicePdu>(&expected).unwrap(), pdu);
+    }
+
+    assert!(decode::<DevicePdu>(&[1, 2, 4, 0, 0]).is_err());
+    assert!(decode::<DevicePdu>(&[1, 7, 0]).is_err());
+    assert!(decode::<DevicePdu>(&[1, 11]).is_err());
+    assert!(decode::<DevicePdu>(&[1, 19, 0, 5, 0, 0]).is_err());
+}
+
 fn exchange(client: &mut DeviceClient<FakeCamera>, channel_id: u32, request: DevicePdu) -> DevicePdu {
     let encoded = encode_vec(&request).unwrap();
     let response = client.process(channel_id, &encoded).unwrap();
@@ -294,6 +387,19 @@ where
 
 fn media_type() -> MediaType {
     MediaType::new(MediaFormat::Rgb24, 2, 2, 30, 1, 1, 1, 0).unwrap()
+}
+
+fn media_type_fixture() -> Vec<u8> {
+    vec![
+        6, // Format
+        2, 0, 0, 0, // Width
+        2, 0, 0, 0, // Height
+        30, 0, 0, 0, // FrameRateNumerator
+        1, 0, 0, 0, // FrameRateDenominator
+        1, 0, 0, 0, // PixelAspectRatioNumerator
+        1, 0, 0, 0, // PixelAspectRatioDenominator
+        0, // Flags
+    ]
 }
 
 fn negotiated_device() -> ironrdp_rdpecam::RedirectedDevice {

--- a/crates/ironrdp-testsuite-core/tests/rdpecam/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpecam/mod.rs
@@ -1,0 +1,308 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_dvc::{DvcChannelListener as _, DvcProcessor as _};
+use ironrdp_rdpecam::client::CameraBackend;
+use ironrdp_rdpecam::pdu::{DevicePdu, EnumerationPdu};
+use ironrdp_rdpecam::{
+    CameraRedirectionSession, DeviceClient, DeviceDescriptor, ErrorCode, MediaFormat, MediaType, ProtocolVersion,
+    StartStreamInfo, StreamDescription,
+};
+
+#[derive(Debug)]
+struct FakeCamera {
+    media_type: MediaType,
+    activate_count: usize,
+    deactivate_count: usize,
+    start_count: usize,
+    stop_count: usize,
+    sample_count: usize,
+    fail_next_start: bool,
+}
+
+impl FakeCamera {
+    fn new() -> Self {
+        Self {
+            media_type: media_type(),
+            activate_count: 0,
+            deactivate_count: 0,
+            start_count: 0,
+            stop_count: 0,
+            sample_count: 0,
+            fail_next_start: false,
+        }
+    }
+}
+
+impl CameraBackend for FakeCamera {
+    fn activate(&mut self) -> Result<(), ErrorCode> {
+        self.activate_count += 1;
+        Ok(())
+    }
+
+    fn deactivate(&mut self) -> Result<(), ErrorCode> {
+        self.deactivate_count += 1;
+        Ok(())
+    }
+
+    fn streams(&mut self) -> Result<Vec<StreamDescription>, ErrorCode> {
+        Ok(vec![StreamDescription::color(true, false)])
+    }
+
+    fn media_types(&mut self, stream_index: u8) -> Result<Vec<MediaType>, ErrorCode> {
+        if stream_index != 0 {
+            return Err(ErrorCode::InvalidStreamNumber);
+        }
+        Ok(vec![self.media_type])
+    }
+
+    fn current_media_type(&mut self, stream_index: u8) -> Result<MediaType, ErrorCode> {
+        if stream_index != 0 {
+            return Err(ErrorCode::InvalidStreamNumber);
+        }
+        Ok(self.media_type)
+    }
+
+    fn start_streams(&mut self, streams: &[StartStreamInfo]) -> Result<(), ErrorCode> {
+        if core::mem::take(&mut self.fail_next_start) {
+            return Err(ErrorCode::Unexpected);
+        }
+        assert_eq!(
+            streams,
+            &[StartStreamInfo {
+                stream_index: 0,
+                media_type: self.media_type,
+            }]
+        );
+        self.start_count += 1;
+        Ok(())
+    }
+
+    fn stop_streams(&mut self) -> Result<(), ErrorCode> {
+        self.stop_count += 1;
+        Ok(())
+    }
+
+    fn sample(&mut self, stream_index: u8) -> Result<Vec<u8>, ErrorCode> {
+        if stream_index != 0 {
+            return Err(ErrorCode::InvalidStreamNumber);
+        }
+        self.sample_count += 1;
+        Ok(vec![0x55; 12])
+    }
+}
+
+#[test]
+fn enumeration_negotiates_before_advertising_selected_devices() {
+    let session = CameraRedirectionSession::new();
+    let descriptor = DeviceDescriptor::new("Selected camera".into(), "RDCamera_Device_0".into()).unwrap();
+    let device = session.select_device(descriptor.clone()).unwrap();
+    let mut listener = device.listener(FakeCamera::new());
+    let mut client = session.enumeration_client(vec![device]).unwrap();
+
+    assert!(listener.create(42).is_none());
+    let initial = client.start(41).unwrap();
+    assert_eq!(
+        decode_message::<EnumerationPdu>(&initial),
+        EnumerationPdu::SelectVersionRequest(ProtocolVersion::V1)
+    );
+    assert!(!client.ready());
+
+    let response = encode_vec(&EnumerationPdu::SelectVersionResponse(ProtocolVersion::V1)).unwrap();
+    let advertised = client.process(41, &response).unwrap();
+    assert!(client.ready());
+    assert_eq!(
+        decode_message::<EnumerationPdu>(&advertised),
+        EnumerationPdu::DeviceAdded {
+            version: ProtocolVersion::V1,
+            device: descriptor,
+        }
+    );
+    assert!(listener.create(42).is_some());
+}
+
+#[test]
+fn device_state_machine_streams_only_after_activation_and_media_validation() {
+    let device = negotiated_device();
+    let mut client = DeviceClient::new(&device, FakeCamera::new());
+    client.start(7).unwrap();
+
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::SampleRequest(0)),
+        DevicePdu::SampleErrorResponse {
+            stream_index: 0,
+            error: ErrorCode::NotInitialized,
+        }
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::ActivateDeviceRequest),
+        DevicePdu::SuccessResponse
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::ActivateDeviceRequest),
+        DevicePdu::SuccessResponse
+    );
+    assert_eq!(client.backend().activate_count, 1);
+
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StreamListRequest),
+        DevicePdu::StreamListResponse(vec![StreamDescription::color(true, false)])
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::MediaTypeListRequest(1)),
+        DevicePdu::ErrorResponse(ErrorCode::InvalidStreamNumber)
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StopStreamsRequest),
+        DevicePdu::SuccessResponse
+    );
+
+    let start = StartStreamInfo {
+        stream_index: 0,
+        media_type: media_type(),
+    };
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StartStreamsRequest(vec![start])),
+        DevicePdu::SuccessResponse
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StartStreamsRequest(vec![start])),
+        DevicePdu::SuccessResponse
+    );
+    assert!(client.is_streaming());
+    client.backend_mut().fail_next_start = true;
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StartStreamsRequest(vec![start])),
+        DevicePdu::ErrorResponse(ErrorCode::Unexpected)
+    );
+    assert!(client.is_streaming());
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::SampleRequest(0)),
+        DevicePdu::SampleResponse {
+            stream_index: 0,
+            sample: vec![0x55; 12],
+        }
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::StopStreamsRequest),
+        DevicePdu::SuccessResponse
+    );
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::DeactivateDeviceRequest),
+        DevicePdu::SuccessResponse
+    );
+    assert!(client.is_activated());
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::DeactivateDeviceRequest),
+        DevicePdu::SuccessResponse
+    );
+    assert!(!client.is_activated());
+    assert_eq!(client.backend().deactivate_count, 1);
+}
+
+#[test]
+fn malformed_device_message_is_rejected_without_backend_activation() {
+    let device = negotiated_device();
+    let mut client = DeviceClient::new(&device, FakeCamera::new());
+    client.start(7).unwrap();
+
+    let response = client.process(7, &[1]).unwrap();
+    assert_eq!(
+        decode_message::<DevicePdu>(&response),
+        DevicePdu::ErrorResponse(ErrorCode::InvalidMessage)
+    );
+    assert_eq!(client.backend().activate_count, 0);
+
+    let response = encode_vec(&DevicePdu::SuccessResponse).unwrap();
+    assert!(client.process(7, &response).unwrap().is_empty());
+}
+
+#[test]
+fn media_type_validation_enforces_plane_geometry_and_sample_length() {
+    assert!(MediaType::new(MediaFormat::Nv12, 3, 2, 30, 1, 1, 1, 0).is_err());
+    assert!(MediaType::new(MediaFormat::Rgb32, 8192, 8192, 30, 1, 1, 1, 0).is_err());
+    assert!(MediaType::new(MediaFormat::Rgb32, 3840, 2160, 30, 1, 1, 1, 0).is_ok());
+
+    let media_type = media_type();
+    assert!(media_type.validate_sample(&[0; 12]));
+    assert!(!media_type.validate_sample(&[0; 11]));
+
+    let pdu = DevicePdu::StartStreamsRequest(vec![StartStreamInfo {
+        stream_index: 0,
+        media_type,
+    }]);
+    let encoded = encode_vec(&pdu).unwrap();
+    assert_eq!(decode::<DevicePdu>(&encoded).unwrap(), pdu);
+}
+
+#[test]
+fn post_removal_request_returns_protocol_error_without_aborting_processing() {
+    let session = CameraRedirectionSession::new();
+    let descriptor = DeviceDescriptor::new("Selected camera".into(), "RDCamera_Device_0".into()).unwrap();
+    let device = session.select_device(descriptor).unwrap();
+    let mut enumeration = session.enumeration_client(vec![device.clone()]).unwrap();
+    enumeration.start(41).unwrap();
+    let response = encode_vec(&EnumerationPdu::SelectVersionResponse(ProtocolVersion::V1)).unwrap();
+    enumeration.process(41, &response).unwrap();
+
+    let mut client = DeviceClient::new(&device, FakeCamera::new());
+    client.start(7).unwrap();
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::ActivateDeviceRequest),
+        DevicePdu::SuccessResponse
+    );
+    enumeration.remove_device("RDCamera_Device_0").unwrap();
+
+    assert_eq!(
+        exchange(&mut client, 7, DevicePdu::SampleRequest(0)),
+        DevicePdu::SampleErrorResponse {
+            stream_index: 0,
+            error: ErrorCode::NotInitialized,
+        }
+    );
+    assert_eq!(client.backend().deactivate_count, 1);
+}
+
+#[test]
+fn decoder_bounds_arrays_before_allocating_and_retains_unknown_advertisement_bits() {
+    let mut oversized = vec![1, 10];
+    oversized.resize(2 + 256 * 5, 0);
+    assert!(decode::<DevicePdu>(&oversized).is_err());
+
+    let stream = StreamDescription {
+        frame_source_types: StreamDescription::COLOR | 0x8000,
+        selected: true,
+        can_be_shared: false,
+    };
+    let pdu = DevicePdu::StreamListResponse(vec![stream]);
+    let encoded = encode_vec(&pdu).unwrap();
+    assert_eq!(decode::<DevicePdu>(&encoded).unwrap(), pdu);
+}
+
+fn exchange(client: &mut DeviceClient<FakeCamera>, channel_id: u32, request: DevicePdu) -> DevicePdu {
+    let encoded = encode_vec(&request).unwrap();
+    let response = client.process(channel_id, &encoded).unwrap();
+    decode_message(&response)
+}
+
+fn decode_message<T>(messages: &[ironrdp_dvc::DvcMessage]) -> T
+where
+    T: for<'de> ironrdp_core::Decode<'de>,
+{
+    assert_eq!(messages.len(), 1);
+    let encoded = encode_vec(&*messages[0]).unwrap();
+    decode(&encoded).unwrap()
+}
+
+fn media_type() -> MediaType {
+    MediaType::new(MediaFormat::Rgb24, 2, 2, 30, 1, 1, 1, 0).unwrap()
+}
+
+fn negotiated_device() -> ironrdp_rdpecam::RedirectedDevice {
+    let session = CameraRedirectionSession::new();
+    let descriptor = DeviceDescriptor::new("Selected camera".into(), "RDCamera_Device_0".into()).unwrap();
+    let device = session.select_device(descriptor).unwrap();
+    let mut enumeration = session.enumeration_client(vec![device.clone()]).unwrap();
+    enumeration.start(41).unwrap();
+    let response = encode_vec(&EnumerationPdu::SelectVersionResponse(ProtocolVersion::V1)).unwrap();
+    enumeration.process(41, &response).unwrap();
+    device
+}


### PR DESCRIPTION
Add bounded MS-RDPECAM v1 codecs and DVC state machines behind a platform-neutral camera backend contract.

Keep ActiveX redirection fail-closed until a native capture backend and worker integration are available.