### PR TITLE
fix(rdpeusb)!: stop deriving pipe MaximumPacketSize from device speed

### DIFF
--- a/crates/ironrdp-rdpeusb/src/usb.rs
+++ b/crates/ironrdp-rdpeusb/src/usb.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 use ironrdp_usb::{
-    Direction, InterfaceSelection, TransferType, UsbSpeed,
+    Direction, InterfaceSelection, TransferType,
     control::{GetDescriptorRequest, Recipient, RequestKind, SetupPacket, standard_request},
     descriptor::{ConfigurationDescriptorSet, InterfaceDescriptor, ValidConfigurationDescriptorSet},
     transfer::{
@@ -556,7 +556,6 @@ pub fn unconfigure() -> TransferInPacket {
 pub fn select_configuration(
     descriptor: ValidConfigurationDescriptorSet<'_>,
     active_interfaces: &[InterfaceSelection],
-    speed: UsbSpeed,
 ) -> Result<TransferInPacket, ConversionError> {
     let descriptor = descriptor.as_set();
 
@@ -573,7 +572,7 @@ pub fn select_configuration(
         let interface = descriptor
             .interface(selection.interface, selection.alternate_setting)
             .ok_or(ConversionError::InterfaceNotFound { selection })?;
-        usbd_ifaces.push(interface_information(interface, speed)?);
+        usbd_ifaces.push(interface_information(interface)?);
     }
     for interface in descriptor.interfaces() {
         if !active_interfaces
@@ -606,7 +605,6 @@ pub fn select_interface(
     config_handle: ConfigHandle,
     descriptor: ValidConfigurationDescriptorSet<'_>,
     selection: InterfaceSelection,
-    speed: UsbSpeed,
 ) -> Result<TransferInPacket, ConversionError> {
     let interface = descriptor
         .as_set()
@@ -614,7 +612,7 @@ pub fn select_interface(
         .ok_or(ConversionError::InterfaceNotFound { selection })?;
     let urb = TsUrbSelectInterface {
         config_handle,
-        usbd_iface: interface_information(interface, speed)?,
+        usbd_iface: interface_information(interface)?,
     };
     Ok(transfer_in(
         TsUrbInKind::SelectIface(urb),
@@ -1051,10 +1049,7 @@ fn configuration_descriptor(descriptor: ConfigurationDescriptorSet<'_>) -> Resul
     })
 }
 
-fn interface_information(
-    interface: InterfaceDescriptor<'_>,
-    speed: UsbSpeed,
-) -> Result<TsUsbdInterfaceInfo, ConversionError> {
+fn interface_information(interface: InterfaceDescriptor<'_>) -> Result<TsUsbdInterfaceInfo, ConversionError> {
     let selection = InterfaceSelection {
         interface: interface.number(),
         alternate_setting: interface.alternate_setting(),
@@ -1071,15 +1066,14 @@ fn interface_information(
                 raw: raw_max_packet_size,
             });
         }
-        let max_packet_size = endpoint
-            .max_packet_size()
-            .usb2_max_payload(speed, endpoint.transfer_type())
-            .ok_or(ConversionError::InvalidMaximumPacketSize {
-                selection,
-                raw: raw_max_packet_size,
-            })?;
         pipes.push(TsUsbdPipeInfo {
-            max_packet_size,
+            // The client opens the pipe and reports the packet size it actually
+            // established in TS_USBD_PIPE_INFORMATION_RESULT, so the request
+            // field only states a preference. Windows servers leave it zero,
+            // and a server-side value would have to be derived from the
+            // announced device speed, which USB_DEVICE_CAPABILITIES
+            // ([MS-RDPEUSB] 2.2.11) cannot express beyond full and high.
+            max_packet_size: 0,
             // MS-RDPEUSB 2.2.9.1.3 notes that the client ignores this
             // obsolete USBD field. Zero requests the client default.
             max_transfer_size: 0,

--- a/crates/ironrdp-server/src/urbdrc.rs
+++ b/crates/ironrdp-server/src/urbdrc.rs
@@ -18,13 +18,12 @@ use ironrdp_rdpeusb::{
     },
     pdu::{
         completion::ts_urb_result::{TsUrbSelectConfigResult, TsUrbSelectInterfaceResult, TsUsbdInterfaceInfoResult},
-        sink::DeviceSpeed,
         utils::{ConfigHandle, PipeHandle},
     },
     server::{UrbdrcControlServerBackend, UrbdrcDeviceServerBackend},
 };
 use ironrdp_usb::{
-    InterfaceSelection, TransferType, UsbSpeed,
+    InterfaceSelection, TransferType,
     control::GetDescriptorRequest,
     descriptor::{ConfigurationDescriptorSet, InterfaceDescriptor, ValidConfigurationDescriptorSet},
     endpoint::EndpointAddress,
@@ -314,8 +313,7 @@ impl UsbDeviceHandle {
                         alternate_setting: interface.alternate_setting(),
                     })
                     .collect();
-                let speed = self.lock_usb_state().speed()?;
-                let packet = ironrdp_rdpeusb::usb::select_configuration(descriptor, &active_interfaces, speed)
+                let packet = ironrdp_rdpeusb::usb::select_configuration(descriptor, &active_interfaces)
                     .map_err(|e| ServerError::custom("failed to translate usb configuration selection", e))?;
                 let plan = ConfigurationSelectionPlan::Configure {
                     descriptor: descriptor.as_set().as_bytes().to_vec(),
@@ -371,12 +369,11 @@ impl UsbDeviceHandle {
 
         let (rx, transition) = {
             let mut state = self.lock_usb_state();
-            let speed = state.speed()?;
             let config_handle = state.interface_plan(descriptor, selection)?;
             let transition = state.reserve_transition(StatefulTransitionKind::SelectInterface {
                 interface: selection.interface,
             })?;
-            let packet = ironrdp_rdpeusb::usb::select_interface(config_handle, descriptor, selection, speed)
+            let packet = ironrdp_rdpeusb::usb::select_interface(config_handle, descriptor, selection)
                 .map_err(|e| ServerError::custom("failed to translate usb interface selection", e))?;
             let rx = self.enqueue_io_message(ServerDeviceIoReq::TransferIn(packet))?;
             if let Err(error) = state.activate_interface_transition(transition, selection.interface) {
@@ -489,18 +486,6 @@ impl UsbDeviceHandle {
         };
         let inner = self.resolve_pending(rx).await?;
         Ok(PendingRequest::new(inner, PendingOperation::Transfer))
-    }
-
-    fn initialize_usb_capabilities(&self, device_speed: DeviceSpeed) {
-        let speed = match device_speed.to_u32() {
-            value if value == DeviceSpeed::FULL_SPEED.to_u32() => Some(UsbSpeed::Full),
-            value if value == DeviceSpeed::HIGH_SPEED.to_u32() => Some(UsbSpeed::High),
-            value => {
-                tracing::warn!(value, "RDPEUSB device reported an unsupported USB speed");
-                None
-            }
-        };
-        self.lock_usb_state().capabilities = Some(UsbCapabilities { speed });
     }
 
     fn lock_usb_state(&self) -> MutexGuard<'_, UsbSharedState> {
@@ -635,7 +620,6 @@ impl ServerUsbDevice {
 
 #[derive(Debug)]
 struct UsbSharedState {
-    capabilities: Option<UsbCapabilities>,
     binding: BindingState,
     transition: TransitionState,
     next_generation: u64,
@@ -644,17 +628,11 @@ struct UsbSharedState {
 impl Default for UsbSharedState {
     fn default() -> Self {
         Self {
-            capabilities: None,
             binding: BindingState::Unconfigured,
             transition: TransitionState::Idle,
             next_generation: 0,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct UsbCapabilities {
-    speed: Option<UsbSpeed>,
 }
 
 #[derive(Debug, Clone)]
@@ -731,13 +709,6 @@ struct InterfaceSelectionPlan {
 }
 
 impl UsbSharedState {
-    fn speed(&self) -> ServerResult<UsbSpeed> {
-        self.capabilities
-            .ok_or_else(|| ServerError::reason("usb capabilities", "usb device capabilities have not been announced"))?
-            .speed
-            .ok_or_else(|| ServerError::reason("usb capabilities", "usb device speed is not supported by the facade"))
-    }
-
     fn reserve_transition(&mut self, kind: StatefulTransitionKind) -> ServerResult<StatefulTransition> {
         match self.transition {
             TransitionState::Idle => {}
@@ -1536,8 +1507,6 @@ impl UsbRedirServer {
 
 impl UrbdrcDeviceServerBackend for UsbRedirServer {
     fn add_device(&mut self, device: DeviceAnnounce) -> PduResult<()> {
-        self.handle
-            .initialize_usb_capabilities(device.usb_device_caps.device_speed);
         self.device.device_added(RdpUsbDeviceAnnounceInfo {
             announce: device,
             usb_handle: self.handle.clone(),

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/usb.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/usb.rs
@@ -21,7 +21,7 @@ use ironrdp_rdpeusb::{
     },
 };
 use ironrdp_usb::{
-    Direction, InterfaceSelection, UsbSpeed,
+    Direction, InterfaceSelection,
     control::{GetDescriptorRequest, Recipient, RequestKind, RequestType, SetupPacket, standard_request},
     descriptor::{ConfigurationDescriptorSet, descriptor_type},
     endpoint::EndpointAddress,
@@ -804,7 +804,7 @@ fn select_configuration_carries_full_descriptor_and_selected_interfaces() {
         .unwrap();
     let selections = [selection(0, 0), selection(1, 1)];
 
-    let request = select_configuration(descriptor, &selections, UsbSpeed::High).unwrap();
+    let request = select_configuration(descriptor, &selections).unwrap();
     assert_eq!(request.output_buffer_size, 0);
     assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION);
     let TsUrbInKind::SelectConfig(urb) = request.ts_urb.kind else {
@@ -817,8 +817,8 @@ fn select_configuration_carries_full_descriptor_and_selected_interfaces() {
     assert_eq!(urb.usbd_ifaces[0].interface_number, 0);
     assert_eq!(urb.usbd_ifaces[0].alternate_setting, 0);
     assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info.len(), 2);
-    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[0].max_packet_size, 192);
-    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[1].max_packet_size, 512);
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[0].max_packet_size, 0);
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[1].max_packet_size, 0);
     assert_eq!(urb.usbd_ifaces[1].interface_number, 1);
     assert_eq!(urb.usbd_ifaces[1].alternate_setting, 1);
 }
@@ -830,7 +830,7 @@ fn select_interface_uses_the_selected_alternate_setting() {
         .validate()
         .unwrap();
 
-    let request = select_interface(42, descriptor, selection(1, 1), UsbSpeed::High).unwrap();
+    let request = select_interface(42, descriptor, selection(1, 1)).unwrap();
     assert_eq!(request.output_buffer_size, 0);
     assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_SELECT_INTERFACE);
     let TsUrbInKind::SelectIface(urb) = request.ts_urb.kind else {
@@ -839,7 +839,7 @@ fn select_interface_uses_the_selected_alternate_setting() {
     assert_eq!(urb.config_handle, 42);
     assert_eq!(urb.usbd_iface.interface_number, 1);
     assert_eq!(urb.usbd_iface.alternate_setting, 1);
-    assert_eq!(urb.usbd_iface.ts_usbd_pipe_info[0].max_packet_size, 32);
+    assert_eq!(urb.usbd_iface.ts_usbd_pipe_info[0].max_packet_size, 0);
 }
 
 #[test]
@@ -938,16 +938,16 @@ fn selection_rejects_inconsistent_interface_sets() {
         .validate()
         .unwrap();
     assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0), selection(0, 0)], UsbSpeed::High).unwrap_err(),
+        select_configuration(descriptor, &[selection(0, 0), selection(0, 0)]).unwrap_err(),
         ConversionError::DuplicateInterface { interface: 0 }
     );
     assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0)], UsbSpeed::High).unwrap_err(),
+        select_configuration(descriptor, &[selection(0, 0)]).unwrap_err(),
         ConversionError::MissingInterfaceSelection { interface: 1 }
     );
     let missing = selection(7, 0);
     assert_eq!(
-        select_configuration(descriptor, &[missing], UsbSpeed::Full).unwrap_err(),
+        select_configuration(descriptor, &[missing]).unwrap_err(),
         ConversionError::InterfaceNotFound { selection: missing }
     );
 }
@@ -964,66 +964,6 @@ fn unconfigure_has_an_empty_transfer_in_request() {
 }
 
 #[test]
-fn selection_rejects_high_bandwidth_bits_at_other_speeds() {
-    let mut bytes = CONFIGURATION;
-    bytes[22] = 0x40;
-    bytes[23] = 0x08;
-    let descriptor = ConfigurationDescriptorSet::parse(&bytes).unwrap().validate().unwrap();
-
-    assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap_err(),
-        ConversionError::InvalidMaximumPacketSize {
-            selection: selection(0, 0),
-            raw: 0x0840
-        }
-    );
-}
-
-#[test]
-fn selection_enforces_usb2_speed_dependent_packet_sizes() {
-    let mut full_speed_bulk = CONFIGURATION;
-    full_speed_bulk[22] = 64;
-    full_speed_bulk[23] = 0;
-    full_speed_bulk[29] = 64;
-    full_speed_bulk[30] = 0;
-    let descriptor = ConfigurationDescriptorSet::parse(&full_speed_bulk)
-        .unwrap()
-        .validate()
-        .unwrap();
-    select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap();
-
-    let mut invalid_full_speed_bulk = full_speed_bulk;
-    invalid_full_speed_bulk[29] = 0;
-    invalid_full_speed_bulk[30] = 2;
-    let descriptor = ConfigurationDescriptorSet::parse(&invalid_full_speed_bulk)
-        .unwrap()
-        .validate()
-        .unwrap();
-    assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap_err(),
-        ConversionError::InvalidMaximumPacketSize {
-            selection: selection(0, 0),
-            raw: 512
-        }
-    );
-
-    let mut invalid_high_speed_bulk = CONFIGURATION;
-    invalid_high_speed_bulk[29] = 64;
-    invalid_high_speed_bulk[30] = 0;
-    let descriptor = ConfigurationDescriptorSet::parse(&invalid_high_speed_bulk)
-        .unwrap()
-        .validate()
-        .unwrap();
-    assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap_err(),
-        ConversionError::InvalidMaximumPacketSize {
-            selection: selection(0, 0),
-            raw: 64
-        }
-    );
-}
-
-#[test]
 fn selection_enforces_default_interface_zero_isochronous_bandwidth() {
     let mut zero_bandwidth = CONFIGURATION;
     zero_bandwidth[21] = 1;
@@ -1033,7 +973,7 @@ fn selection_enforces_default_interface_zero_isochronous_bandwidth() {
         .unwrap()
         .validate()
         .unwrap();
-    let request = select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap();
+    let request = select_configuration(descriptor, &[selection(0, 0), selection(1, 1)]).unwrap();
     let TsUrbInKind::SelectConfig(urb) = request.ts_urb.kind else {
         panic!("configuration selection used the wrong TS_URB variant");
     };
@@ -1046,7 +986,7 @@ fn selection_enforces_default_interface_zero_isochronous_bandwidth() {
         .validate()
         .unwrap();
     assert_eq!(
-        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap_err(),
+        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)]).unwrap_err(),
         ConversionError::InvalidMaximumPacketSize {
             selection: selection(0, 0),
             raw: 1


### PR DESCRIPTION
`interface_information` derived `TS_USBD_PIPE_INFORMATION.MaximumPacketSize` from
the announced device speed. The client opens the pipe and reports the size it
actually established in `TS_USBD_PIPE_INFORMATION_RESULT`, so the request field
only states a preference, and a Windows server sends zero. `select_configuration`
and `select_interface` now send zero and no longer take a speed.

`USB_DEVICE_CAPABILITIES` ([MS-RDPEUSB] 2.2.11) expresses only full and high speed,
so the derived value was also unreachable for anything faster.

`ironrdp-server` tracked the announced speed only to feed those two calls, so
`UsbCapabilities` and its accessor go with them; nothing in its public API changes.

Observed against a Windows server redirecting a USB 3.1 flash drive from FreeRDP:
it sends `MaximumPacketSize` 0 for both bulk pipes and receives 1024 back for each.