### PR TITLE
feat(rdpdr): redirect default Windows printer

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -332,14 +332,33 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | --- | --- |
 | Legacy RDP 6.1 through 11 host selection | The six published `MsRdpClient*NotSafeForScripting` class identifiers are accepted by `DllGetClassObject` and preserve their requested `IPersist` class identity. They are explicit backend aliases, not global COM registrations. |
 | WinForms `AxHost` lifecycle | Windowed OLE activation, focus, sizing, the inherited `IMsRdpClient` through `IMsRdpClient10` raw interfaces, and the RDM virtual channels `RDMJump`, `RDMLog`, and `RDMCmd` are supported. |
-| Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio and quality policy, clipboard, CredSSP, administrative session, load-balance routing token, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
+| Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio and quality policy, clipboard, default-printer redirection, CredSSP, administrative session, load-balance routing token, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, writable confirm-close, and worker-backed warning and auto-reconnect events are delivered on the creating apartment. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. `IMsRdpCameraRedirConfigCollection` exposes connected Windows camera metadata and offline configurations, but camera stream redirection remains unavailable. Non-filesystem device, monitor, and preferred-redirection capabilities remain unavailable. |
 | Smartcard redirection | `IMsRdpClientAdvancedSettings::RedirectSmartCards` enables WinSCard RDPDR smartcard redirection (smartcard-only sessions are valid without redirected drives). |
+| Printer redirection | `IMsRdpClientAdvancedSettings::RedirectPrinters` redirects the current user's default Windows printer through RDPDR when the remote server has the same printer driver. |
 
-The audit also identified unsupported `AdvancedSettings` members: plug-in DLL loading, idle policy, printer/port/generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, and security-layer negotiation.
+The audit also identified unsupported `AdvancedSettings` members: plug-in DLL loading, idle policy, port and generic-device redirection, persistent bitmap caching, video policy, PCB, super-pan, and security-layer negotiation.
 Their audited vtable slots use published ABI signatures, initialize getter outputs, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
 `IMsRdpClientNonScriptable8::StartWorkspaceExtension` independently returns `E_NOTIMPL` because IronRDP does not implement Microsoft workspace extensions.
+
+### Default-printer redirection
+
+Set `RedirectPrinters` to `VARIANT_TRUE` before connecting to redirect one printer.
+The control snapshots the current user's default Windows queue, announces its local driver name, and streams each remote print job to that same queue with the Windows `RAW` spooler data type.
+If no default printer exists, the connection proceeds without a printer or an otherwise-empty RDPDR channel.
+`DisableRdpdr` overrides this setting, and changing it after connection settings are sealed returns `E_FAIL`.
+
+The remote server must permit printer redirection and have a compatible driver registered under the announced name.
+IronRDP does not implement Easy Print/XPS negotiation, printer cache PDUs, multiple-printer enumeration, printer hotplug, or printer entries in `IMsRdpDeviceCollection`.
+Print operations run on a bounded worker, allow at most 16 concurrent jobs, 16 MiB per write, and 128 MiB per job, reject nonempty create paths, and abort incomplete jobs on write failure, reset, reconnect, or teardown.
+
+To opt in to the ignored smoke test, confirm that creating a real empty job on the current user's default queue is acceptable, then run:
+
+```powershell
+$env:IRONRDP_RDPDR_PRINTER_SMOKE = "1"
+cargo test -p ironrdp-rdpdr-native authorized_default_printer_smoke -- --ignored
+```
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
 published `IMsTscAxEvents` IID `{336D5562-EFA8-482E-8CB3-C5C0FC7A7DB6}`. Lifecycle events are delivered
@@ -867,8 +886,8 @@ The worker translates supported Automation settings into `ironrdp-client::Config
 Connection points retain sinks through `Advise`/`Unadvise`, enumerate correctly, and query the supplied
 sink for the event interface IID before retaining its `IDispatch`.
 
-This is an Automation, lifecycle, hosting, framebuffer, basic input, RemoteApp projection, persistence, static virtual-channel, and bounded read-only OLE clipboard-snapshot foundation.
-It does not implement writable or file-backed OLE clipboard exchange, monikers, non-filesystem RDPDR device redirection, or arbitrary persisted designer state.
+This is an Automation, lifecycle, hosting, framebuffer, basic input, RemoteApp projection, persistence, static virtual-channel, default-printer redirection, and bounded read-only OLE clipboard-snapshot foundation.
+It does not implement writable or file-backed OLE clipboard exchange, monikers, serial/parallel or generic PnP/USB redirection, or arbitrary persisted designer state.
 Those contracts must be added as exact ABI implementations before advertising their individual methods as supported.
 
 [MS-RDPEFS sections 3.2.5.1.9 and 3.2.5.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -206,6 +206,40 @@ const MAX_MODERN_SNAPSHOT_RGB_BYTES: usize = 16 * 1024 * 1024;
 const ACTIVEX_DVC_PLUGIN_OPT_IN: &str = "IRONRDP_ACTIVEX_ENABLE_DVC_PLUGINS";
 const MAX_ACTIVEX_DVC_PLUGINS: usize = 16;
 
+struct ActiveXPrinterWorkerGuard {
+    module_raw: isize,
+    active: bool,
+}
+
+impl Drop for ActiveXPrinterWorkerGuard {
+    fn drop(&mut self) {
+        if self.active {
+            com::release_worker();
+            com::release_module_reference(HMODULE(self.module_raw as *mut c_void));
+        }
+    }
+}
+
+impl ironrdp_rdpdr_native::RdpdrWorkerThreadGuard for ActiveXPrinterWorkerGuard {
+    fn exit(self: Box<Self>) -> ! {
+        let this = ManuallyDrop::new(self);
+        let module = HMODULE(this.module_raw as *mut c_void);
+        com::release_worker();
+        unsafe { com::release_module_and_exit_worker(module) }
+    }
+}
+
+fn acquire_activex_printer_worker_guard() -> ironrdp_rdpdr_native::RdpdrWorkerThreadGuardResult {
+    let module = com::retain_module_for_worker().map_err(|error| {
+        Box::new(std::io::Error::other(error.to_string())) as Box<dyn core::error::Error + Send + Sync>
+    })?;
+    com::add_worker();
+    Ok(Box::new(ActiveXPrinterWorkerGuard {
+        module_raw: module.0 as isize,
+        active: true,
+    }))
+}
+
 #[derive(Default)]
 struct RemoteApplicationConfiguration {
     enabled: bool,
@@ -1389,6 +1423,7 @@ struct CompatibilitySettings {
     redirect_webauthn: bool,
     redirect_drives: bool,
     redirect_dynamic_drives: bool,
+    redirect_printers: bool,
     redirect_smart_cards: bool,
     disable_rdpdr: bool,
     drive_catalog: Rc<RefCell<DriveCatalog>>,
@@ -1471,6 +1506,7 @@ impl Default for CompatibilitySettings {
             redirect_webauthn: true,
             redirect_drives: false,
             redirect_dynamic_drives: false,
+            redirect_printers: false,
             redirect_smart_cards: false,
             disable_rdpdr: false,
             drive_catalog: Rc::new(RefCell::new(DriveCatalog::new())),
@@ -2531,7 +2567,6 @@ advanced_put_not_implemented!(
     (7, advanced_put_plugin_dlls, Bstr),
     (93, advanced_put_bitmap_persistence, i32),
     (95, advanced_put_minutes_to_idle_timeout, i32),
-    (116, advanced_put_redirect_printers, i16),
     (118, advanced_put_redirect_ports, i16),
     (150, advanced_put_redirect_devices, i16),
     (161, advanced_put_pcb, Bstr),
@@ -2543,7 +2578,6 @@ advanced_put_not_implemented!(
 advanced_get_not_implemented!(
     (94, advanced_get_bitmap_persistence, i32),
     (96, advanced_get_minutes_to_idle_timeout, i32),
-    (117, advanced_get_redirect_printers, i16),
     (119, advanced_get_redirect_ports, i16),
     (151, advanced_get_redirect_devices, i16),
     (174, advanced_get_video_playback_mode, u32),
@@ -3183,6 +3217,34 @@ unsafe extern "system" fn advanced_get_redirect_drives(this: *mut c_void, value:
     write_out(
         value,
         if object.settings.borrow().redirect_drives {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        },
+    )
+    .map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_redirect_printers(this: *mut c_void, value: i16) -> HRESULT {
+    let value = match normalize_variant_bool(value) {
+        Ok(value) => value == VARIANT_TRUE.0,
+        Err(error) => return error.code(),
+    };
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.redirect_printers = value;
+    mark_compatibility_persistence_dirty(&settings);
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_redirect_printers(this: *mut c_void, value: *mut i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(
+        value,
+        if object.settings.borrow().redirect_printers {
             VARIANT_TRUE.0
         } else {
             VARIANT_FALSE.0
@@ -8016,6 +8078,7 @@ fn active_x_property_snapshot(settings: &Settings, compatibility: &Compatibility
     );
     properties.insert("redirectclipboard", compatibility.redirect_clipboard);
     properties.insert("redirectwebauthn", compatibility.redirect_webauthn);
+    properties.insert("redirectprinters", compatibility.redirect_printers);
     properties.insert("ironrdp_smartcard", compatibility.redirect_smart_cards);
     properties.insert("compression", compatibility.compression.unwrap_or(true));
     properties
@@ -11396,6 +11459,7 @@ impl Control {
         let warn_about_credentials = compatibility.warn_about_sending_credentials;
         let warn_about_clipboard = clipboard && compatibility.warn_about_clipboard_redirection;
         let redirect_dynamic_drives = !compatibility.disable_rdpdr && compatibility.redirect_dynamic_drives;
+        let redirect_printers = !compatibility.disable_rdpdr && compatibility.redirect_printers;
         let (configured_drives, initial_drive_ids) = if compatibility.disable_rdpdr {
             (Vec::new(), Vec::new())
         } else {
@@ -11405,7 +11469,11 @@ impl Control {
             (catalog.configured_drives()?, initial_drive_ids)
         };
         let redirect_smart_cards = !compatibility.disable_rdpdr && compatibility.redirect_smart_cards;
-        let rdpdr_factory = if initial_drive_ids.is_empty() && !redirect_dynamic_drives && !redirect_smart_cards {
+        let rdpdr_factory = if initial_drive_ids.is_empty()
+            && !redirect_dynamic_drives
+            && !redirect_printers
+            && !redirect_smart_cards
+        {
             None
         } else {
             Some(
@@ -11415,6 +11483,10 @@ impl Control {
                 )
                 .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?
                 .with_dynamic_drives(redirect_dynamic_drives)
+                .with_default_printer(redirect_printers)
+                .with_worker_thread_hooks(ironrdp_rdpdr_native::RdpdrWorkerThreadHooks::new(
+                    acquire_activex_printer_worker_guard,
+                ))
                 .with_smartcard(redirect_smart_cards),
             )
         };
@@ -18975,6 +19047,23 @@ mod tests {
             S_OK
         );
         assert_eq!(redirect_drives, VARIANT_TRUE.0);
+
+        assert_eq!(unsafe { advanced_put_redirect_printers(this, VARIANT_TRUE.0) }, S_OK);
+        let mut redirect_printers = VARIANT_FALSE.0;
+        assert_eq!(
+            unsafe { advanced_get_redirect_printers(this, &mut redirect_printers) },
+            S_OK
+        );
+        assert_eq!(redirect_printers, VARIANT_TRUE.0);
+        assert_eq!(unsafe { advanced_put_redirect_printers(this, 1) }, E_INVALIDARG);
+        assert_eq!(
+            unsafe { advanced_get_redirect_printers(this, ptr::null_mut()) },
+            E_POINTER
+        );
+        settings.borrow_mut().connection_settings_sealed = true;
+        assert_eq!(unsafe { advanced_put_redirect_printers(this, VARIANT_FALSE.0) }, E_FAIL);
+        assert!(settings.borrow().redirect_printers);
+        settings.borrow_mut().connection_settings_sealed = false;
 
         assert_eq!(unsafe { advanced_put_redirect_smart_cards(this, VARIANT_TRUE.0) }, S_OK);
         let mut redirect_smart_cards = VARIANT_FALSE.0;

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -221,9 +221,10 @@ impl Drop for ActiveXPrinterWorkerGuard {
 }
 
 impl ironrdp_rdpdr_native::RdpdrWorkerThreadGuard for ActiveXPrinterWorkerGuard {
-    fn exit(self: Box<Self>) -> ! {
-        let this = ManuallyDrop::new(self);
-        let module = HMODULE(this.module_raw as *mut c_void);
+    fn exit(mut self: Box<Self>) -> ! {
+        let module = HMODULE(self.module_raw as *mut c_void);
+        self.active = false;
+        drop(self);
         com::release_worker();
         unsafe { com::release_module_and_exit_worker(module) }
     }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -38,7 +38,9 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 use ironrdp_pdu::pdu_other_err;
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 #[cfg(feature = "rdpdr")]
-pub use ironrdp_rdpdr::backend::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
+pub use ironrdp_rdpdr::backend::{
+    RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive, RdpdrPrinter,
+};
 use ironrdp_rdpei::RdpeiClient;
 use ironrdp_rdpei::pdu::TouchEventPdu;
 #[cfg(feature = "location")]
@@ -1325,6 +1327,7 @@ fn build_rdpdr_channel(
         .build_rdpdr_backend()
         .map_err(|error| ironrdp_connector::custom_err!("build RDPDR backend", RdpdrBackendBuildError(error)))?;
     let drive_hotplug = allow_drives && product.drive_hotplug();
+    let printer = product.printer().cloned();
     let (backend, initial_drives) = product.into_parts();
     // Gateway drive restrictions do not apply to smartcard redirection, which shares RDPDR.
     let initial_drives = if allow_drives { initial_drives } else { Vec::new() };
@@ -1334,7 +1337,23 @@ fn build_rdpdr_channel(
     #[cfg(not(feature = "smartcard"))]
     let smartcard = false;
 
-    if initial_drives.is_empty() && !smartcard && !drive_hotplug {
+    if let Some(printer) = &printer {
+        let collides_with_drive = initial_drives
+            .iter()
+            .any(|drive| drive.device_id() == printer.device_id());
+        let collides_with_smartcard = smartcard && printer.device_id() == 0;
+        if collides_with_drive || collides_with_smartcard {
+            return Err(ironrdp_connector::custom_err!(
+                "build RDPDR channel",
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "RDPDR printer device ID is already configured"
+                )
+            ));
+        }
+    }
+
+    if initial_drives.is_empty() && !smartcard && !drive_hotplug && printer.is_none() {
         return Ok(None);
     }
 
@@ -1350,6 +1369,10 @@ fn build_rdpdr_channel(
     let mut rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned());
     if !initial_drives.is_empty() || drive_hotplug {
         rdpdr_channel = rdpdr_channel.with_drives(Some(initial_drives));
+    }
+    if let Some(printer) = printer {
+        let (device_id, name, driver_name, network) = printer.into_parts();
+        rdpdr_channel = rdpdr_channel.with_printer_driver_and_network(device_id, name, driver_name, network);
     }
 
     #[cfg(feature = "smartcard")]
@@ -3861,6 +3884,7 @@ mod tests {
         builds: AtomicUsize,
         initial_drives: Vec<RdpdrDrive>,
         drive_hotplug: bool,
+        printer: Option<RdpdrPrinter>,
     }
 
     #[cfg(feature = "rdpdr")]
@@ -3870,11 +3894,17 @@ mod tests {
                 builds: AtomicUsize::new(0),
                 initial_drives,
                 drive_hotplug: false,
+                printer: None,
             }
         }
 
         fn with_drive_hotplug(mut self) -> Self {
             self.drive_hotplug = true;
+            self
+        }
+
+        fn with_printer(mut self, printer: RdpdrPrinter) -> Self {
+            self.printer = Some(printer);
             self
         }
     }
@@ -3883,10 +3913,13 @@ mod tests {
     impl RdpdrBackendFactory for CountingRdpdrFactory {
         fn build_rdpdr_backend(&self) -> RdpdrBackendFactoryResult<RdpdrBackendProduct> {
             let instance = self.builds.fetch_add(1, Ordering::SeqCst) + 1;
-            Ok(
+            let mut product =
                 RdpdrBackendProduct::new(Box::new(TestRdpdrBackend::new(instance)), self.initial_drives.clone())
-                    .with_drive_hotplug(self.drive_hotplug),
-            )
+                    .with_drive_hotplug(self.drive_hotplug);
+            if let Some(printer) = &self.printer {
+                product = product.with_printer(printer.clone());
+            }
+            Ok(product)
         }
     }
 
@@ -4110,6 +4143,90 @@ mod tests {
                 .is_none()
         );
         assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "rdpdr")]
+    #[test]
+    fn printer_only_rdpdr_product_attaches_the_channel() {
+        let factory = CountingRdpdrFactory::new(Vec::new()).with_printer(
+            RdpdrPrinter::new(42, "Office Printer".to_owned(), "Office Driver".to_owned()).with_network(false),
+        );
+        let config = crate::config::RdpdrConfig {
+            enabled: true,
+            #[cfg(feature = "smartcard")]
+            smartcard: false,
+        };
+
+        let mut rdpdr = build_rdpdr_channel(Some(&factory), &config, true)
+            .expect("printer-only RDPDR product should build")
+            .expect("printer metadata keeps the RDPDR channel attached");
+        let client_id = 0x1234_5678;
+        rdpdr
+            .process(
+                &encode_vec(&RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
+                    version_major: 1,
+                    version_minor: VERSION_MINOR_12,
+                    client_id,
+                    kind: VersionAndIdPduKind::ServerAnnounceRequest,
+                }))
+                .expect("encode server announce"),
+            )
+            .expect("process server announce");
+        rdpdr
+            .process(
+                &encode_vec(&RdpdrPdu::CoreCapability(CoreCapability {
+                    capabilities: vec![CapabilityMessage::new_general(0), CapabilityMessage::new_printer()],
+                    kind: CoreCapabilityKind::ServerCoreCapabilityRequest,
+                }))
+                .expect("encode server capability"),
+            )
+            .expect("process server capability");
+        assert!(
+            rdpdr
+                .process(
+                    &encode_vec(&RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
+                        version_major: 1,
+                        version_minor: VERSION_MINOR_12,
+                        client_id,
+                        kind: VersionAndIdPduKind::ServerClientIdConfirm,
+                    }))
+                    .expect("encode client ID confirm"),
+                )
+                .expect("process client ID confirm")
+                .is_empty()
+        );
+
+        let announcements = rdpdr
+            .process(&encode_vec(&RdpdrPdu::UserLoggedon).expect("encode user logged on"))
+            .expect("process user logged on");
+        assert_eq!(announcements.len(), 1);
+        let wire = announcements[0]
+            .encode_unframed_pdu()
+            .expect("encode printer announcement");
+        assert_eq!(
+            u32::from_le_bytes(wire[8..12].try_into().unwrap()),
+            u32::from(DeviceType::Print)
+        );
+        assert_eq!(u32::from_le_bytes(wire[12..16].try_into().unwrap()), 42);
+        assert_eq!(
+            u32::from_le_bytes(wire[28..32].try_into().unwrap()),
+            ironrdp_rdpdr::pdu::efs::RDPDR_PRINTER_ANNOUNCE_FLAG_DEFAULTPRINTER
+        );
+    }
+
+    #[cfg(feature = "rdpdr")]
+    #[test]
+    fn rdpdr_rejects_duplicate_printer_and_drive_device_ids() {
+        let factory = CountingRdpdrFactory::new(vec![RdpdrDrive::new(42, "drive".to_owned())]).with_printer(
+            RdpdrPrinter::new(42, "Office Printer".to_owned(), "Office Driver".to_owned()),
+        );
+        let config = crate::config::RdpdrConfig {
+            enabled: true,
+            #[cfg(feature = "smartcard")]
+            smartcard: false,
+        };
+
+        assert!(build_rdpdr_channel(Some(&factory), &config, true).is_err());
     }
 
     #[cfg(feature = "rdpdr")]

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -29,15 +29,4 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 tracing = { version = "0.1", features = ["log"] }
-windows = { version = "0.62", features = [
-    "Wdk_Foundation",
-    "Wdk_Storage_FileSystem",
-    "Wdk_System_SystemServices",
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Security_Authorization",
-    "Win32_Security_Credentials",
-    "Win32_Storage_FileSystem",
-    "Win32_System_IO",
-    "Win32_System_Threading",
-] }
+windows = { version = "0.62", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_SystemServices", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Graphics_Printing", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Credentials", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -4,34 +4,16 @@ Native backend building blocks for the IronRDP RDPDR static channel.
 
 - On macOS and Linux, the crate exports the existing `nix::backend` filesystem
   backend.
-- On Windows, the crate contains the native, handle-relative filesystem
-  foundation used for drive redirection. It validates every protocol path
-  before resolving it below an opened volume root, and it rejects DOS device
-  aliases and reparse-point traversal. Its static filesystem support includes
-  create/open with initial allocation and validated delete-on-close, close,
-  flush, bounded synchronous offset I/O, basic file-information queries, actual
-  selected-volume information, basic metadata, EOF/allocation, delete-on-close
-  and confined rename changes, handle-bound security descriptor queries and
-  validated descriptor updates, alternate-data-stream information, plus
-  one-entry-at-a-time directory enumeration. Waiting byte-range locks and
-  directory-change notifications complete from bounded, cancellable worker
-  operations; close, reset, and device removal cancel outstanding work. Device
-  Control is deny-by-default: supported filesystem controls are the
-  handle-bound `FSCTL_CREATE_OR_GET_OBJECT_ID` with an empty input and fixed
-  64-byte output, plus the read-only `FSCTL_GET_COMPRESSION`,
-  `FSCTL_GET_INTEGRITY_INFORMATION`, and `FSCTL_QUERY_ALLOCATED_RANGES`, all
-  with validated, bounded buffers.
-  - Smartcard-only products are valid when the channel is configured with `ironrdp_rdpdr::Rdpdr::with_smartcard(0)`.
-        The Windows backend implements a WinSCard path for MS-RDPESC IOCTLs: core logon ops
-        (context, readers, status-change, connect/transmit/status/state) plus extended calls
-        (LocateCards/LocateCardsByATR, Control, Get/SetAttrib, GetTransmitCount, Read/WriteCache,
-        GetReaderIcon, GetDeviceTypeId, and ContextAndString/TwoString reader-group admin).
-        ANSI IOCTLs are upgraded to UTF-16 and executed through WinSCard `*W` APIs; StatusA/List*A
-        replies keep ANSI charset on the wire. Buffer probes follow the same NULL/INSUFFICIENT_BUFFER
-        discipline as the core path. Product wiring (daemon/agent/viewer/ActiveX) remains separate.
+- On Windows, the crate contains the native, handle-relative filesystem foundation used for drive redirection.
+  It validates every protocol path before resolving it below an opened volume root, and it rejects DOS device aliases and reparse-point traversal.
+  Its static filesystem support includes create/open, close, flush, bounded offset I/O, file and volume information, metadata changes, security descriptors, alternate data streams, directory enumeration, locks, notifications, and deny-by-default device controls.
+  Smartcard-only products are valid when the channel is configured with `ironrdp_rdpdr::Rdpdr::with_smartcard(0)`.
+  The WinSCard path implements core and extended MS-RDPESC calls, preserves ANSI wire variants, and follows Windows buffer-probe rules.
+  `WindowsRdpdrBackendFactory::with_default_printer(true)` discovers the current user's default queue, announces its local driver, and spools bounded `RAW` jobs on a worker thread.
+  Default-printer redirection requires a matching remote driver and does not implement Easy Print/XPS, multiple printers, cache PDUs, or hotplug.
 
 The Windows implementation is intentionally layered so protocol code remains
 platform independent in `ironrdp-rdpdr`.
 
-`WindowsRdpdrBackendFactory` configures zero or more `RedirectedDrive`s.
+`WindowsRdpdrBackendFactory` configures zero or more `RedirectedDrive`s and optional default-printer discovery.
 Multi-drive registry management remains outside this native backend.

--- a/crates/ironrdp-rdpdr-native/src/lib.rs
+++ b/crates/ironrdp-rdpdr-native/src/lib.rs
@@ -17,4 +17,7 @@ pub use nix::backend;
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub use windows::{RedirectedDrive, RedirectedDriveError, WindowsRdpdrBackend, WindowsRdpdrBackendFactory};
+pub use windows::{
+    RdpdrWorkerThreadGuard, RdpdrWorkerThreadGuardResult, RdpdrWorkerThreadHooks, RedirectedDrive,
+    RedirectedDriveError, WindowsRdpdrBackend, WindowsRdpdrBackendFactory,
+};

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use ironrdp_core::impl_as_any;
 use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_rdpdr::pdu::efs::{
-    AnyIoCtlCode, DecodedDeviceControlRequest, DeviceControlRequest, ServerDeviceAnnounceResponse, ServerDriveIoRequest,
+    AnyIoCtlCode, DecodedDeviceControlRequest, DeviceControlRequest, PrinterIoRequest, ServerDeviceAnnounceResponse,
+    ServerDriveIoRequest,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_svc::SvcMessage;
@@ -14,6 +16,7 @@ use super::file_table::FileTable;
 use super::handles::{FileHandle, RootDirectory};
 use super::path::RelativePath;
 use super::pending::DeferredOperations;
+use super::printer::{PrinterWorker, RdpdrWorkerThreadHooks};
 use super::scard::ScardSession;
 use super::status::from_open_directory;
 use super::{control, directory, file, locks, security, volume};
@@ -32,6 +35,9 @@ pub struct WindowsRdpdrBackend {
     pub(super) open_files: FileTable<OpenFile>,
     deferred_operations: DeferredOperations,
     scard: ScardSession,
+    configured_printer: Option<ironrdp_rdpdr::RdpdrPrinter>,
+    printer_worker: Option<Mutex<PrinterWorker>>,
+    worker_thread_hooks: Option<RdpdrWorkerThreadHooks>,
 }
 
 impl WindowsRdpdrBackend {
@@ -41,12 +47,23 @@ impl WindowsRdpdrBackend {
     }
 
     pub(crate) fn from_drives(drives: Vec<RedirectedDrive>) -> Self {
+        Self::from_configuration(drives, None, None)
+    }
+
+    pub(super) fn from_configuration(
+        drives: Vec<RedirectedDrive>,
+        configured_printer: Option<ironrdp_rdpdr::RdpdrPrinter>,
+        worker_thread_hooks: Option<RdpdrWorkerThreadHooks>,
+    ) -> Self {
         Self {
             drives: drives.into_iter().map(|drive| (drive.device_id(), drive)).collect(),
             roots: HashMap::new(),
             open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
             deferred_operations: DeferredOperations::new(),
             scard: ScardSession::new(),
+            configured_printer,
+            printer_worker: None,
+            worker_thread_hooks,
         }
     }
 
@@ -154,6 +171,12 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         self.scard.reset();
         self.open_files.clear();
         self.roots.clear();
+        if let Some(worker) = &mut self.printer_worker {
+            worker
+                .get_mut()
+                .map_err(|_| pdu_other_err!("Windows printer worker lock is poisoned"))?
+                .restart()?;
+        }
         Ok(())
     }
 
@@ -207,9 +230,50 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         control::handle(self, req.request, &req.input_buffer)
     }
 
+    fn handle_printer_io_request(&mut self, req: PrinterIoRequest) -> PduResult<Vec<SvcMessage>> {
+        if self.printer_worker.is_none() {
+            let printer = self
+                .configured_printer
+                .clone()
+                .ok_or_else(|| pdu_other_err!("printer IRP reached an unconfigured Windows RDPDR backend"))?;
+            self.printer_worker = Some(Mutex::new(PrinterWorker::new(printer, self.worker_thread_hooks)?));
+        }
+        self.printer_worker
+            .as_mut()
+            .expect("printer worker was initialized")
+            .get_mut()
+            .map_err(|_| pdu_other_err!("Windows printer worker lock is poisoned"))?
+            .handle(req)
+    }
+
+    fn reject_printer_write(&mut self, req: ironrdp_rdpdr::pdu::efs::DeviceIoRequest) -> PduResult<Vec<SvcMessage>> {
+        if self.printer_worker.is_none() {
+            let printer = self
+                .configured_printer
+                .clone()
+                .ok_or_else(|| pdu_other_err!("printer write reached an unconfigured Windows RDPDR backend"))?;
+            self.printer_worker = Some(Mutex::new(PrinterWorker::new(printer, self.worker_thread_hooks)?));
+        }
+        Ok(self
+            .printer_worker
+            .as_mut()
+            .expect("printer worker was initialized")
+            .get_mut()
+            .map_err(|_| pdu_other_err!("Windows printer worker lock is poisoned"))?
+            .reject_write(req))
+    }
+
     fn poll_deferred_messages(&mut self) -> PduResult<Vec<SvcMessage>> {
         let mut messages = self.deferred_operations.poll();
         messages.extend(self.scard.poll());
+        if let Some(worker) = &mut self.printer_worker {
+            messages.extend(
+                worker
+                    .get_mut()
+                    .map_err(|_| pdu_other_err!("Windows printer worker lock is poisoned"))?
+                    .poll()?,
+            );
+        }
         Ok(messages)
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -4,9 +4,13 @@ use core::fmt;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use ironrdp_rdpdr::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
+use ironrdp_rdpdr::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive, RdpdrPrinter};
+use tracing::warn;
 
 use super::backend::WindowsRdpdrBackend;
+use super::printer::{RdpdrWorkerThreadHooks, discover_default_printer};
+
+const DEFAULT_PRINTER_DEVICE_ID: u32 = u32::MAX - 1;
 
 /// Immutable logical-volume definition selected for Windows RDPDR redirection.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -103,6 +107,8 @@ pub struct WindowsRdpdrBackendFactory {
     initial_drive_ids: Vec<u32>,
     dynamic_drives: bool,
     smartcard: bool,
+    default_printer: bool,
+    worker_thread_hooks: Option<RdpdrWorkerThreadHooks>,
 }
 
 impl WindowsRdpdrBackendFactory {
@@ -115,6 +121,8 @@ impl WindowsRdpdrBackendFactory {
             initial_drive_ids: vec![device_id],
             dynamic_drives: false,
             smartcard: false,
+            default_printer: false,
+            worker_thread_hooks: None,
         }
     }
 
@@ -153,6 +161,8 @@ impl WindowsRdpdrBackendFactory {
             initial_drive_ids,
             dynamic_drives: false,
             smartcard: false,
+            default_printer: false,
+            worker_thread_hooks: None,
         })
     }
 
@@ -183,6 +193,26 @@ impl WindowsRdpdrBackendFactory {
         self.smartcard
     }
 
+    /// Enables default-printer discovery when [`RdpdrBackendFactory::build_rdpdr_backend`] builds the product.
+    #[must_use]
+    pub fn with_default_printer(mut self, enabled: bool) -> Self {
+        self.default_printer = enabled;
+        self
+    }
+
+    /// Returns whether products request default-printer discovery.
+    #[must_use]
+    pub fn default_printer(&self) -> bool {
+        self.default_printer
+    }
+
+    /// Configures host lifetime hooks for native worker threads.
+    #[must_use]
+    pub fn with_worker_thread_hooks(mut self, hooks: RdpdrWorkerThreadHooks) -> Self {
+        self.worker_thread_hooks = Some(hooks);
+        self
+    }
+
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
     #[must_use]
     pub fn initial_drives(&self) -> Vec<(u32, String)> {
@@ -208,20 +238,67 @@ impl WindowsRdpdrBackendFactory {
     pub fn build(&self) -> WindowsRdpdrBackend {
         WindowsRdpdrBackend::from_drives(self.drives.clone())
     }
-}
 
-impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
-    fn build_rdpdr_backend(&self) -> RdpdrBackendFactoryResult<RdpdrBackendProduct> {
-        Ok(RdpdrBackendProduct::new(
-            Box::new(self.build()),
+    fn build_product(&self, printer: Option<RdpdrPrinter>) -> RdpdrBackendProduct {
+        let mut product = RdpdrBackendProduct::new(
+            Box::new(WindowsRdpdrBackend::from_configuration(
+                self.drives.clone(),
+                printer.clone(),
+                self.worker_thread_hooks,
+            )),
             self.initial_drives()
                 .into_iter()
                 .map(|(device_id, name)| RdpdrDrive::new(device_id, name))
                 .collect(),
         )
-        .with_drive_hotplug(self.dynamic_drives))
+        .with_drive_hotplug(self.dynamic_drives);
+        if let Some(printer) = printer {
+            product = product.with_printer(printer);
+        }
+        product
     }
 }
+
+impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
+    fn build_rdpdr_backend(&self) -> RdpdrBackendFactoryResult<RdpdrBackendProduct> {
+        let printer = if self.default_printer {
+            match discover_default_printer(self.default_printer_device_id()?) {
+                Ok(printer) => printer,
+                Err(error) => {
+                    warn!(%error, "Default printer discovery failed; continuing without printer redirection");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        Ok(self.build_product(printer))
+    }
+}
+
+impl WindowsRdpdrBackendFactory {
+    fn default_printer_device_id(&self) -> Result<u32, NoAvailablePrinterDeviceId> {
+        let mut device_id = DEFAULT_PRINTER_DEVICE_ID;
+        while self.drives.iter().any(|drive| drive.device_id() == device_id) {
+            device_id = device_id
+                .checked_sub(1)
+                .filter(|device_id| *device_id != 0)
+                .ok_or(NoAvailablePrinterDeviceId)?;
+        }
+        Ok(device_id)
+    }
+}
+
+#[derive(Debug)]
+struct NoAvailablePrinterDeviceId;
+
+impl fmt::Display for NoAvailablePrinterDeviceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("no RDPDR device ID is available for the default printer")
+    }
+}
+
+impl core::error::Error for NoAvailablePrinterDeviceId {}
 
 /// Invalid selected-drive factory configuration.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -322,6 +399,34 @@ mod tests {
     }
 
     #[test]
+    fn factory_tracks_default_printer_enablement() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new())
+            .expect("empty drive list is valid")
+            .with_default_printer(true);
+        assert!(factory.default_printer());
+        assert!(!factory.with_default_printer(false).default_printer());
+    }
+
+    #[test]
+    fn factory_product_preserves_default_printer_metadata() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new()).expect("empty drive list is valid");
+        let product = factory.build_product(Some(
+            RdpdrPrinter::new(
+                DEFAULT_PRINTER_DEVICE_ID,
+                "Office Printer".to_owned(),
+                "Office Driver".to_owned(),
+            )
+            .with_network(false),
+        ));
+
+        let printer = product.printer().expect("printer metadata is present");
+        assert_eq!(printer.device_id(), DEFAULT_PRINTER_DEVICE_ID);
+        assert_eq!(printer.name(), "Office Printer");
+        assert_eq!(printer.driver_name(), "Office Driver");
+        assert!(!printer.network());
+    }
+
+    #[test]
     fn factory_tracks_dynamic_drive_enablement() {
         let product = WindowsRdpdrBackendFactory::from_drives(Vec::new())
             .expect("empty drive list is valid")
@@ -355,5 +460,19 @@ mod tests {
             WindowsRdpdrBackendFactory::from_drive_configuration(vec![drive], vec![2]),
             Err(RedirectedDriveFactoryError::UnconfiguredInitialSelection(2))
         ));
+    }
+
+    #[test]
+    fn printer_device_id_avoids_configured_drives() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(vec![
+            RedirectedDrive::new(DEFAULT_PRINTER_DEVICE_ID, "reserved", r"C:\", false)
+                .expect("all nonzero drive IDs are valid"),
+        ])
+        .expect("drive configuration is valid");
+
+        assert_eq!(
+            factory.default_printer_device_id().unwrap(),
+            DEFAULT_PRINTER_DEVICE_ID - 1
+        );
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/mod.rs
@@ -8,6 +8,7 @@ mod handles;
 mod locks;
 mod path;
 mod pending;
+mod printer;
 mod scard;
 mod security;
 mod status;
@@ -15,3 +16,4 @@ mod volume;
 
 pub use backend::WindowsRdpdrBackend;
 pub use factory::{RedirectedDrive, RedirectedDriveError, WindowsRdpdrBackendFactory};
+pub use printer::{RdpdrWorkerThreadGuard, RdpdrWorkerThreadGuardResult, RdpdrWorkerThreadHooks};

--- a/crates/ironrdp-rdpdr-native/src/windows/printer.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/printer.rs
@@ -513,7 +513,7 @@ impl PrinterWorker {
 
     pub(super) fn poll(&mut self) -> PduResult<Vec<SvcMessage>> {
         if self.completion_disconnected {
-            return Ok(Vec::new());
+            return Err(pdu_other_err!("Windows printer worker completion channel disconnected"));
         }
         let mut messages = Vec::new();
         loop {
@@ -522,8 +522,11 @@ impl PrinterWorker {
                 Err(TryRecvError::Empty) => return Ok(messages),
                 Err(TryRecvError::Disconnected) => {
                     warn!("Windows printer worker completion channel disconnected");
-                    self.completion_disconnected = true;
                     self.request_stop();
+                    if messages.is_empty() {
+                        return Err(pdu_other_err!("Windows printer worker completion channel disconnected"));
+                    }
+                    self.completion_disconnected = true;
                     return Ok(messages);
                 }
             }
@@ -975,6 +978,21 @@ mod tests {
             assert!(Instant::now() < deadline, "printer worker shutdown timed out");
             std::thread::yield_now();
         }
+    }
+
+    #[test]
+    fn disconnected_worker_propagates_an_error() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+        worker.request_stop();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !worker.finished.load(std::sync::atomic::Ordering::Acquire) {
+            assert!(Instant::now() < deadline, "printer worker shutdown timed out");
+            std::thread::yield_now();
+        }
+
+        assert!(worker.poll().is_err());
     }
 
     #[test]

--- a/crates/ironrdp-rdpdr-native/src/windows/printer.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/printer.rs
@@ -1,0 +1,1005 @@
+use core::ffi::c_void;
+use core::fmt;
+use core::mem::size_of;
+use core::slice;
+use std::collections::{HashMap, HashSet};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
+use std::time::{Duration, Instant};
+
+use ironrdp_pdu::{PduResult, pdu_other_err};
+use ironrdp_rdpdr::RdpdrPrinter;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    DeviceCloseResponse, DeviceCreateRequest, DeviceCreateResponse, DeviceIoResponse, DeviceWriteRequest,
+    DeviceWriteResponse, Information, NtStatus, PrinterIoRequest,
+};
+use ironrdp_svc::SvcMessage;
+use tracing::{debug, warn};
+use windows::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_INSUFFICIENT_BUFFER, GetLastError};
+use windows::Win32::Graphics::Printing::{
+    AbortPrinter, ClosePrinter, DOC_INFO_1W, EndDocPrinter, GetDefaultPrinterW, GetPrinterW, OpenPrinterW,
+    PRINTER_ATTRIBUTE_NETWORK, PRINTER_HANDLE, PRINTER_INFO_2W, StartDocPrinterW, WritePrinter,
+};
+use windows::core::{Error, HRESULT, PCWSTR, PWSTR};
+
+const MAX_PRINTER_NAME_UTF16_UNITS: usize = 1_024;
+const MAX_PRINTER_METADATA_BYTES: usize = 1024 * 1024;
+const MAX_OPEN_PRINT_JOBS: usize = 16;
+const MAX_PRINT_JOB_BYTES: usize = 128 * 1024 * 1024;
+const PRINTER_COMMAND_QUEUE_CAPACITY: usize = 16;
+const PRINTER_RESET_WAIT: Duration = Duration::from_millis(100);
+
+/// Guard that releases a host lifetime pin while atomically exiting the worker thread.
+pub trait RdpdrWorkerThreadGuard: Send {
+    /// Releases the host lifetime pin and exits the current worker thread atomically.
+    fn exit(self: Box<Self>) -> !;
+}
+
+/// Result of acquiring a host lifetime guard before spawning an RDPDR worker.
+pub type RdpdrWorkerThreadGuardResult =
+    Result<Box<dyn RdpdrWorkerThreadGuard>, Box<dyn core::error::Error + Send + Sync>>;
+
+/// Acquires a host lifetime guard before a native RDPDR worker thread starts.
+#[derive(Clone, Copy, Debug)]
+pub struct RdpdrWorkerThreadHooks {
+    acquire: fn() -> RdpdrWorkerThreadGuardResult,
+}
+
+impl RdpdrWorkerThreadHooks {
+    /// Creates a worker-lifetime hook.
+    pub fn new(acquire: fn() -> RdpdrWorkerThreadGuardResult) -> Self {
+        Self { acquire }
+    }
+
+    fn acquire(&self) -> RdpdrWorkerThreadGuardResult {
+        (self.acquire)()
+    }
+}
+
+pub(super) fn discover_default_printer(device_id: u32) -> Result<Option<RdpdrPrinter>, DefaultPrinterError> {
+    let queue_name = match default_printer_name()? {
+        Some(name) => name,
+        None => return Ok(None),
+    };
+    let (driver_name, network) = printer_driver(&queue_name)?;
+
+    validate_printer_name(&queue_name)?;
+    validate_printer_name(&driver_name)?;
+
+    Ok(Some(
+        RdpdrPrinter::new(device_id, queue_name, driver_name).with_network(network),
+    ))
+}
+
+#[derive(Debug)]
+pub(super) enum DefaultPrinterError {
+    Windows(Error),
+    InvalidMetadata(&'static str),
+    InvalidUtf16,
+}
+
+impl fmt::Display for DefaultPrinterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Windows(error) => write!(f, "query Windows default printer: {error}"),
+            Self::InvalidMetadata(message) => f.write_str(message),
+            Self::InvalidUtf16 => f.write_str("default printer metadata contains invalid UTF-16"),
+        }
+    }
+}
+
+impl core::error::Error for DefaultPrinterError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Windows(error) => Some(error),
+            Self::InvalidMetadata(_) | Self::InvalidUtf16 => None,
+        }
+    }
+}
+
+impl From<Error> for DefaultPrinterError {
+    fn from(error: Error) -> Self {
+        Self::Windows(error)
+    }
+}
+
+fn validate_printer_name(value: &str) -> Result<(), DefaultPrinterError> {
+    let units = value.encode_utf16().count();
+    if units == 0 {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer metadata must not be empty",
+        ));
+    }
+    if units > MAX_PRINTER_NAME_UTF16_UNITS {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer metadata exceeds the supported length",
+        ));
+    }
+    if value.contains('\0') {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer metadata must not contain NUL",
+        ));
+    }
+    Ok(())
+}
+
+fn default_printer_name() -> Result<Option<String>, DefaultPrinterError> {
+    let mut length = 0u32;
+    // SAFETY: A null output buffer is the documented size-probe form and `length` is writable.
+    let result = unsafe { GetDefaultPrinterW(None, &mut length) };
+    if result.as_bool() {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer size probe unexpectedly succeeded",
+        ));
+    }
+
+    // SAFETY: GetLastError only reads the calling thread's error state immediately after the failed probe.
+    let error = unsafe { GetLastError() };
+    if error == ERROR_FILE_NOT_FOUND {
+        return Ok(None);
+    }
+    if error != ERROR_INSUFFICIENT_BUFFER {
+        return Err(Error::from_hresult(HRESULT::from_win32(error.0)).into());
+    }
+
+    let length = usize::try_from(length)
+        .map_err(|_| DefaultPrinterError::InvalidMetadata("default printer name length does not fit usize"))?;
+    if length == 0 || length > MAX_PRINTER_NAME_UTF16_UNITS + 1 {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer name has an invalid length",
+        ));
+    }
+
+    let mut buffer = vec![0u16; length];
+    let mut actual = u32::try_from(buffer.len()).expect("bounded printer name length fits u32");
+    // SAFETY: `buffer` is writable for `actual` UTF-16 units and remains alive for the call.
+    if !unsafe { GetDefaultPrinterW(Some(PWSTR(buffer.as_mut_ptr())), &mut actual) }.as_bool() {
+        return Err(last_error().into());
+    }
+
+    let actual = usize::try_from(actual)
+        .map_err(|_| DefaultPrinterError::InvalidMetadata("default printer name length does not fit usize"))?;
+    if actual == 0 || actual > buffer.len() || buffer[actual - 1] != 0 || buffer[..actual - 1].contains(&0) {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer name is not a single NUL-terminated string",
+        ));
+    }
+
+    String::from_utf16(&buffer[..actual - 1])
+        .map(Some)
+        .map_err(|_| DefaultPrinterError::InvalidUtf16)
+}
+
+fn printer_driver(queue_name: &str) -> Result<(String, bool), DefaultPrinterError> {
+    let queue_name = wide_nul(queue_name);
+    let handle = PrinterHandle::open(&queue_name)?;
+    let mut needed = 0u32;
+    // SAFETY: `handle` is valid and a null buffer is the documented size-probe form.
+    let probe_error = match unsafe { GetPrinterW(handle.raw(), 2, None, &mut needed) } {
+        Ok(()) => {
+            return Err(DefaultPrinterError::InvalidMetadata(
+                "printer metadata size probe unexpectedly succeeded",
+            ));
+        }
+        Err(error) => error,
+    };
+    let buffer_length = usize::try_from(needed)
+        .map_err(|_| DefaultPrinterError::InvalidMetadata("printer metadata length does not fit usize"))?;
+    if buffer_length < size_of::<PRINTER_INFO_2W>() || buffer_length > MAX_PRINTER_METADATA_BYTES {
+        return Err(if buffer_length == 0 {
+            DefaultPrinterError::Windows(probe_error)
+        } else {
+            DefaultPrinterError::InvalidMetadata("printer metadata has an invalid length")
+        });
+    }
+
+    let word_count = buffer_length.div_ceil(size_of::<usize>());
+    let mut storage = vec![0usize; word_count];
+    // SAFETY: `storage` is contiguous, writable, and spans at least `buffer_length` bytes.
+    let bytes = unsafe { slice::from_raw_parts_mut(storage.as_mut_ptr().cast::<u8>(), buffer_length) };
+    // SAFETY: `handle` is valid and `bytes` is a writable buffer of the size returned by the probe.
+    unsafe { GetPrinterW(handle.raw(), 2, Some(bytes), &mut needed) }?;
+
+    // SAFETY: GetPrinterW level 2 initialized the aligned buffer with a PRINTER_INFO_2W.
+    let info = unsafe { &*storage.as_ptr().cast::<PRINTER_INFO_2W>() };
+    if info.pDriverName.is_null() {
+        return Err(DefaultPrinterError::InvalidMetadata(
+            "default printer has no driver name",
+        ));
+    }
+    // SAFETY: GetPrinterW returned a NUL-terminated driver-name pointer valid while `storage` is alive.
+    let driver_name = unsafe { info.pDriverName.to_string() }.map_err(|_| DefaultPrinterError::InvalidUtf16)?;
+    Ok((driver_name, info.Attributes & PRINTER_ATTRIBUTE_NETWORK != 0))
+}
+
+fn wide_nul(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(core::iter::once(0)).collect()
+}
+
+fn last_error() -> Error {
+    // SAFETY: GetLastError only reads the calling thread's error state.
+    let error = unsafe { GetLastError() };
+    Error::from_hresult(HRESULT::from_win32(error.0))
+}
+
+struct PrinterHandle(PRINTER_HANDLE);
+
+// SAFETY: PrinterHandle is exclusively owned and all access remains serialized on the worker thread.
+unsafe impl Send for PrinterHandle {}
+
+impl PrinterHandle {
+    fn open(queue_name: &[u16]) -> Result<Self, Error> {
+        let mut handle = PRINTER_HANDLE::default();
+        // SAFETY: `queue_name` is NUL-terminated and `handle` is writable.
+        unsafe { OpenPrinterW(PCWSTR(queue_name.as_ptr()), &mut handle, None) }?;
+        Ok(Self(handle))
+    }
+
+    fn raw(&self) -> PRINTER_HANDLE {
+        self.0
+    }
+}
+
+impl Drop for PrinterHandle {
+    fn drop(&mut self) {
+        // SAFETY: This object owns the printer handle and closes it exactly once.
+        if let Err(error) = unsafe { ClosePrinter(self.0) } {
+            warn!(%error, "Failed to close Windows printer handle");
+        }
+    }
+}
+
+struct Win32PrintJob {
+    handle: PrinterHandle,
+    active: bool,
+}
+
+impl Drop for Win32PrintJob {
+    fn drop(&mut self) {
+        if self.active {
+            // SAFETY: The handle owns an active StartDocPrinter job.
+            if !unsafe { AbortPrinter(self.handle.raw()) }.as_bool() {
+                warn!(error = %last_error(), "Failed to abort Windows print job");
+            }
+        }
+    }
+}
+
+type SpoolerResult = Result<(), Box<dyn core::error::Error + Send>>;
+
+trait PrintSpooler: Send + 'static {
+    fn create(&mut self, file_id: u32, printer: &RdpdrPrinter) -> SpoolerResult;
+    fn write(&mut self, file_id: u32, data: &[u8]) -> SpoolerResult;
+    fn close(&mut self, file_id: u32) -> SpoolerResult;
+    fn abort(&mut self, file_id: u32);
+    fn reset(&mut self);
+}
+
+#[derive(Default)]
+struct Win32PrintSpooler {
+    jobs: HashMap<u32, Win32PrintJob>,
+}
+
+impl PrintSpooler for Win32PrintSpooler {
+    fn create(&mut self, file_id: u32, printer: &RdpdrPrinter) -> SpoolerResult {
+        let queue_name = wide_nul(printer.name());
+        let handle =
+            PrinterHandle::open(&queue_name).map_err(|error| Box::new(error) as Box<dyn core::error::Error + Send>)?;
+        let mut document_name = wide_nul("Remote Desktop Document");
+        let mut data_type = wide_nul("RAW");
+        let document = DOC_INFO_1W {
+            pDocName: PWSTR(document_name.as_mut_ptr()),
+            pOutputFile: PWSTR::null(),
+            pDatatype: PWSTR(data_type.as_mut_ptr()),
+        };
+        // SAFETY: `handle` is valid and all DOC_INFO_1W strings remain alive for the call.
+        let job_id = unsafe { StartDocPrinterW(handle.raw(), 1, &document) };
+        if job_id == 0 {
+            return Err(Box::new(last_error()));
+        }
+
+        self.jobs.insert(file_id, Win32PrintJob { handle, active: true });
+        Ok(())
+    }
+
+    fn write(&mut self, file_id: u32, data: &[u8]) -> SpoolerResult {
+        let job = self
+            .jobs
+            .get(&file_id)
+            .ok_or_else(|| Box::new(InvalidPrintHandle) as Box<dyn core::error::Error + Send>)?;
+        let length = u32::try_from(data.len())
+            .map_err(|_| Box::new(PrintChunkTooLarge) as Box<dyn core::error::Error + Send>)?;
+        let mut written = 0u32;
+        // SAFETY: The job handle is active and `data` is readable for `length` bytes.
+        if !unsafe { WritePrinter(job.handle.raw(), data.as_ptr().cast::<c_void>(), length, &mut written) }.as_bool() {
+            return Err(Box::new(last_error()));
+        }
+        if written != length {
+            return Err(Box::new(ShortPrinterWrite {
+                expected: length,
+                actual: written,
+            }));
+        }
+        Ok(())
+    }
+
+    fn close(&mut self, file_id: u32) -> SpoolerResult {
+        let mut job = self
+            .jobs
+            .remove(&file_id)
+            .ok_or_else(|| Box::new(InvalidPrintHandle) as Box<dyn core::error::Error + Send>)?;
+        // SAFETY: The job handle owns an active StartDocPrinter job.
+        if !unsafe { EndDocPrinter(job.handle.raw()) }.as_bool() {
+            return Err(Box::new(last_error()));
+        }
+        job.active = false;
+        Ok(())
+    }
+
+    fn abort(&mut self, file_id: u32) {
+        self.jobs.remove(&file_id);
+    }
+
+    fn reset(&mut self) {
+        self.jobs.clear();
+    }
+}
+
+#[derive(Debug)]
+struct InvalidPrintHandle;
+
+impl fmt::Display for InvalidPrintHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid print handle")
+    }
+}
+
+impl core::error::Error for InvalidPrintHandle {}
+
+#[derive(Debug)]
+struct PrintChunkTooLarge;
+
+impl fmt::Display for PrintChunkTooLarge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("print chunk exceeds the Windows spooler size limit")
+    }
+}
+
+impl core::error::Error for PrintChunkTooLarge {}
+
+#[derive(Debug)]
+struct ShortPrinterWrite {
+    expected: u32,
+    actual: u32,
+}
+
+impl fmt::Display for ShortPrinterWrite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Windows spooler accepted {} of {} print bytes",
+            self.actual, self.expected
+        )
+    }
+}
+
+impl core::error::Error for ShortPrinterWrite {}
+
+enum PrinterCommand {
+    Create { request: DeviceCreateRequest, file_id: u32 },
+    Write(DeviceWriteRequest),
+    Close(ironrdp_rdpdr::pdu::efs::DeviceCloseRequest),
+}
+
+#[derive(Debug)]
+pub(super) struct PrinterWorker {
+    printer: RdpdrPrinter,
+    commands: Option<SyncSender<PrinterCommand>>,
+    completions: Receiver<SvcMessage>,
+    next_file_id: u32,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    poisoned_file_ids: std::sync::Arc<std::sync::Mutex<HashSet<u32>>>,
+    live_file_ids: std::sync::Arc<std::sync::Mutex<HashSet<u32>>>,
+    finished: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    completion_disconnected: bool,
+    hooks: Option<RdpdrWorkerThreadHooks>,
+    guarded: bool,
+}
+
+impl PrinterWorker {
+    pub(super) fn new(printer: RdpdrPrinter, hooks: Option<RdpdrWorkerThreadHooks>) -> PduResult<Self> {
+        Self::with_spooler(printer, Box::<Win32PrintSpooler>::default(), hooks)
+    }
+
+    fn with_spooler(
+        printer: RdpdrPrinter,
+        spooler: Box<dyn PrintSpooler>,
+        hooks: Option<RdpdrWorkerThreadHooks>,
+    ) -> PduResult<Self> {
+        let (commands, command_rx) = sync_channel(PRINTER_COMMAND_QUEUE_CAPACITY);
+        let (completion_tx, completions) = std::sync::mpsc::channel();
+        let worker_printer = printer.clone();
+        let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_cancelled = std::sync::Arc::clone(&cancelled);
+        let poisoned_file_ids = std::sync::Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let worker_poisoned_file_ids = std::sync::Arc::clone(&poisoned_file_ids);
+        let live_file_ids = std::sync::Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let worker_live_file_ids = std::sync::Arc::clone(&live_file_ids);
+        let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_finished = std::sync::Arc::clone(&finished);
+        let thread_guard = hooks
+            .as_ref()
+            .map(RdpdrWorkerThreadHooks::acquire)
+            .transpose()
+            .map_err(|error| {
+                pdu_other_err!(
+                    "acquire Windows printer worker lifetime",
+                    source: std::io::Error::other(error.to_string())
+                )
+            })?;
+        let thread = std::thread::Builder::new()
+            .name("ironrdp-printer".to_owned())
+            .spawn(move || {
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    worker_loop(
+                        worker_printer,
+                        spooler,
+                        command_rx,
+                        completion_tx,
+                        worker_cancelled,
+                        worker_poisoned_file_ids,
+                        worker_live_file_ids,
+                    )
+                }));
+                if result.is_err() {
+                    warn!("Windows printer worker panicked");
+                }
+                worker_finished.store(true, std::sync::atomic::Ordering::Release);
+                if let Some(thread_guard) = thread_guard {
+                    thread_guard.exit();
+                }
+            })
+            .map_err(|error| pdu_other_err!("spawn Windows printer worker", source: error))?;
+
+        Ok(Self {
+            printer,
+            commands: Some(commands),
+            completions,
+            next_file_id: 1,
+            cancelled,
+            poisoned_file_ids,
+            live_file_ids,
+            finished,
+            thread: Some(thread),
+            completion_disconnected: false,
+            guarded: hooks.is_some(),
+            hooks,
+        })
+    }
+
+    pub(super) fn handle(&mut self, request: PrinterIoRequest) -> PduResult<Vec<SvcMessage>> {
+        let command = match request {
+            PrinterIoRequest::Create(request) => {
+                if !request.path.is_empty() {
+                    return Ok(vec![create_response(request, 0, NtStatus::INVALID_PARAMETER)]);
+                }
+                let file_id = self.allocate_file_id();
+                PrinterCommand::Create { request, file_id }
+            }
+            PrinterIoRequest::Write(request) => PrinterCommand::Write(request),
+            PrinterIoRequest::Close(request) => PrinterCommand::Close(request),
+        };
+
+        let commands = self
+            .commands
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("Windows printer worker is shutting down"))?;
+        match commands.try_send(command) {
+            Ok(()) => Ok(Vec::new()),
+            Err(TrySendError::Full(command)) => {
+                warn!("Windows printer worker queue is full");
+                match &command {
+                    PrinterCommand::Write(request) => self.poison(request.device_io_request.file_id),
+                    PrinterCommand::Close(request) => self.poison(request.device_io_request.file_id),
+                    PrinterCommand::Create { .. } => {}
+                }
+                Ok(vec![failed_command_response(command, NtStatus::UNSUCCESSFUL)])
+            }
+            Err(TrySendError::Disconnected(_)) => Err(pdu_other_err!("Windows printer worker stopped unexpectedly")),
+        }
+    }
+
+    pub(super) fn poll(&mut self) -> PduResult<Vec<SvcMessage>> {
+        if self.completion_disconnected {
+            return Ok(Vec::new());
+        }
+        let mut messages = Vec::new();
+        loop {
+            match self.completions.try_recv() {
+                Ok(message) => messages.push(message),
+                Err(TryRecvError::Empty) => return Ok(messages),
+                Err(TryRecvError::Disconnected) => {
+                    warn!("Windows printer worker completion channel disconnected");
+                    self.completion_disconnected = true;
+                    self.request_stop();
+                    return Ok(messages);
+                }
+            }
+        }
+    }
+
+    pub(super) fn restart(&mut self) -> PduResult<()> {
+        self.request_stop();
+        let deadline = Instant::now() + PRINTER_RESET_WAIT;
+        while !self.finished.load(std::sync::atomic::Ordering::Acquire) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        if !self.finished.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(pdu_other_err!(
+                "Windows printer worker did not stop within reset deadline"
+            ));
+        }
+        if let Some(thread) = self.thread.take()
+            && !self.guarded
+            && thread.join().is_err()
+        {
+            return Err(pdu_other_err!("Windows printer worker panicked during reset"));
+        }
+        let replacement = Self::new(self.printer.clone(), self.hooks)?;
+        *self = replacement;
+        Ok(())
+    }
+
+    pub(super) fn reject_write(&mut self, request: ironrdp_rdpdr::pdu::efs::DeviceIoRequest) -> Vec<SvcMessage> {
+        self.poison(request.file_id);
+        vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(DeviceWriteResponse {
+            device_io_reply: DeviceIoResponse::new(request, NtStatus::INVALID_PARAMETER),
+            length: 0,
+        }))]
+    }
+
+    fn poison(&self, file_id: u32) {
+        if !self
+            .live_file_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&file_id)
+        {
+            return;
+        }
+        self.poisoned_file_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(file_id);
+    }
+
+    fn request_stop(&mut self) {
+        self.cancelled.store(true, std::sync::atomic::Ordering::Release);
+        self.commands.take();
+    }
+
+    fn allocate_file_id(&mut self) -> u32 {
+        let file_id = self.next_file_id;
+        self.next_file_id = self.next_file_id.wrapping_add(1);
+        if self.next_file_id == 0 {
+            self.next_file_id = 1;
+        }
+        file_id
+    }
+}
+
+impl Drop for PrinterWorker {
+    fn drop(&mut self) {
+        self.request_stop();
+        self.thread.take();
+    }
+}
+
+fn worker_loop(
+    printer: RdpdrPrinter,
+    mut spooler: Box<dyn PrintSpooler>,
+    commands: Receiver<PrinterCommand>,
+    completions: std::sync::mpsc::Sender<SvcMessage>,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    poisoned_file_ids: std::sync::Arc<std::sync::Mutex<HashSet<u32>>>,
+    live_file_ids: std::sync::Arc<std::sync::Mutex<HashSet<u32>>>,
+) {
+    let mut job_sizes = HashMap::<u32, usize>::new();
+    while let Ok(command) = commands.recv() {
+        if cancelled.load(std::sync::atomic::Ordering::Acquire) {
+            break;
+        }
+        let poisoned = {
+            let mut poisoned = poisoned_file_ids
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            core::mem::take(&mut *poisoned)
+        };
+        for file_id in poisoned {
+            if job_sizes.remove(&file_id).is_some() {
+                spooler.abort(file_id);
+                live_file_ids
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&file_id);
+            }
+        }
+        let response = match command {
+            PrinterCommand::Create { request, file_id } => {
+                let result = if job_sizes.len() >= MAX_OPEN_PRINT_JOBS {
+                    Err("maximum open print-job count reached".to_owned())
+                } else {
+                    spooler.create(file_id, &printer).map_err(|error| error.to_string())
+                };
+                let status = match result {
+                    Ok(()) => {
+                        job_sizes.insert(file_id, 0);
+                        live_file_ids
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .insert(file_id);
+                        debug!(
+                            file_id,
+                            printer = printer.name(),
+                            "Started redirected Windows print job"
+                        );
+                        NtStatus::SUCCESS
+                    }
+                    Err(error) => {
+                        warn!(file_id, %error, "Failed to start redirected Windows print job");
+                        NtStatus::UNSUCCESSFUL
+                    }
+                };
+                create_response(request, file_id, status)
+            }
+            PrinterCommand::Write(request) => {
+                let file_id = request.device_io_request.file_id;
+                let length = u32::try_from(request.write_data.len())
+                    .expect("printer write length round-trips from the u32 wire field");
+                let projected_size = job_sizes
+                    .get(&file_id)
+                    .and_then(|current| current.checked_add(request.write_data.len()))
+                    .filter(|size| *size <= MAX_PRINT_JOB_BYTES);
+                let status = match projected_size {
+                    Some(size) => match spooler.write(file_id, &request.write_data) {
+                        Ok(()) => {
+                            job_sizes.insert(file_id, size);
+                            NtStatus::SUCCESS
+                        }
+                        Err(error) => {
+                            warn!(file_id, %error, "Failed to write redirected Windows print data");
+                            spooler.abort(file_id);
+                            job_sizes.remove(&file_id);
+                            live_file_ids
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .remove(&file_id);
+                            NtStatus::UNSUCCESSFUL
+                        }
+                    },
+                    None => {
+                        warn!(
+                            file_id,
+                            limit = MAX_PRINT_JOB_BYTES,
+                            "Redirected print job exceeds byte limit"
+                        );
+                        spooler.abort(file_id);
+                        job_sizes.remove(&file_id);
+                        live_file_ids
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .remove(&file_id);
+                        NtStatus::UNSUCCESSFUL
+                    }
+                };
+                write_response(request, length, status)
+            }
+            PrinterCommand::Close(request) => {
+                let file_id = request.device_io_request.file_id;
+                let status = if job_sizes.remove(&file_id).is_some() {
+                    live_file_ids
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .remove(&file_id);
+                    match spooler.close(file_id) {
+                        Ok(()) => NtStatus::SUCCESS,
+                        Err(error) => {
+                            warn!(file_id, %error, "Failed to finish redirected Windows print job");
+                            spooler.abort(file_id);
+                            NtStatus::UNSUCCESSFUL
+                        }
+                    }
+                } else {
+                    NtStatus::INVALID_HANDLE
+                };
+                close_response(request, status)
+            }
+        };
+
+        if cancelled.load(std::sync::atomic::Ordering::Acquire) {
+            break;
+        }
+        if completions.send(response).is_err() {
+            break;
+        }
+    }
+    spooler.reset();
+    live_file_ids
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clear();
+}
+
+fn failed_command_response(command: PrinterCommand, status: NtStatus) -> SvcMessage {
+    match command {
+        PrinterCommand::Create { request, .. } => create_response(request, 0, status),
+        PrinterCommand::Write(request) => write_response(request, 0, status),
+        PrinterCommand::Close(request) => close_response(request, status),
+    }
+}
+
+fn create_response(request: DeviceCreateRequest, file_id: u32, status: NtStatus) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::DeviceCreateResponse(DeviceCreateResponse {
+        device_io_reply: DeviceIoResponse::new(request.device_io_request, status),
+        file_id: if status == NtStatus::SUCCESS { file_id } else { 0 },
+        information: if status == NtStatus::SUCCESS {
+            Information::FILE_OPENED
+        } else {
+            Information::empty()
+        },
+    }))
+}
+
+fn write_response(request: DeviceWriteRequest, length: u32, status: NtStatus) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::DeviceWriteResponse(DeviceWriteResponse {
+        device_io_reply: DeviceIoResponse::new(request.device_io_request, status),
+        length: if status == NtStatus::SUCCESS { length } else { 0 },
+    }))
+}
+
+fn close_response(request: ironrdp_rdpdr::pdu::efs::DeviceCloseRequest, status: NtStatus) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::DeviceCloseResponse(DeviceCloseResponse {
+        device_io_response: DeviceIoResponse::new(request.device_io_request, status),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, DeviceCloseRequest, DeviceIoRequest, FileAttributes,
+        MajorFunction, MinorFunction, SharedAccess,
+    };
+
+    #[derive(Debug, Default)]
+    struct FakeState {
+        events: Vec<String>,
+        fail_write: bool,
+    }
+
+    struct FakeSpooler(Arc<Mutex<FakeState>>);
+
+    impl PrintSpooler for FakeSpooler {
+        fn create(&mut self, file_id: u32, _printer: &RdpdrPrinter) -> Result<(), Box<dyn core::error::Error + Send>> {
+            self.0.lock().unwrap().events.push(format!("create:{file_id}"));
+            Ok(())
+        }
+
+        fn write(&mut self, file_id: u32, data: &[u8]) -> Result<(), Box<dyn core::error::Error + Send>> {
+            let mut state = self.0.lock().unwrap();
+            state.events.push(format!("write:{file_id}:{}", data.len()));
+            if state.fail_write {
+                Err(Box::new(std::io::Error::other("injected write failure")))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn close(&mut self, file_id: u32) -> Result<(), Box<dyn core::error::Error + Send>> {
+            self.0.lock().unwrap().events.push(format!("close:{file_id}"));
+            Ok(())
+        }
+
+        fn abort(&mut self, file_id: u32) {
+            self.0.lock().unwrap().events.push(format!("abort:{file_id}"));
+        }
+
+        fn reset(&mut self) {
+            self.0.lock().unwrap().events.push("reset".to_owned());
+        }
+    }
+
+    fn printer() -> RdpdrPrinter {
+        RdpdrPrinter::new(0xFFFF_FFFE, "Test Printer".to_owned(), "Test Driver".to_owned())
+    }
+
+    fn request(file_id: u32, completion_id: u32, major_function: MajorFunction) -> DeviceIoRequest {
+        DeviceIoRequest {
+            device_id: 0xFFFF_FFFE,
+            file_id,
+            completion_id,
+            major_function,
+            minor_function: MinorFunction::from(0),
+        }
+    }
+
+    fn create_request(path: &str) -> DeviceCreateRequest {
+        DeviceCreateRequest {
+            device_io_request: request(0, 1, MajorFunction::Create),
+            desired_access: DesiredAccess::empty(),
+            allocation_size: 0,
+            file_attributes: FileAttributes::empty(),
+            shared_access: SharedAccess::empty(),
+            create_disposition: CreateDisposition::FILE_OPEN,
+            create_options: CreateOptions::empty(),
+            path: path.to_owned(),
+        }
+    }
+
+    fn wait_for_completion(worker: &mut PrinterWorker) -> Vec<u8> {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let messages = worker.poll().unwrap();
+            if let Some(message) = messages.into_iter().next() {
+                return message.encode_unframed_pdu().unwrap();
+            }
+            assert!(Instant::now() < deadline, "printer worker completion timed out");
+            std::thread::yield_now();
+        }
+    }
+
+    fn status(bytes: &[u8]) -> NtStatus {
+        NtStatus::from(u32::from_le_bytes(bytes[12..16].try_into().unwrap()))
+    }
+
+    #[test]
+    fn worker_completes_create_write_close_in_order() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+
+        assert!(
+            worker
+                .handle(PrinterIoRequest::Create(create_request("")))
+                .unwrap()
+                .is_empty()
+        );
+        let create = wait_for_completion(&mut worker);
+        assert_eq!(status(&create), NtStatus::SUCCESS);
+        let file_id = u32::from_le_bytes(create[16..20].try_into().unwrap());
+
+        let write = DeviceWriteRequest {
+            device_io_request: request(file_id, 2, MajorFunction::Write),
+            offset: 0,
+            write_data: b"test".to_vec(),
+        };
+        assert!(worker.handle(PrinterIoRequest::Write(write)).unwrap().is_empty());
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::SUCCESS);
+
+        let close = DeviceCloseRequest {
+            device_io_request: request(file_id, 3, MajorFunction::Close),
+        };
+        assert!(worker.handle(PrinterIoRequest::Close(close)).unwrap().is_empty());
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::SUCCESS);
+        assert_eq!(state.lock().unwrap().events, ["create:1", "write:1:4", "close:1"]);
+    }
+
+    #[test]
+    fn worker_rejects_nonempty_create_path_without_touching_spooler() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+
+        let responses = worker
+            .handle(PrinterIoRequest::Create(create_request(r"C:\forbidden")))
+            .unwrap();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(
+            status(&responses[0].encode_unframed_pdu().unwrap()),
+            NtStatus::INVALID_PARAMETER
+        );
+        assert!(state.lock().unwrap().events.is_empty());
+    }
+
+    #[test]
+    fn failed_write_aborts_job_and_rejects_later_close() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+        worker.handle(PrinterIoRequest::Create(create_request(""))).unwrap();
+        let create = wait_for_completion(&mut worker);
+        let file_id = u32::from_le_bytes(create[16..20].try_into().unwrap());
+        state.lock().unwrap().fail_write = true;
+
+        worker
+            .handle(PrinterIoRequest::Write(DeviceWriteRequest {
+                device_io_request: request(file_id, 2, MajorFunction::Write),
+                offset: 0,
+                write_data: vec![1],
+            }))
+            .unwrap();
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::UNSUCCESSFUL);
+
+        worker
+            .handle(PrinterIoRequest::Close(DeviceCloseRequest {
+                device_io_request: request(file_id, 3, MajorFunction::Close),
+            }))
+            .unwrap();
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::INVALID_HANDLE);
+        assert_eq!(state.lock().unwrap().events, ["create:1", "write:1:1", "abort:1"]);
+    }
+
+    #[test]
+    fn rejected_write_poisons_job_before_later_close() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+        worker.handle(PrinterIoRequest::Create(create_request(""))).unwrap();
+        let create = wait_for_completion(&mut worker);
+        let file_id = u32::from_le_bytes(create[16..20].try_into().unwrap());
+
+        let rejected = worker.reject_write(request(file_id, 2, MajorFunction::Write));
+        assert_eq!(
+            status(&rejected[0].encode_unframed_pdu().unwrap()),
+            NtStatus::INVALID_PARAMETER
+        );
+        worker
+            .handle(PrinterIoRequest::Close(DeviceCloseRequest {
+                device_io_request: request(file_id, 3, MajorFunction::Close),
+            }))
+            .unwrap();
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::INVALID_HANDLE);
+        assert_eq!(state.lock().unwrap().events, ["create:1", "abort:1"]);
+    }
+
+    #[test]
+    fn worker_shutdown_aborts_open_jobs_before_returning() {
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let mut worker =
+            PrinterWorker::with_spooler(printer(), Box::new(FakeSpooler(Arc::clone(&state))), None).unwrap();
+        worker.handle(PrinterIoRequest::Create(create_request(""))).unwrap();
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::SUCCESS);
+
+        drop(worker);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if state.lock().unwrap().events == ["create:1", "reset"] {
+                break;
+            }
+            assert!(Instant::now() < deadline, "printer worker shutdown timed out");
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    #[ignore = "requires IRONRDP_RDPDR_PRINTER_SMOKE=1 and an authorized default printer"]
+    fn authorized_default_printer_smoke() {
+        if std::env::var_os("IRONRDP_RDPDR_PRINTER_SMOKE").as_deref() != Some(std::ffi::OsStr::new("1")) {
+            return;
+        }
+
+        let printer = discover_default_printer(0xFFFF_FFFE)
+            .expect("default printer discovery succeeds")
+            .expect("an authorized default printer is configured");
+        let mut worker = PrinterWorker::new(printer, None).expect("printer worker starts");
+        worker
+            .handle(PrinterIoRequest::Create(create_request("")))
+            .expect("queue empty print job");
+        let create = wait_for_completion(&mut worker);
+        assert_eq!(status(&create), NtStatus::SUCCESS);
+        let file_id = u32::from_le_bytes(create[16..20].try_into().unwrap());
+
+        worker
+            .handle(PrinterIoRequest::Close(DeviceCloseRequest {
+                device_io_request: request(file_id, 2, MajorFunction::Close),
+            }))
+            .expect("finish empty print job");
+        assert_eq!(status(&wait_for_completion(&mut worker)), NtStatus::SUCCESS);
+    }
+}

--- a/crates/ironrdp-rdpdr/src/backend/mod.rs
+++ b/crates/ironrdp-rdpdr/src/backend/mod.rs
@@ -125,6 +125,17 @@ pub trait RdpdrBackend: AsAny + fmt::Debug + Send {
             },
         ))])
     }
+
+    /// Rejects an oversized printer write before its server-controlled payload is allocated.
+    ///
+    /// Stateful printer implementations should also poison or abort the target file handle so a
+    /// later close cannot submit a partial job.
+    fn reject_printer_write(&mut self, req: crate::pdu::efs::DeviceIoRequest) -> PduResult<Vec<SvcMessage>> {
+        let _ = req;
+        Err(ironrdp_pdu::pdu_other_err!(
+            "printer backend does not support safe oversized-write rejection"
+        ))
+    }
 }
 
 /// Immutable filesystem-device metadata announced for one RDPDR channel lifetime.
@@ -156,6 +167,59 @@ impl RdpdrDrive {
     }
 }
 
+/// Immutable printer metadata announced for one RDPDR channel lifetime.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RdpdrPrinter {
+    device_id: u32,
+    name: String,
+    driver_name: String,
+    network: bool,
+}
+
+impl RdpdrPrinter {
+    /// Creates printer metadata for an RDPDR announcement.
+    pub fn new(device_id: u32, name: String, driver_name: String) -> Self {
+        Self {
+            device_id,
+            name,
+            driver_name,
+            network: true,
+        }
+    }
+
+    /// Records whether the local Windows queue is a network printer.
+    #[must_use]
+    pub fn with_network(mut self, network: bool) -> Self {
+        self.network = network;
+        self
+    }
+
+    /// Returns the device identifier used in RDPDR requests.
+    pub fn device_id(&self) -> u32 {
+        self.device_id
+    }
+
+    /// Returns the local printer queue name announced to the server.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the Windows printer driver name requested on the server.
+    pub fn driver_name(&self) -> &str {
+        &self.driver_name
+    }
+
+    /// Returns whether the queue should carry the MS-RDPEPC network-printer flag.
+    pub fn network(&self) -> bool {
+        self.network
+    }
+
+    /// Splits the metadata into the RDPDR announcement fields.
+    pub fn into_parts(self) -> (u32, String, String, bool) {
+        (self.device_id, self.name, self.driver_name, self.network)
+    }
+}
+
 /// Per-connection product created by an [`RdpdrBackendFactory`].
 ///
 /// The initial list is announced during channel initialization.
@@ -164,6 +228,7 @@ pub struct RdpdrBackendProduct {
     backend: Box<dyn RdpdrBackend>,
     initial_drives: Vec<RdpdrDrive>,
     drive_hotplug: bool,
+    printer: Option<RdpdrPrinter>,
 }
 
 impl RdpdrBackendProduct {
@@ -173,6 +238,7 @@ impl RdpdrBackendProduct {
             backend,
             initial_drives,
             drive_hotplug: false,
+            printer: None,
         }
     }
 
@@ -191,6 +257,18 @@ impl RdpdrBackendProduct {
     /// Returns whether the channel must remain available for later drive announcements.
     pub fn drive_hotplug(&self) -> bool {
         self.drive_hotplug
+    }
+
+    /// Configures one printer announced after the remote user logs on.
+    #[must_use]
+    pub fn with_printer(mut self, printer: RdpdrPrinter) -> Self {
+        self.printer = Some(printer);
+        self
+    }
+
+    /// Returns the configured printer, if any.
+    pub fn printer(&self) -> Option<&RdpdrPrinter> {
+        self.printer.as_ref()
     }
 
     /// Consumes the product into its backend and matching announcement metadata.

--- a/crates/ironrdp-rdpdr/src/backend/noop.rs
+++ b/crates/ironrdp-rdpdr/src/backend/noop.rs
@@ -3,7 +3,11 @@ use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_svc::SvcMessage;
 
 use super::RdpdrBackend;
-use crate::pdu::efs::{DeviceControlRequest, ServerDeviceAnnounceResponse};
+use crate::pdu::RdpdrPdu;
+use crate::pdu::efs::{
+    DeviceControlRequest, DeviceIoRequest, DeviceIoResponse, DeviceWriteResponse, NtStatus,
+    ServerDeviceAnnounceResponse,
+};
 use crate::pdu::esc::{ScardCall, ScardIoCtlCode};
 
 #[derive(Debug)]
@@ -26,5 +30,14 @@ impl RdpdrBackend for NoopRdpdrBackend {
         Err(pdu_other_err!(
             "filesystem I/O is not supported by the noop RDPDR backend"
         ))
+    }
+
+    fn reject_printer_write(&mut self, req: DeviceIoRequest) -> PduResult<Vec<SvcMessage>> {
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(
+            DeviceWriteResponse {
+                device_io_reply: DeviceIoResponse::new(req, NtStatus::INVALID_PARAMETER),
+                length: 0,
+            },
+        ))])
     }
 }

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -9,9 +9,9 @@ use ironrdp_svc::{CompressionCondition, SvcClientProcessor, SvcMessage, SvcProce
 use pdu::efs::{
     AnyIoCtlCode, Capabilities, ClientDeviceListAnnounce, ClientDeviceListRemove, ClientNameRequest,
     ClientNameRequestUnicodeFlag, CoreCapability, CoreCapabilityKind, DEFAULT_PRINTER_DRIVER_NAME,
-    DeviceAnnounceHeader, DeviceCloseResponse, DeviceControlRequest, DeviceControlResponse, DeviceIoRequest,
-    DeviceIoResponse, DeviceType, Devices, MajorFunction, NtStatus, PrinterIoRequest, ServerDeviceAnnounceResponse,
-    VERSION_MINOR_12, VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
+    DeviceAnnounceHeader, DeviceCloseResponse, DeviceControlRequest, DeviceControlResponse, DeviceCreateResponse,
+    DeviceIoRequest, DeviceIoResponse, DeviceType, Devices, Information, MajorFunction, NtStatus, PrinterIoRequest,
+    ServerDeviceAnnounceResponse, VERSION_MINOR_12, VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
 };
 use pdu::esc::{ScardCall, ScardIoCtlCode};
 use pdu::{PacketId, RdpdrPdu, SharedHeader};
@@ -23,9 +23,11 @@ pub mod server;
 
 pub use self::backend::noop::NoopRdpdrBackend;
 pub use self::backend::{
-    RdpdrBackend, RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive,
+    RdpdrBackend, RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive, RdpdrPrinter,
 };
 use crate::pdu::efs::ServerDriveIoRequest;
+
+const MAX_PRINTER_WRITE_BYTES: u32 = 16 * 1024 * 1024;
 
 /// The RDPDR channel as specified in [\[MS-RDPEFS\]].
 ///
@@ -51,6 +53,7 @@ pub struct Rdpdr {
     drive_capability_configured: bool,
     client_id: Option<u32>,
     server_capabilities_received: bool,
+    printer_capability_negotiated: bool,
     client_id_confirmed: bool,
     post_logon_devices_announced: bool,
     pending_device_announcements: Vec<u32>,
@@ -77,6 +80,7 @@ impl Rdpdr {
             drive_capability_configured: false,
             client_id: None,
             server_capabilities_received: false,
+            printer_capability_negotiated: false,
             client_id_confirmed: false,
             post_logon_devices_announced: false,
             pending_device_announcements: Vec::new(),
@@ -140,9 +144,22 @@ impl Rdpdr {
     /// [`DEFAULT_PRINTER_DRIVER_NAME`] for the redirected printer queue.
     #[must_use]
     pub fn with_printer_driver(mut self, device_id: u32, print_name: String, driver_name: String) -> Self {
+        self = self.with_printer_driver_and_network(device_id, print_name, driver_name, true);
+        self
+    }
+
+    /// Adds printer redirection capability with explicit driver and network-queue metadata.
+    #[must_use]
+    pub fn with_printer_driver_and_network(
+        mut self,
+        device_id: u32,
+        print_name: String,
+        driver_name: String,
+        network: bool,
+    ) -> Self {
         self.capabilities.add_printer();
         self.device_list
-            .add_printer_with_driver(device_id, print_name, driver_name);
+            .add_printer_with_driver_and_network(device_id, print_name, driver_name, network);
         self.device_types.push((device_id, DeviceType::Print));
         self
     }
@@ -336,6 +353,7 @@ impl Rdpdr {
         self.backend_active_drive_ids = configured_drive_ids;
 
         self.server_capabilities_received = false;
+        self.printer_capability_negotiated = false;
         self.client_id_confirmed = false;
         self.post_logon_devices_announced = false;
         self.pending_device_announcements.clear();
@@ -376,6 +394,7 @@ impl Rdpdr {
         }
 
         self.server_capabilities_received = true;
+        self.printer_capability_negotiated = req.supports_printer();
         let client_capability_response =
             RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.clone_supported_by(&req)));
         trace!("sending {:?}", client_capability_response);
@@ -403,6 +422,7 @@ impl Rdpdr {
             .zip(self.device_types.iter().copied())
             .filter(|(device, (device_id, _))| {
                 !self.manually_announced_device_ids.contains(device_id)
+                    && (device.device_type() != DeviceType::Print || self.printer_capability_negotiated)
                     && (announce_all_devices || Self::is_pre_logon_device(device))
             })
             .map(|(device, (device_id, _))| (device, device_id))
@@ -432,7 +452,9 @@ impl Rdpdr {
             .into_iter()
             .zip(self.device_types.iter().copied())
             .filter(|(device, (device_id, _))| {
-                !self.manually_announced_device_ids.contains(device_id) && !Self::is_pre_logon_device(device)
+                !self.manually_announced_device_ids.contains(device_id)
+                    && (device.device_type() != DeviceType::Print || self.printer_capability_negotiated)
+                    && !Self::is_pre_logon_device(device)
             })
             .map(|(device, (device_id, _))| (device, device_id))
             .unzip();
@@ -498,6 +520,10 @@ impl Rdpdr {
         }
 
         let device_id = pdu.device_id;
+        let device_type = self
+            .device_list
+            .for_device_type(device_id)
+            .map_err(|e| decode_err!(e))?;
         let accepted = pdu.result_code == NtStatus::SUCCESS;
         self.backend
             .as_mut()
@@ -536,9 +562,11 @@ impl Rdpdr {
             self.unregister_drive(device_id)?;
         }
 
-        messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
-            ClientDeviceListRemove::remove_device(device_id),
-        )));
+        if device_type == DeviceType::Filesystem {
+            messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
+                ClientDeviceListRemove::remove_device(device_id),
+            )));
+        }
         Ok(messages)
     }
 
@@ -648,36 +676,97 @@ impl Rdpdr {
                     .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
                     .handle_drive_io_request(req)?)
             }
-            DeviceType::Print => match dev_io_req.major_function {
-                MajorFunction::DeviceControl => {
-                    let req =
-                        DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src).map_err(|e| decode_err!(e))?;
-                    debug!(?req, "Completing printer device-control IRP");
-
-                    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(
-                        DeviceControlResponse::new(req, NtStatus::SUCCESS, None),
-                    ))])
-                }
-                MajorFunction::Create | MajorFunction::Write | MajorFunction::Close => {
-                    let req = PrinterIoRequest::decode(dev_io_req, src).map_err(|e| decode_err!(e))?;
-                    debug!(?req, "Dispatching printer IRP to backend");
-                    self.backend
-                        .as_mut()
-                        .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
-                        .handle_printer_io_request(req)
-                }
-                _ => {
-                    debug!(
-                        major = ?dev_io_req.major_function,
-                        minor = ?dev_io_req.minor_function,
+            DeviceType::Print => {
+                if self.rejected_device_ids.contains(&dev_io_req.device_id) {
+                    warn!(
+                        device_id = dev_io_req.device_id,
                         file_id = dev_io_req.file_id,
                         completion_id = dev_io_req.completion_id,
-                        "Completing unsupported printer IRP"
+                        "Ignoring printer IRP for a rejected device"
                     );
-
-                    Ok(vec![Self::unsupported_printer_io_response(dev_io_req)])
+                    return Ok(Vec::new());
                 }
-            },
+                if !self.active_device_ids.contains(&dev_io_req.device_id) {
+                    warn!(
+                        device_id = dev_io_req.device_id,
+                        file_id = dev_io_req.file_id,
+                        completion_id = dev_io_req.completion_id,
+                        "Ignoring printer IRP before device announcement confirmation"
+                    );
+                    return Ok(Vec::new());
+                }
+
+                match dev_io_req.major_function {
+                    MajorFunction::DeviceControl => {
+                        let req = DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src)
+                            .map_err(|e| decode_err!(e))?;
+                        if !src.is_empty() {
+                            return Err(pdu_other_err!(
+                                "received printer device-control IRP with trailing RDPDR data"
+                            ));
+                        }
+                        debug!(?req, "Completing printer device-control IRP");
+
+                        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(
+                            DeviceControlResponse::new(req, NtStatus::SUCCESS, None),
+                        ))])
+                    }
+                    MajorFunction::Create | MajorFunction::Write | MajorFunction::Close => {
+                        if dev_io_req.major_function == MajorFunction::Create && src.len() >= 32 {
+                            let path_length =
+                                u32::from_le_bytes(src.remaining()[28..32].try_into().expect("four-byte path length"));
+                            if path_length != 0 {
+                                return Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCreateResponse(
+                                    DeviceCreateResponse {
+                                        device_io_reply: DeviceIoResponse::new(dev_io_req, NtStatus::INVALID_PARAMETER),
+                                        file_id: 0,
+                                        information: Information::empty(),
+                                    },
+                                ))]);
+                            }
+                        }
+                        if dev_io_req.major_function == MajorFunction::Write && src.len() >= 4 {
+                            let write_length =
+                                u32::from_le_bytes(src.remaining()[..4].try_into().expect("four-byte write length"));
+                            if write_length > MAX_PRINTER_WRITE_BYTES {
+                                return self
+                                    .backend
+                                    .as_mut()
+                                    .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
+                                    .reject_printer_write(dev_io_req);
+                            }
+                        }
+                        if dev_io_req.major_function == MajorFunction::Close {
+                            const CLOSE_REQUEST_PADDING_SIZE: usize = 32;
+
+                            if src.len() < CLOSE_REQUEST_PADDING_SIZE {
+                                return Err(pdu_other_err!("received truncated printer close IRP"));
+                            }
+                            src.advance(CLOSE_REQUEST_PADDING_SIZE);
+                        }
+                        let req = PrinterIoRequest::decode(dev_io_req, src).map_err(|e| decode_err!(e))?;
+                        if !src.is_empty() {
+                            return Err(pdu_other_err!("received printer IRP with trailing RDPDR data"));
+                        }
+                        debug!(?req, "Dispatching printer IRP to backend");
+                        self.backend
+                            .as_mut()
+                            .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
+                            .handle_printer_io_request(req)
+                    }
+                    _ => {
+                        debug!(
+                            major = ?dev_io_req.major_function,
+                            minor = ?dev_io_req.minor_function,
+                            file_id = dev_io_req.file_id,
+                            completion_id = dev_io_req.completion_id,
+                            "Completing unsupported printer IRP"
+                        );
+
+                        Ok(vec![Self::unsupported_printer_io_response(dev_io_req)])
+                    }
+                }
+            }
             _ => {
                 // This should never happen, as we only announce devices that we support.
                 warn!(?dev_io_req, "received packet for unsupported device type");

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -698,7 +698,7 @@ impl Rdpdr {
 
                 match dev_io_req.major_function {
                     MajorFunction::DeviceControl => {
-                        let req = DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src)
+                        let req = DeviceControlRequest::<AnyIoCtlCode>::decode_with_input_buffer(dev_io_req, src)
                             .map_err(|e| decode_err!(e))?;
                         if !src.is_empty() {
                             return Err(pdu_other_err!(
@@ -708,7 +708,7 @@ impl Rdpdr {
                         debug!(?req, "Completing printer device-control IRP");
 
                         Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(
-                            DeviceControlResponse::new(req, NtStatus::SUCCESS, None),
+                            DeviceControlResponse::new(req.request, NtStatus::SUCCESS, None),
                         ))])
                     }
                     MajorFunction::Create | MajorFunction::Write | MajorFunction::Close => {

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -286,6 +286,13 @@ impl CoreCapability {
         }
     }
 
+    /// Returns whether this capability set advertises printer redirection.
+    pub fn supports_printer(&self) -> bool {
+        self.capabilities
+            .iter()
+            .any(|capability| capability.header.cap_type == CapabilityType::Printer)
+    }
+
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(ctx: self.name(), in: dst, size: self.size());
         dst.write_u16(cast_length!(
@@ -1094,10 +1101,22 @@ impl Devices {
 
     /// Announce a virtual printer device with an explicit server-side driver.
     pub fn add_printer_with_driver(&mut self, device_id: u32, print_name: String, driver_name: String) {
-        self.push(DeviceAnnounceHeader::new_printer_with_driver(
+        self.add_printer_with_driver_and_network(device_id, print_name, driver_name, true);
+    }
+
+    /// Announce a printer with an explicit driver and network-queue classification.
+    pub fn add_printer_with_driver_and_network(
+        &mut self,
+        device_id: u32,
+        print_name: String,
+        driver_name: String,
+        network: bool,
+    ) {
+        self.push(DeviceAnnounceHeader::new_printer_with_driver_and_network(
             device_id,
             print_name,
             driver_name,
+            network,
         ));
     }
 
@@ -1219,6 +1238,20 @@ impl DeviceAnnounceHeader {
     /// `u32::MAX` bytes. Real printer names are well under 200 bytes,
     /// so this is unreachable in practice.
     pub fn new_printer_with_driver(device_id: u32, print_name: String, driver_name: String) -> Self {
+        Self::new_printer_with_driver_and_network(device_id, print_name, driver_name, true)
+    }
+
+    /// Construct a printer announce with an explicit driver and network-queue classification.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either UTF-16 name exceeds `u32::MAX` encoded bytes.
+    pub fn new_printer_with_driver_and_network(
+        device_id: u32,
+        print_name: String,
+        driver_name: String,
+        network: bool,
+    ) -> Self {
         // [MS-RDPEPC 2.2.2.3] RDPDR_PRINTER_ANNOUNCE device_data layout:
         //   Flags            u32 LE
         //   CodePage         u32 LE   (reserved; MUST be ignored)
@@ -1240,16 +1273,20 @@ impl DeviceAnnounceHeader {
         let driver_name_bytes = utf16le_with_nul(&driver_name);
         let print_name_bytes = utf16le_with_nul(&print_name);
 
-        // [MS-RDPEPC 2.2.2.3] Flags. We match FreeRDP's PostScript
-        // redirection behavior: mark the queue as the session default and as
-        // a network printer. We intentionally leave the others off:
+        // [MS-RDPEPC 2.2.2.3] Flags. Mark the single configured queue as the
+        // session default and preserve its network classification. We intentionally leave the others off:
         //  - XPSFORMAT (0x10): advertises *client* XPS-consumption support;
         //    our driver is PostScript so this is irrelevant and could nudge
         //    mixed-driver hosts toward the XPS path.
         //  - TSPRINTER (0x08): "printer is from a previous terminal server
         //    session" (i.e. nested-hop re-redirection). We're a first-hop
         //    client, so setting it would be a lie.
-        let flags: u32 = RDPDR_PRINTER_ANNOUNCE_FLAG_DEFAULTPRINTER | RDPDR_PRINTER_ANNOUNCE_FLAG_NETWORKPRINTER;
+        let flags: u32 = RDPDR_PRINTER_ANNOUNCE_FLAG_DEFAULTPRINTER
+            | if network {
+                RDPDR_PRINTER_ANNOUNCE_FLAG_NETWORKPRINTER
+            } else {
+                0
+            };
         let code_page: u32 = 0;
         let pnp_name_len: u32 = 0;
         let cached_fields_len: u32 = 0;

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -161,6 +161,63 @@ fn encoded_printer_device_control_request() -> Vec<u8> {
     encoded
 }
 
+fn encoded_printer_create_request(path_length: u32) -> Vec<u8> {
+    let mut encoded = encoded_printer_device_io_request(MajorFunction::Create);
+    encoded.extend_from_slice(&0u32.to_le_bytes()); // DesiredAccess
+    encoded.extend_from_slice(&0u64.to_le_bytes()); // AllocationSize
+    encoded.extend_from_slice(&0u32.to_le_bytes()); // FileAttributes
+    encoded.extend_from_slice(&0u32.to_le_bytes()); // SharedAccess
+    encoded.extend_from_slice(&1u32.to_le_bytes()); // CreateDisposition
+    encoded.extend_from_slice(&0u32.to_le_bytes()); // CreateOptions
+    encoded.extend_from_slice(&path_length.to_le_bytes());
+    encoded
+}
+
+fn encoded_printer_write_request(length: u32) -> Vec<u8> {
+    let mut encoded = encoded_printer_device_io_request(MajorFunction::Write);
+    encoded.extend_from_slice(&length.to_le_bytes());
+    encoded
+}
+
+fn negotiate_printer_capability(rdpdr: &mut Rdpdr) {
+    let server_capability = RdpdrPdu::CoreCapability(CoreCapability {
+        capabilities: vec![CapabilityMessage::new_general(0), CapabilityMessage::new_printer()],
+        kind: CoreCapabilityKind::ServerCoreCapabilityRequest,
+    });
+    assert_eq!(
+        rdpdr.process(&encode_vec(&server_capability).unwrap()).unwrap().len(),
+        1
+    );
+}
+
+fn acknowledge_printer(rdpdr: &mut Rdpdr, result_code: NtStatus) {
+    let client_id = announce_client_id(rdpdr, 12);
+    negotiate_printer_capability(rdpdr);
+    assert!(
+        rdpdr
+            .process(&encoded_server_client_id_confirm(client_id))
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        rdpdr
+            .process(&encode_vec(&RdpdrPdu::UserLoggedon).unwrap())
+            .unwrap()
+            .len(),
+        1
+    );
+    let responses = rdpdr
+        .process(
+            &encode_vec(&RdpdrPdu::ServerDeviceAnnounceResponse(ServerDeviceAnnounceResponse {
+                device_id: 42,
+                result_code,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    assert!(responses.is_empty());
+}
+
 fn announced_devices(message: &SvcMessage) -> Vec<(u32, DeviceType)> {
     let encoded = message.encode_unframed_pdu().unwrap();
     assert_eq!(&encoded[..4], &[0x72, 0x44, 0x41, 0x44]); // RDPDR + DEVICELIST_ANNOUNCE
@@ -430,6 +487,7 @@ fn printer_device_announce_is_deferred_until_user_loggedon() {
     let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
 
     let client_id = announce_client_id(&mut rdpdr, 12);
+    negotiate_printer_capability(&mut rdpdr);
     assert!(
         rdpdr
             .process(&encoded_server_client_id_confirm(client_id))
@@ -457,6 +515,7 @@ fn smartcard_device_announce_remains_pre_logon() {
         .with_printer(42, "PrintMe".to_owned());
 
     let client_id = announce_client_id(&mut rdpdr, 12);
+    negotiate_printer_capability(&mut rdpdr);
     let responses = rdpdr.process(&encoded_server_client_id_confirm(client_id)).unwrap();
     assert_eq!(responses.len(), 1);
 
@@ -475,6 +534,7 @@ fn rdp51_client_id_confirm_announces_all_devices_pre_logon() {
         .with_printer(42, "PrintMe".to_owned());
 
     let client_id = announce_client_id(&mut rdpdr, VERSION_MINOR_RDP51);
+    negotiate_printer_capability(&mut rdpdr);
     let responses = rdpdr
         .process(&encoded_server_client_id_confirm_with_minor(
             VERSION_MINOR_RDP51,
@@ -497,8 +557,32 @@ fn rdp51_client_id_confirm_announces_all_devices_pre_logon() {
 }
 
 #[test]
+fn printer_is_not_announced_without_server_printer_capability() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    let client_id = announce_client_id(&mut rdpdr, 12);
+    let server_capability = RdpdrPdu::CoreCapability(CoreCapability {
+        capabilities: vec![CapabilityMessage::new_general(0)],
+        kind: CoreCapabilityKind::ServerCoreCapabilityRequest,
+    });
+    rdpdr.process(&encode_vec(&server_capability).unwrap()).unwrap();
+    assert!(
+        rdpdr
+            .process(&encoded_server_client_id_confirm(client_id))
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        rdpdr
+            .process(&encode_vec(&RdpdrPdu::UserLoggedon).unwrap())
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn printer_device_control_is_completed_with_empty_success_response() {
     let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::SUCCESS);
 
     let responses = rdpdr.process(&encoded_printer_device_control_request()).unwrap();
     assert_eq!(responses.len(), 1);
@@ -512,6 +596,7 @@ fn printer_device_control_is_completed_with_empty_success_response() {
 #[test]
 fn unsupported_printer_irp_is_completed_by_svc_processor() {
     let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::SUCCESS);
 
     let responses = rdpdr
         .process(&encoded_printer_device_io_request(MajorFunction::Read))
@@ -521,6 +606,59 @@ fn unsupported_printer_irp_is_completed_by_svc_processor() {
     let encoded = responses[0].encode_unframed_pdu().unwrap();
     assert_eq!(&encoded[..4], &[0x72, 0x44, 0x43, 0x49]); // RDPDR + DEVICE_IOCOMPLETION
     assert_eq!(ntstatus_at(&encoded, 12), NtStatus::NOT_SUPPORTED);
+}
+
+#[test]
+fn printer_irp_is_ignored_before_announcement_acknowledgement() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+
+    assert!(
+        rdpdr
+            .process(&encoded_printer_device_io_request(MajorFunction::Read))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn printer_irp_is_ignored_after_server_rejection() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::NOT_SUPPORTED);
+
+    assert!(
+        rdpdr
+            .process(&encoded_printer_device_io_request(MajorFunction::Read))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn printer_create_rejects_nonzero_wire_path_length_before_decoding_path() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::SUCCESS);
+
+    let responses = rdpdr.process(&encoded_printer_create_request(2)).unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(
+        ntstatus_at(&responses[0].encode_unframed_pdu().unwrap(), 12),
+        NtStatus::INVALID_PARAMETER
+    );
+}
+
+#[test]
+fn printer_write_rejects_oversized_length_before_allocating_payload() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::SUCCESS);
+
+    let responses = rdpdr
+        .process(&encoded_printer_write_request(16 * 1024 * 1024 + 1))
+        .unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(
+        ntstatus_at(&responses[0].encode_unframed_pdu().unwrap(), 12),
+        NtStatus::INVALID_PARAMETER
+    );
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -153,11 +153,16 @@ fn encoded_printer_device_io_request(major_function: MajorFunction) -> Vec<u8> {
 }
 
 fn encoded_printer_device_control_request() -> Vec<u8> {
+    encoded_printer_device_control_request_with_input(&[])
+}
+
+fn encoded_printer_device_control_request_with_input(input: &[u8]) -> Vec<u8> {
     let mut encoded = encoded_printer_device_io_request(MajorFunction::DeviceControl);
     encoded.extend_from_slice(&0u32.to_le_bytes()); // OutputBufferLength
-    encoded.extend_from_slice(&0u32.to_le_bytes()); // InputBufferLength
+    encoded.extend_from_slice(&u32::try_from(input.len()).unwrap().to_le_bytes());
     encoded.extend_from_slice(&0u32.to_le_bytes()); // IoControlCode
     encoded.extend_from_slice(&[0; 20]); // Padding
+    encoded.extend_from_slice(input);
     encoded
 }
 
@@ -591,6 +596,21 @@ fn printer_device_control_is_completed_with_empty_success_response() {
     assert_eq!(&encoded[..4], &[0x72, 0x44, 0x43, 0x49]); // RDPDR + DEVICE_IOCOMPLETION
     assert_eq!(ntstatus_at(&encoded, 12), NtStatus::SUCCESS);
     assert_eq!(read_u32(&encoded[16..]), 0); // OutputBufferLength
+}
+
+#[test]
+fn printer_device_control_consumes_declared_input_before_trailing_check() {
+    let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
+    acknowledge_printer(&mut rdpdr, NtStatus::SUCCESS);
+
+    let responses = rdpdr
+        .process(&encoded_printer_device_control_request_with_input(&[1, 2, 3]))
+        .unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(
+        ntstatus_at(&responses[0].encode_unframed_pdu().unwrap(), 12),
+        NtStatus::SUCCESS
+    );
 }
 
 #[test]

--- a/crates/ironrdp-web/src/printer.rs
+++ b/crates/ironrdp-web/src/printer.rs
@@ -360,6 +360,18 @@ impl RdpdrBackend for WasmPrinterBackend {
             }
         }
     }
+
+    fn reject_printer_write(&mut self, req: ironrdp::rdpdr::pdu::efs::DeviceIoRequest) -> PduResult<Vec<SvcMessage>> {
+        if self.open_files.remove(&req.file_id).is_some() {
+            self.proxy.send_job_aborted(req.file_id);
+        }
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(
+            DeviceWriteResponse {
+                device_io_reply: DeviceIoResponse::new(req, NtStatus::INVALID_PARAMETER),
+                length: 0,
+            },
+        ))])
+    }
 }
 
 /// Event-loop-side companion to [`WasmPrinterBackend`]. Owns the


### PR DESCRIPTION
Expose the preconnect RedirectPrinters setting and carry printer metadata through the RDPDR client factory.

Discover the current Windows default queue, negotiate its driver metadata, and stream bounded RAW jobs on a module-pinned worker. Ports, generic PnP/USB devices, multiple printers, and Easy Print/XPS remain unsupported.