### PR TITLE
feat(activex): honor input timing settings

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -305,7 +305,7 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. `IMsRdpCameraRedirConfigCollection` exposes connected Windows camera metadata and offline configurations, but camera stream redirection remains unavailable. Non-filesystem device, monitor, and preferred-redirection capabilities remain unavailable. |
 | Smartcard redirection | `IMsRdpClientAdvancedSettings::RedirectSmartCards` enables WinSCard RDPDR smartcard redirection (smartcard-only sessions are valid without redirected drives). |
 
-The audit also identified unsupported `AdvancedSettings` members: plug-in DLL loading, input throttling, keepalive and idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, and security-layer negotiation.
+The audit also identified unsupported `AdvancedSettings` members: plug-in DLL loading, idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, and security-layer negotiation.
 Their audited vtable slots use published ABI signatures, initialize getter outputs, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
 `IMsRdpClientNonScriptable8::StartWorkspaceExtension` independently returns `E_NOTIMPL` because IronRDP does not implement Microsoft workspace extensions.
 
@@ -476,14 +476,7 @@ The `AdvancedSettings` through `AdvancedSettings9`, `SecuredSettings` through `S
 and `TransportSettings` through `TransportSettings4` getters return reference-counted, non-null
 settings objects with the published vtable lengths required by mstsc.exe and MsRdpEx. Returned
 settings objects keep the server loaded until their final `Release`, even if their parent control
-has already been released. The currently mapped members are `SmartSizing`, `EnableCredSspSupport`,
-`KeyboardHookMode`, keyboard type,
-subtype, and functional-key count, secured `StartProgram`/`WorkDir`, both public
-`AudioRedirectionMode` slots, both public `AudioCaptureRedirectionMode` slots,
-`AudioQualityMode`, `LoadBalanceInfo`, `ConnectToServerConsole`/`ConnectToAdministerServer`,
-`GrabFocusOnConnect`, `Compress`, `RDPPort`,
-`AuthenticationLevel`, and `PublicMode`,
-`RedirectClipboard`, `PerformanceFlags`, and RD Gateway transport selection.
+has already been released. The currently mapped members are `SmartSizing`, `EnableCredSspSupport`, `MinInputSendInterval`, `KeepAliveInterval`, `KeyboardHookMode`, keyboard type, subtype, and functional-key count, secured `StartProgram`/`WorkDir`, both public `AudioRedirectionMode` slots, both public `AudioCaptureRedirectionMode` slots, `AudioQualityMode`, `LoadBalanceInfo`, `ConnectToServerConsole`/`ConnectToAdministerServer`, `GrabFocusOnConnect`, `Compress`, `RDPPort`, `AuthenticationLevel`, `PublicMode`, `RedirectClipboard`, `PerformanceFlags`, and RD Gateway transport selection.
 `StartProgram` and `WorkDir` retain their caller-owned BSTR values and configure IronRDP's next
 Client Info PDU alternate shell and working directory. The keyboard fields configure the next GCC
 Client Core Data block.
@@ -505,6 +498,11 @@ with the Windows CPAL capture backend and sets `INFO_AUDIOCAPTURE` on Client Inf
 When requested,
 `GrabFocusOnConnect` focuses the ActiveX renderer only after its first remote frame arrives.
 Invalid audio modes and keyboard types return `E_INVALIDARG`.
+`MinInputSendInterval` defaults to 100 milliseconds and accepts values from 0 through 2000.
+It batches mouse-movement events until the interval expires or ten events accumulate, while keyboard, button, wheel, synchronization, and QoE events remain immediate.
+`KeepAliveInterval` defaults to zero and sends no synthetic input when disabled.
+Nonzero values are read back unchanged and reinterpreted as unsigned seconds, scheduling a no-op mouse movement after that much idle time.
+Both timing settings can be changed while a connection is active and apply to the next connection.
 `Compress`, `RDPPort`, and `RedirectClipboard` configure the next IronRDP connection. Clipboard
 redirection creates its Windows CLIPRDR listener on the ActiveX creating apartment, where its hidden
 window is serviced by the host message loop; the RDP worker receives only the thread-safe backend

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2517,6 +2517,7 @@ advanced_get_not_implemented!(
     (180, advanced_get_negotiate_security_layer, i16),
 );
 
+// Re-run the ignored `native_mstsc_input_timing_properties_match` parity test after Windows updates.
 const DEFAULT_MIN_INPUT_SEND_INTERVAL_MS: i32 = 100;
 const MAX_MIN_INPUT_SEND_INTERVAL_MS: i32 = 2_000;
 
@@ -2536,6 +2537,8 @@ unsafe extern "system" fn advanced_get_min_input_send_interval(this: *mut c_void
 
 unsafe extern "system" fn advanced_put_keep_alive_interval(this: *mut c_void, value: i32) -> HRESULT {
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    // Current mstscax stores the public LONG as an unsigned property without validation. Its input
+    // handler later multiplies that value by 1000 before comparing it with millisecond tick counts.
     object.settings.borrow_mut().keep_alive_interval_seconds = value;
     S_OK
 }
@@ -10831,6 +10834,7 @@ impl Control {
         } else {
             builder
         };
+        // Preserve mstscax's unsigned interpretation of the public LONG property.
         let keep_alive_interval_seconds = u32::from_ne_bytes(keep_alive_interval_seconds.to_ne_bytes());
         let builder = if keep_alive_interval_seconds == 0 {
             builder
@@ -16608,6 +16612,8 @@ fn dispid_for_name(name: &str) -> Option<i32> {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
     use super::*;
     use ironrdp_pdu::input::fast_path::{FastPathInputEvent, KeyboardFlags};
     use ironrdp_pdu::rdp::capability_sets::{CodecProperty, client_codecs_capabilities};
@@ -18325,6 +18331,61 @@ mod tests {
         assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 1) }, E_FAIL);
         assert_eq!(unsafe { advanced_put_min_input_send_interval(this, 1) }, S_OK);
         assert_eq!(unsafe { advanced_put_keep_alive_interval(this, 1) }, S_OK);
+    }
+
+    #[test]
+    #[ignore = "probes the registered Microsoft mstscax.dll"]
+    fn native_mstsc_input_timing_properties_match() {
+        let script = r#"
+$ErrorActionPreference = 'Stop'
+$clsid = [guid]'1df7c823-b2d4-4b54-975a-f2ac5d7cf8b8'
+$control = [Activator]::CreateInstance([type]::GetTypeFromCLSID($clsid))
+$advanced = $control.AdvancedSettings9
+try {
+    "min.default=$($advanced.MinInputSendInterval)"
+    $advanced.MinInputSendInterval = 2000
+    "min.2000=$($advanced.MinInputSendInterval)"
+    try {
+        $advanced.MinInputSendInterval = 2001
+        'min.2001=OK'
+    } catch {
+        $exception = $_.Exception
+        while ($exception.InnerException) {
+            $exception = $exception.InnerException
+        }
+        'min.2001=0x{0:X8}' -f $exception.HResult
+    }
+    "keep.default=$($advanced.KeepAliveInterval)"
+    $advanced.KeepAliveInterval = [int]::MinValue
+    "keep.min=$($advanced.KeepAliveInterval)"
+    $advanced.KeepAliveInterval = [int]::MaxValue
+    "keep.max=$($advanced.KeepAliveInterval)"
+} finally {
+    [Runtime.InteropServices.Marshal]::FinalReleaseComObject($advanced) | Out-Null
+    [Runtime.InteropServices.Marshal]::FinalReleaseComObject($control) | Out-Null
+}
+"#;
+        let output = Command::new("powershell.exe")
+            .args(["-NoProfile", "-Sta", "-Command", script])
+            .output()
+            .expect("launch native mstsc parity probe");
+        assert!(
+            output.status.success(),
+            "native mstsc parity probe failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout).expect("PowerShell output is UTF-8");
+        assert_eq!(
+            stdout.lines().collect::<Vec<_>>(),
+            [
+                "min.default=100",
+                "min.2000=2000",
+                "min.2001=0x80070057",
+                "keep.default=0",
+                "keep.min=-2147483648",
+                "keep.max=2147483647",
+            ]
+        );
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -10759,7 +10759,7 @@ impl Control {
             .with_audio_quality_mode(audio_quality_mode)
             .with_load_balance_info(load_balance_info)
             .with_input_send_interval(Duration::from_millis(
-                u64::try_from(min_input_send_interval_ms).expect("validated ActiveX input interval"),
+                u64::try_from(min_input_send_interval_ms).map_err(|_| Error::from_hresult(E_INVALIDARG))?,
             ))
             .with_administrative_session(administrative_session)
             .with_certificate_validation(certificate_validation)

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -1343,6 +1343,8 @@ struct CompatibilitySettings {
     grab_focus_on_connect: bool,
     enable_credssp: Option<bool>,
     compression: Option<bool>,
+    min_input_send_interval_ms: i32,
+    keep_alive_interval_seconds: i32,
     load_balance_info: String,
     administrative_session: bool,
     audio_quality_mode: AudioQualityMode,
@@ -1423,6 +1425,8 @@ impl Default for CompatibilitySettings {
             grab_focus_on_connect: false,
             enable_credssp: None,
             compression: None,
+            min_input_send_interval_ms: DEFAULT_MIN_INPUT_SEND_INTERVAL_MS,
+            keep_alive_interval_seconds: 0,
             load_balance_info: String::new(),
             administrative_session: false,
             audio_quality_mode: AudioQualityMode::Dynamic,
@@ -2491,8 +2495,6 @@ macro_rules! advanced_get_not_implemented {
 
 advanced_put_not_implemented!(
     (7, advanced_put_plugin_dlls, Bstr),
-    (69, advanced_put_min_input_send_interval, i32),
-    (75, advanced_put_keep_alive_interval, i32),
     (93, advanced_put_bitmap_persistence, i32),
     (95, advanced_put_minutes_to_idle_timeout, i32),
     (116, advanced_put_redirect_printers, i16),
@@ -2505,8 +2507,6 @@ advanced_put_not_implemented!(
 );
 
 advanced_get_not_implemented!(
-    (70, advanced_get_min_input_send_interval, i32),
-    (76, advanced_get_keep_alive_interval, i32),
     (94, advanced_get_bitmap_persistence, i32),
     (96, advanced_get_minutes_to_idle_timeout, i32),
     (117, advanced_get_redirect_printers, i16),
@@ -2516,6 +2516,34 @@ advanced_get_not_implemented!(
     (176, advanced_get_enable_super_pan, i16),
     (180, advanced_get_negotiate_security_layer, i16),
 );
+
+const DEFAULT_MIN_INPUT_SEND_INTERVAL_MS: i32 = 100;
+const MAX_MIN_INPUT_SEND_INTERVAL_MS: i32 = 2_000;
+
+unsafe extern "system" fn advanced_put_min_input_send_interval(this: *mut c_void, value: i32) -> HRESULT {
+    if !(0..=MAX_MIN_INPUT_SEND_INTERVAL_MS).contains(&value) {
+        return E_INVALIDARG;
+    }
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    object.settings.borrow_mut().min_input_send_interval_ms = value;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_min_input_send_interval(this: *mut c_void, value: *mut i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(value, object.settings.borrow().min_input_send_interval_ms).map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_keep_alive_interval(this: *mut c_void, value: i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    object.settings.borrow_mut().keep_alive_interval_seconds = value;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_keep_alive_interval(this: *mut c_void, value: *mut i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(value, object.settings.borrow().keep_alive_interval_seconds).map_or_else(|error| error.code(), |_| S_OK)
+}
 
 const MAX_LOAD_BALANCE_INFO_BYTES: usize = ironrdp_pdu::nego::MAX_ROUTING_TOKEN_LENGTH;
 
@@ -7606,6 +7634,11 @@ fn active_x_property_snapshot(settings: &Settings, compatibility: &Compatibility
         properties.insert("loadbalanceinfo", compatibility.load_balance_info.clone());
     }
     properties.insert("administrative session", compatibility.administrative_session);
+    properties.insert("mininputsendinterval", compatibility.min_input_send_interval_ms);
+    properties.insert(
+        "keepaliveinterval",
+        u32::from_ne_bytes(compatibility.keep_alive_interval_seconds.to_ne_bytes()),
+    );
     properties.insert(
         "audioqualitymode",
         match compatibility.audio_quality_mode {
@@ -10239,6 +10272,15 @@ impl Control {
             compatibility.fake_events_interval_minutes = config
                 .fake_events_interval()
                 .map(|interval| u32::try_from(interval.as_secs() / 60).unwrap_or(u32::MAX));
+            compatibility.keep_alive_interval_seconds = config
+                .input_keepalive_interval()
+                .map(|interval| u32::try_from(interval.as_secs()).unwrap_or(u32::MAX))
+                .map(|seconds| i32::from_ne_bytes(seconds.to_ne_bytes()))
+                .unwrap_or(0);
+            compatibility.min_input_send_interval_ms = config
+                .input_send_interval()
+                .map(|interval| i32::try_from(interval.as_millis()).unwrap_or(i32::MAX))
+                .unwrap_or(DEFAULT_MIN_INPUT_SEND_INTERVAL_MS);
             compatibility.audio_redirection_mode = if connector.enable_audio_playback { 0 } else { 2 };
             compatibility.audio_capture_redirection_mode = if connector.enable_audio_capture {
                 VARIANT_TRUE.0
@@ -10574,6 +10616,8 @@ impl Control {
         let ime_file_name = compatibility.ime_file_name.clone();
         let digital_product_id = compatibility.digital_product_id.clone();
         let fake_events_interval_minutes = compatibility.fake_events_interval_minutes;
+        let min_input_send_interval_ms = compatibility.min_input_send_interval_ms;
+        let keep_alive_interval_seconds = compatibility.keep_alive_interval_seconds;
         let authentication_level = compatibility.authentication_level;
         let authentication_level_set = compatibility.authentication_level_set;
         let public_mode = compatibility.public_mode;
@@ -10711,6 +10755,9 @@ impl Control {
             .with_audio_capture(audio_capture_enabled)
             .with_audio_quality_mode(audio_quality_mode)
             .with_load_balance_info(load_balance_info)
+            .with_input_send_interval(Duration::from_millis(
+                u64::try_from(min_input_send_interval_ms).expect("validated ActiveX input interval"),
+            ))
             .with_administrative_session(administrative_session)
             .with_certificate_validation(certificate_validation)
             // The GDI presenter has no hardware-cursor overlay, so cursor updates must be
@@ -10783,6 +10830,12 @@ impl Control {
             builder.with_fake_events_interval(Duration::from_secs(u64::from(minutes) * 60))
         } else {
             builder
+        };
+        let keep_alive_interval_seconds = u32::from_ne_bytes(keep_alive_interval_seconds.to_ne_bytes());
+        let builder = if keep_alive_interval_seconds == 0 {
+            builder
+        } else {
+            builder.with_input_keepalive_interval(Duration::from_secs(u64::from(keep_alive_interval_seconds)))
         };
         let using_rdcleanpath = matches!(&transport, ActiveXTransport::RDCleanPath(_));
         let builder = match transport {
@@ -18196,6 +18249,40 @@ mod tests {
         assert_eq!(audio_quality_mode, 2);
         assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 3) }, E_INVALIDARG);
 
+        let mut min_input_send_interval = i32::MAX;
+        assert_eq!(
+            unsafe { advanced_get_min_input_send_interval(this, &mut min_input_send_interval) },
+            S_OK
+        );
+        assert_eq!(min_input_send_interval, DEFAULT_MIN_INPUT_SEND_INTERVAL_MS);
+        assert_eq!(unsafe { advanced_put_min_input_send_interval(this, -1) }, E_INVALIDARG);
+        assert_eq!(
+            unsafe { advanced_put_min_input_send_interval(this, MAX_MIN_INPUT_SEND_INTERVAL_MS + 1) },
+            E_INVALIDARG
+        );
+        assert_eq!(
+            unsafe { advanced_put_min_input_send_interval(this, MAX_MIN_INPUT_SEND_INTERVAL_MS) },
+            S_OK
+        );
+        assert_eq!(
+            unsafe { advanced_get_min_input_send_interval(this, &mut min_input_send_interval) },
+            S_OK
+        );
+        assert_eq!(min_input_send_interval, MAX_MIN_INPUT_SEND_INTERVAL_MS);
+
+        let mut keep_alive_interval = i32::MAX;
+        assert_eq!(
+            unsafe { advanced_get_keep_alive_interval(this, &mut keep_alive_interval) },
+            S_OK
+        );
+        assert_eq!(keep_alive_interval, 0);
+        assert_eq!(unsafe { advanced_put_keep_alive_interval(this, i32::MIN) }, S_OK);
+        assert_eq!(
+            unsafe { advanced_get_keep_alive_interval(this, &mut keep_alive_interval) },
+            S_OK
+        );
+        assert_eq!(keep_alive_interval, i32::MIN);
+
         let snapshot = active_x_property_snapshot(&Settings::default(), &settings.borrow());
         assert_eq!(
             snapshot.get::<&str>("loadbalanceinfo").map(str::len),
@@ -18203,6 +18290,14 @@ mod tests {
         );
         assert_eq!(snapshot.get::<bool>("administrative session"), Some(true));
         assert_eq!(snapshot.get::<u32>("audioqualitymode"), Some(2));
+        assert_eq!(
+            snapshot.get::<i32>("mininputsendinterval"),
+            Some(MAX_MIN_INPUT_SEND_INTERVAL_MS)
+        );
+        assert_eq!(
+            snapshot.get::<u32>("keepaliveinterval"),
+            Some(u32::from_ne_bytes(i32::MIN.to_ne_bytes()))
+        );
 
         let mut authentication_level = u32::MAX;
         assert_eq!(
@@ -18218,13 +18313,6 @@ mod tests {
         );
         assert_eq!(redirect_devices, VARIANT_FALSE.0);
 
-        let mut keep_alive_interval = i32::MAX;
-        assert_eq!(
-            unsafe { advanced_get_keep_alive_interval(this, &mut keep_alive_interval) },
-            E_NOTIMPL
-        );
-        assert_eq!(keep_alive_interval, 0);
-
         object.settings.borrow_mut().connection_settings_sealed = true;
         assert_eq!(
             unsafe { advanced_put_connect_to_administer_server(this, VARIANT_FALSE.0) },
@@ -18235,6 +18323,8 @@ mod tests {
             E_FAIL
         );
         assert_eq!(unsafe { advanced_put_audio_quality_mode(this, 1) }, E_FAIL);
+        assert_eq!(unsafe { advanced_put_min_input_send_interval(this, 1) }, S_OK);
+        assert_eq!(unsafe { advanced_put_keep_alive_interval(this, 1) }, S_OK);
     }
 
     #[test]
@@ -18516,6 +18606,11 @@ mod tests {
         assert_eq!(vtable.slots[2], advanced_settings_stub_2 as *const () as usize);
         assert_eq!(vtable.slots[82], advanced_settings_stub_82 as *const () as usize);
         assert_eq!(vtable.slots[0], advanced_put_compress as *const () as usize);
+        assert_eq!(
+            vtable.slots[69],
+            advanced_put_min_input_send_interval as *const () as usize
+        );
+        assert_eq!(vtable.slots[75], advanced_put_keep_alive_interval as *const () as usize);
         assert_eq!(vtable.slots[97], advanced_put_smart_sizing as *const () as usize);
         assert_eq!(
             vtable.slots[136],

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -102,6 +102,8 @@ pub struct Config {
     #[cfg(all(windows, feature = "vmconnect"))]
     pub(crate) vmconnect_current_user: bool,
     pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
+    pub(crate) input_send_interval: Option<Duration>,
+    pub(crate) input_keepalive_interval: Option<Duration>,
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
     pub(crate) administrative_session: bool,
@@ -195,6 +197,16 @@ impl Config {
         self.kerberos_config.as_ref()
     }
 
+    /// Minimum interval between non-forced input batches.
+    pub fn input_send_interval(&self) -> Option<Duration> {
+        self.input_send_interval
+    }
+
+    /// Interval between synthetic input keepalive events.
+    pub fn input_keepalive_interval(&self) -> Option<Duration> {
+        self.input_keepalive_interval
+    }
+
     /// Idle anti-lock fake-events interval, if enabled.
     pub fn fake_events_interval(&self) -> Option<Duration> {
         self.fake_events_interval
@@ -269,6 +281,8 @@ impl fmt::Debug for Config {
             );
         }
         s.field("kerberos_config", &self.kerberos_config);
+        s.field("input_send_interval", &self.input_send_interval);
+        s.field("input_keepalive_interval", &self.input_keepalive_interval);
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
         s.field("administrative_session", &self.administrative_session);
@@ -766,6 +780,8 @@ pub struct ConfigBuilder {
     vmconnect_current_user: bool,
     rdcleanpath_token: Option<String>,
     kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
+    input_send_interval: Option<Duration>,
+    input_keepalive_interval: Option<Duration>,
     fake_events_interval: Option<Duration>,
     channels: ChannelConfig,
     #[cfg(any(feature = "sound", feature = "rdpdr"))]
@@ -1307,6 +1323,26 @@ impl ConfigBuilder {
             self.properties.clear_kdc_proxy_url();
         }
         self.kerberos_config = Some(cfg);
+        self
+    }
+
+    /// Set the minimum interval between non-forced input batches.
+    ///
+    /// Mouse movement is batched until this interval elapses.
+    /// Keyboard, button, wheel, synchronization, and QoE events remain immediate.
+    #[must_use]
+    pub fn with_input_send_interval(mut self, interval: Duration) -> Self {
+        self.input_send_interval = Some(interval);
+        self
+    }
+
+    /// Set the interval between synthetic input keepalive events.
+    ///
+    /// Unlike [`with_fake_events_interval`](Self::with_fake_events_interval), this does not write the minute-based `ironrdp_fakeeventsinterval` compatibility property.
+    /// When both intervals are configured, the shorter interval controls synthetic input.
+    #[must_use]
+    pub fn with_input_keepalive_interval(mut self, interval: Duration) -> Self {
+        self.input_keepalive_interval = Some(interval);
         self
     }
 
@@ -1930,6 +1966,8 @@ impl ConfigBuilder {
             #[cfg(all(windows, feature = "vmconnect"))]
             vmconnect_current_user: self.vmconnect_current_user,
             kerberos_config,
+            input_send_interval: self.input_send_interval,
+            input_keepalive_interval: self.input_keepalive_interval,
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,
             administrative_session: self.administrative_session,
@@ -2051,6 +2089,15 @@ impl ConfigBuilder {
         }
         if let Some(minutes) = ps.fake_events_interval() {
             self.fake_events_interval = Some(Duration::from_secs(u64::from(minutes) * 60));
+        }
+        if let Some(milliseconds) = ps.get::<u32>("mininputsendinterval") {
+            if milliseconds > 2_000 {
+                anyhow::bail!("invalid minimum input send interval: valid values are 0 through 2000 milliseconds");
+            }
+            self.input_send_interval = Some(Duration::from_millis(u64::from(milliseconds)));
+        }
+        if let Some(seconds) = ps.get::<u32>("keepaliveinterval") {
+            self.input_keepalive_interval = (seconds != 0).then(|| Duration::from_secs(u64::from(seconds)));
         }
         if let Some(level) = ps.compression_level() {
             self.compression_type = Some(compression_type_from_level(level)?);
@@ -2316,6 +2363,8 @@ fn kerberos_config_from_properties(
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use ironrdp_cfg::PropertySetExt as _;
     use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 
@@ -2347,6 +2396,34 @@ mod tests {
             .build()
             .expect("terminator-only load-balance info clears the token");
         assert!(cleared.load_balance_info().is_none());
+    }
+
+    #[test]
+    fn input_timing_configuration_preserves_subminute_precision() {
+        let config = complete_builder()
+            .with_input_send_interval(Duration::from_millis(100))
+            .with_input_keepalive_interval(Duration::from_secs(5))
+            .build()
+            .expect("valid input timing configuration");
+
+        assert_eq!(config.input_send_interval(), Some(Duration::from_millis(100)));
+        assert_eq!(config.input_keepalive_interval(), Some(Duration::from_secs(5)));
+        assert_eq!(config.fake_events_interval(), None);
+        assert_eq!(config.properties.get::<u32>("ironrdp_fakeeventsinterval"), None);
+
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.insert("mininputsendinterval", 2_000u32);
+        properties.insert("keepaliveinterval", 30u32);
+        let config = complete_builder()
+            .with_property_set(&properties)
+            .expect("valid input timing properties")
+            .build()
+            .expect("valid input timing configuration");
+        assert_eq!(config.input_send_interval(), Some(Duration::from_secs(2)));
+        assert_eq!(config.input_keepalive_interval(), Some(Duration::from_secs(30)));
+
+        properties.insert("mininputsendinterval", 2_001u32);
+        assert!(complete_builder().with_property_set(&properties).is_err());
     }
 
     #[cfg(any(feature = "sound", feature = "rdpdr"))]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1004,6 +1004,11 @@ impl RdpClient {
                 }
             }
 
+            let input_keepalive_interval =
+                match (self.config.input_keepalive_interval, self.config.fake_events_interval) {
+                    (Some(input_keepalive), Some(fake_events)) => Some(input_keepalive.min(fake_events)),
+                    (input_keepalive, fake_events) => input_keepalive.or(fake_events),
+                };
             match active_session(
                 framed,
                 connection_result,
@@ -1013,7 +1018,8 @@ impl RdpClient {
                 &mut self.clipboard_event_receiver,
                 &mut self.close_receiver,
                 &mut self.graceful_close_receiver,
-                self.config.fake_events_interval,
+                self.config.input_send_interval,
+                input_keepalive_interval,
                 &mut auto_reconnect_cookie,
                 &mut reconnect_attempt,
             )
@@ -1794,6 +1800,73 @@ trait AsyncReadWrite: AsyncRead + AsyncWrite {}
 impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite {}
 type UpgradedFramed = ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin + Send + Sync>>;
 
+const INPUT_BATCH_EVENT_LIMIT: usize = 10;
+
+struct FastPathInputBatcher {
+    interval: Duration,
+    last_send: tokio::time::Instant,
+    pending: SmallVec<[FastPathInputEvent; INPUT_BATCH_EVENT_LIMIT]>,
+}
+
+impl FastPathInputBatcher {
+    fn new(interval: Option<Duration>, now: tokio::time::Instant) -> Self {
+        Self {
+            interval: interval.unwrap_or(Duration::ZERO),
+            last_send: now,
+            pending: SmallVec::new(),
+        }
+    }
+
+    fn deadline(&self) -> Option<tokio::time::Instant> {
+        (!self.pending.is_empty()).then_some(self.last_send + self.interval)
+    }
+
+    fn queue(
+        &mut self,
+        events: impl IntoIterator<Item = FastPathInputEvent>,
+        now: tokio::time::Instant,
+    ) -> Option<SmallVec<[FastPathInputEvent; INPUT_BATCH_EVENT_LIMIT]>> {
+        let mut force = false;
+        for event in events {
+            force |= !matches!(
+                event,
+                FastPathInputEvent::MouseEvent(MousePdu {
+                    flags: PointerFlags::MOVE,
+                    number_of_wheel_rotation_units: 0,
+                    ..
+                })
+            );
+            self.pending.push(event);
+        }
+        if force
+            || self.interval.is_zero()
+            || self.pending.len() >= INPUT_BATCH_EVENT_LIMIT
+            || now.duration_since(self.last_send) >= self.interval
+        {
+            self.flush(now)
+        } else {
+            None
+        }
+    }
+
+    fn queue_forced(
+        &mut self,
+        events: impl IntoIterator<Item = FastPathInputEvent>,
+        now: tokio::time::Instant,
+    ) -> SmallVec<[FastPathInputEvent; INPUT_BATCH_EVENT_LIMIT]> {
+        self.pending.extend(events);
+        self.flush(now).unwrap_or_default()
+    }
+
+    fn flush(&mut self, now: tokio::time::Instant) -> Option<SmallVec<[FastPathInputEvent; INPUT_BATCH_EVENT_LIMIT]>> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        self.last_send = now;
+        Some(core::mem::take(&mut self.pending))
+    }
+}
+
 /// Direct TCP → TLS connection (no gateway).
 async fn connect_direct(
     config: &Config,
@@ -2545,6 +2618,7 @@ async fn active_session(
     clipboard_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
     close_receiver: &mut watch::Receiver<bool>,
     graceful_close_receiver: &mut watch::Receiver<bool>,
+    input_send_interval: Option<Duration>,
     fake_events_interval: Option<Duration>,
     auto_reconnect_cookie: &mut Option<ServerAutoReconnect>,
     reconnect_attempt: &mut u32,
@@ -2589,8 +2663,10 @@ async fn active_session(
     // synthesize a no-op mouse move when the session has been idle for too long. Default to the
     // middle of the screen so a synthetic move before any real input doesn't snap the pointer to a
     // corner.
-    let mut last_input = tokio::time::Instant::now();
+    let now = tokio::time::Instant::now();
+    let mut last_input = now;
     let mut last_mouse_pos = (desktop_size.width / 2, desktop_size.height / 2);
+    let mut input_batcher = FastPathInputBatcher::new(input_send_interval, now);
     let mut fake_events_interval =
         fake_events_interval.map(|interval| tokio::time::interval(core::cmp::max(interval, Duration::from_secs(1))));
     let mut resize_queue = ResizeQueue::default();
@@ -2614,6 +2690,7 @@ async fn active_session(
 
     let disconnect_reason = 'outer: loop {
         let resize_deadline = resize_queue.deadline();
+        let input_batch_deadline = input_batcher.deadline();
         let mut malformed_bitmap_redraw_queued = false;
         let clipboard_event = async {
             #[cfg(feature = "clipboard")]
@@ -2792,7 +2869,10 @@ async fn active_session(
                                 last_mouse_pos = (mouse.x_position, mouse.y_position);
                             }
                         }
-                        active_stage.process_fastpath_input(&mut image, &events)?
+                        match input_batcher.queue(events, tokio::time::Instant::now()) {
+                            Some(events) => active_stage.process_fastpath_input(&mut image, &events)?,
+                            None => Vec::new(),
+                        }
                     }
                     RdpInputEvent::Touch(event) => {
                         trace!(frames = event.frames.len(), "RDPEI touch event");
@@ -3074,6 +3154,17 @@ async fn active_session(
                         None => Vec::new(),
                     }
                 }
+                _ = async {
+                    match input_batch_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => core::future::pending().await,
+                    }
+                } => {
+                    match input_batcher.flush(tokio::time::Instant::now()) {
+                        Some(events) => active_stage.process_fastpath_input(&mut image, &events)?,
+                        None => Vec::new(),
+                    }
+                }
                 _ = async { match fake_events_interval.as_mut() {
                 Some(interval) => interval.tick().await,
                 None => core::future::pending().await,
@@ -3089,6 +3180,7 @@ async fn active_session(
                         x_position: last_mouse_pos.0,
                         y_position: last_mouse_pos.1,
                     }));
+                    let events = input_batcher.queue_forced(events, tokio::time::Instant::now());
                     active_stage.process_fastpath_input(&mut image, &events)?
                 } else {
                     Vec::new()
@@ -3587,6 +3679,7 @@ mod tests {
 
     #[cfg(feature = "rdpdr")]
     use ironrdp_core::encode_vec;
+    use ironrdp_pdu::input::fast_path::KeyboardFlags;
     #[cfg(feature = "rdpdr")]
     use ironrdp_rdpdr::RdpdrBackend;
     #[cfg(feature = "rdpdr")]
@@ -3600,6 +3693,70 @@ mod tests {
     use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
     #[cfg(feature = "rdpdr")]
     use ironrdp_svc::{StaticChannelSet, SvcProcessor as _};
+
+    fn mouse_move(x: u16, y: u16) -> FastPathInputEvent {
+        FastPathInputEvent::MouseEvent(MousePdu {
+            flags: PointerFlags::MOVE,
+            number_of_wheel_rotation_units: 0,
+            x_position: x,
+            y_position: y,
+        })
+    }
+
+    #[test]
+    fn input_batcher_delays_mouse_moves_until_the_minimum_interval() {
+        let start = tokio::time::Instant::now();
+        let mut batcher = FastPathInputBatcher::new(Some(Duration::from_millis(100)), start);
+
+        assert!(batcher.queue([mouse_move(1, 1)], start).is_none());
+        assert_eq!(batcher.deadline(), Some(start + Duration::from_millis(100)));
+        assert!(
+            batcher
+                .queue([mouse_move(2, 2)], start + Duration::from_millis(99))
+                .is_none()
+        );
+
+        let events = batcher
+            .flush(start + Duration::from_millis(100))
+            .expect("pending mouse movement");
+        assert_eq!(events.as_slice(), [mouse_move(1, 1), mouse_move(2, 2)]);
+        assert_eq!(batcher.deadline(), None);
+    }
+
+    #[test]
+    fn input_batcher_sends_forced_and_full_batches_immediately() {
+        let start = tokio::time::Instant::now();
+        let mut batcher = FastPathInputBatcher::new(Some(Duration::from_millis(100)), start);
+        assert!(batcher.queue([mouse_move(1, 1)], start).is_none());
+
+        let events = batcher
+            .queue(
+                [FastPathInputEvent::KeyboardEvent(KeyboardFlags::empty(), 0x1e)],
+                start + Duration::from_millis(1),
+            )
+            .expect("keyboard input forces the pending batch");
+        assert_eq!(events.len(), 2);
+
+        let events = batcher
+            .queue(
+                (0..INPUT_BATCH_EVENT_LIMIT).map(|position| {
+                    let position = u16::try_from(position).expect("test event count fits in u16");
+                    mouse_move(position, position)
+                }),
+                start + Duration::from_millis(2),
+            )
+            .expect("the native event-count threshold forces the batch");
+        assert_eq!(events.len(), INPUT_BATCH_EVENT_LIMIT);
+
+        assert!(
+            batcher
+                .queue([mouse_move(20, 20)], start + Duration::from_millis(3))
+                .is_none()
+        );
+        let events = batcher.queue_forced([mouse_move(20, 20)], start + Duration::from_millis(4));
+        assert_eq!(events.as_slice(), [mouse_move(20, 20), mouse_move(20, 20)]);
+        assert_eq!(batcher.deadline(), None);
+    }
 
     #[cfg(feature = "location")]
     #[test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1800,6 +1800,7 @@ trait AsyncReadWrite: AsyncRead + AsyncWrite {}
 impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite {}
 type UpgradedFramed = ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin + Send + Sync>>;
 
+// mstsc's input handler reads this threshold from the `EventsAtOnce` property, whose default is 10.
 const INPUT_BATCH_EVENT_LIMIT: usize = 10;
 
 struct FastPathInputBatcher {

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -152,7 +152,7 @@ impl ActiveStage {
 
         // If mouse was moved by client - we should update framebuffer to reflect new
         // pointer position
-        let mouse_pos = events.iter().find_map(|event| match event {
+        let mouse_pos = events.iter().rev().find_map(|event| match event {
             FastPathInputEvent::MouseEvent(event) => Some((event.x_position, event.y_position)),
             FastPathInputEvent::MouseEventEx(event) => Some((event.x_position, event.y_position)),
             _ => None,
@@ -1013,7 +1013,9 @@ mod tests {
     };
     use ironrdp_graphics::image_processing::PixelFormat;
     use ironrdp_pdu::gcc::MonitorFlags;
+    use ironrdp_pdu::input::MousePdu;
     use ironrdp_pdu::input::fast_path::KeyboardFlags;
+    use ironrdp_pdu::input::mouse::PointerFlags;
     use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute, PointerUpdateData};
     use ironrdp_rdpei::pdu::{PenEventPdu, RdpInputProtocolVersion, RdpeiPdu, ScReadyPdu, TouchEventPdu};
 
@@ -1107,6 +1109,59 @@ mod tests {
                 .flat_map(FastPathInput::input_events)
                 .collect::<Vec<_>>(),
             events.iter().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fastpath_input_renders_the_last_mouse_position_in_a_batch() {
+        let mut stage = ActiveStageBuilder {
+            static_channels: StaticChannelSet::new(),
+            user_channel_id: 1001,
+            io_channel_id: 1003,
+            message_channel_id: None,
+            share_id: 1,
+            compression_type: None,
+            enable_server_pointer: true,
+            pointer_software_rendering: true,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 8, 8);
+        image
+            .update_pointer(Arc::new(DecodedPointer {
+                width: 1,
+                height: 1,
+                hotspot_x: 0,
+                hotspot_y: 0,
+                bitmap_data: vec![0xff; 4],
+            }))
+            .expect("set software pointer");
+        let mouse_move = |x, y| {
+            FastPathInputEvent::MouseEvent(MousePdu {
+                flags: PointerFlags::MOVE,
+                number_of_wheel_rotation_units: 0,
+                x_position: x,
+                y_position: y,
+            })
+        };
+
+        let output = stage
+            .process_fastpath_input(&mut image, &[mouse_move(1, 1), mouse_move(5, 5)])
+            .expect("process batched mouse input");
+        let region = output
+            .iter()
+            .find_map(|output| match output {
+                ActiveStageOutput::GraphicsUpdate(region) => Some(region),
+                _ => None,
+            })
+            .expect("software pointer movement redraw");
+        assert_eq!(
+            *region,
+            InclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: 5,
+                bottom: 5,
+            }
         );
     }
 


### PR DESCRIPTION
Wire MinInputSendInterval and KeepAliveInterval through the client configuration and active session loop.

Delay mouse-only batches without delaying forced input, keep the software-rendered cursor aligned with the final batched position, and synthesize current-position keepalives using native defaults and value handling.

Keep idle timeout, cache, video, device, and security policy settings explicitly unsupported until their owning backends exist.