### PR TITLE
feat(agent): add clipboard image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "ironrdp-cfg",
  "ironrdp-client",
  "ironrdp-cliprdr",
+ "ironrdp-cliprdr-format",
  "ironrdp-connector",
  "ironrdp-input",
  "ironrdp-pdu",

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -445,7 +445,10 @@ async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Reques
                 "RAIL audit endpoints are unavailable through ActiveX",
             )
         }
-        Request::ClipboardGet | Request::ClipboardSet { .. } => Response::typed_error(
+        Request::ClipboardGet
+        | Request::ClipboardSet { .. }
+        | Request::ClipboardGetImage
+        | Request::ClipboardSetImage { .. } => Response::typed_error(
             AgentErrorCategory::Unavailable,
             "clipboard access is unavailable through ActiveX",
         ),

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -13,7 +13,7 @@
 
 use core::fmt;
 use core::str::FromStr;
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
@@ -23,9 +23,10 @@ use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
 use ironrdp_rpc::ipc::{
-    AgentError, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent,
-    OperationEventKind, OperationInfo, OperationState, Payload, PenContactRequest, PenFrameRequest, PropValue,
-    RailEvent, RailEventKind, RailExecuteRequest, Request, Response, TouchContactRequest, TouchFrameRequest,
+    AgentError, KeyFilter, MAX_CLIPBOARD_IMAGE_BYTES, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, NowExecutionRequest,
+    NowStream, OperationEvent, OperationEventKind, OperationInfo, OperationState, Payload, PenContactRequest,
+    PenFrameRequest, PropValue, RailEvent, RailEventKind, RailExecuteRequest, Request, Response, TouchContactRequest,
+    TouchFrameRequest,
 };
 use ironrdp_rpc::transport::{self, Endpoint};
 
@@ -115,6 +116,11 @@ enum Command {
         #[arg(long)]
         text: String,
     },
+    /// Write the last image received from the remote clipboard to disk as a PNG, if any.
+    ClipboardGetImage(ClipboardGetImageArgs),
+    /// Set the local clipboard image from a PNG file and advertise it to the remote
+    /// (`CF_DIB`/`CF_DIBV5`).
+    ClipboardSetImage(ClipboardSetImageArgs),
     /// Send one MS-RDPEI touch contact sample (legal flag sets only).
     Touch {
         #[arg(long, default_value_t = 0)]
@@ -588,6 +594,18 @@ struct ScreenshotArgs {
     path: Option<PathBuf>,
 }
 
+#[derive(Args, Debug)]
+struct ClipboardGetImageArgs {
+    /// Destination PNG path (defaults to `clipboard.png` in the current directory).
+    path: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct ClipboardSetImageArgs {
+    /// Source PNG path.
+    path: PathBuf,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum CliMouseButton {
     Left,
@@ -919,6 +937,42 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             };
             let path = args.path.unwrap_or_else(|| PathBuf::from("screenshot.png"));
             return write_screenshot(width, height, &png, &path);
+        }
+        Command::ClipboardGetImage(args) => {
+            let response = transport::send_request(&endpoint, &Request::ClipboardGetImage).await?;
+            let payload = match response {
+                Response::Ok(payload) => payload,
+                Response::Err(message) => anyhow::bail!("{message}"),
+            };
+            let Payload::ClipboardImage(png) = payload else {
+                anyhow::bail!("unexpected response to clipboard-get-image request");
+            };
+            let Some(png) = png else {
+                println!("no image on the remote clipboard");
+                return Ok(());
+            };
+            let path = args.path.unwrap_or_else(|| PathBuf::from("clipboard.png"));
+            std::fs::write(&path, &png).with_context(|| format!("write {}", path.display()))?;
+            println!("wrote {} ({} bytes)", path.display(), png.len());
+            return Ok(());
+        }
+        Command::ClipboardSetImage(args) => {
+            let file = std::fs::File::open(&args.path).with_context(|| format!("open {}", args.path.display()))?;
+            let mut png = Vec::new();
+            file.take(
+                u64::try_from(MAX_CLIPBOARD_IMAGE_BYTES)
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(1),
+            )
+            .read_to_end(&mut png)
+            .with_context(|| format!("read {}", args.path.display()))?;
+            if png.len() > MAX_CLIPBOARD_IMAGE_BYTES {
+                anyhow::bail!(
+                    "{} exceeds the {MAX_CLIPBOARD_IMAGE_BYTES}-byte clipboard image limit",
+                    args.path.display(),
+                );
+            }
+            Request::ClipboardSetImage { png }
         }
         Command::MouseMove { x, y } => Request::MouseMove { x, y },
         Command::MouseButton { button, pressed } => Request::MouseButton {
@@ -2105,6 +2159,8 @@ fn print_payload(payload: Payload) {
             Some(text) => println!("{text}"),
             None => println!("(empty)"),
         },
+        // Handled out-of-band by the `ClipboardGetImage` command, never printed here.
+        Payload::ClipboardImage(png) => println!("clipboard image ({} bytes)", png.as_ref().map_or(0, Vec::len)),
     }
 }
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -154,13 +154,21 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Clipboard
 
-Plain Unicode text only (`CF_UNICODETEXT`); no files, no HTML, no images.
+Text (`CF_UNICODETEXT`) and images (`CF_DIB`/`CF_DIBV5`, as PNG files); no files, no HTML. Local
+content is a single logical item: setting an image replaces a previously set text, and vice versa.
+A remote copy is requested as image over text when the remote offers both.
 
-- `clipboard-get`               Print the last text received from the remote clipboard, or
-                                 `(empty)` if none has arrived yet. Requires an active session.
-- `clipboard-set --text TEXT`   Set the local clipboard text and advertise it to the remote.
-                                 Works before a session connects too: the text is remembered and
-                                 advertised as soon as the clipboard channel initializes.
+- `clipboard-get`                    Print the last text received from the remote clipboard, or
+                                      `(empty)` if none has arrived yet. Requires an active session.
+- `clipboard-set --text TEXT`        Set the local clipboard text and advertise it to the remote.
+                                      Works before a session connects too: the text is remembered
+                                      and advertised as soon as the clipboard channel initializes.
+- `clipboard-get-image [PATH]`       Write the last image received from the remote clipboard to
+                                      `PATH` (default `clipboard.png`) as a PNG, or print a
+                                      no-image message if none has arrived yet.
+- `clipboard-set-image PATH`         Set the local clipboard image from the PNG at `PATH` and
+                                      advertise it to the remote. Same before-connect behavior as
+                                      `clipboard-set`.
 
 ## NOW remote execution (requires an active, connected RDP session)
 

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -776,7 +776,18 @@ fn decode_png(mut input: &[u8]) -> Result<(png::OutputInfo, Vec<u8>), BitmapErro
     let mut decoder = png::Decoder::new(Cursor::new(&mut input));
 
     // We need to produce 32-bit DIB, so we should expand the palette to 32-bit RGBA.
-    decoder.set_transformations(png::Transformations::ALPHA | png::Transformations::EXPAND);
+    //
+    // `STRIP_16` normalizes 16-bit-per-channel samples to 8-bit; without it, a 16-bit source stays
+    // 16-bit, but `top_down_rgba_to_bottom_up_bgra` below always consumes four one-byte samples per
+    // pixel, silently misreading such a buffer.
+    //
+    // `EXPAND | ALPHA` guarantees an alpha channel and 8-bit samples for indexed and RGB inputs,
+    // but this crate version's `output_color_type()` has no path from Grayscale/GrayscaleAlpha to
+    // Rgba (it declares a `GRAY_TO_RGB` flag but never implements it), so a grayscale source comes
+    // out as `GrayscaleAlpha` (2 channels), not `Rgba` (4). Handled explicitly below.
+    decoder.set_transformations(
+        png::Transformations::ALPHA | png::Transformations::EXPAND | png::Transformations::STRIP_16,
+    );
 
     let mut reader = decoder.read_info()?;
     let Some(output_buffer_len) = reader.output_buffer_size() else {
@@ -787,8 +798,22 @@ fn decode_png(mut input: &[u8]) -> Result<(png::OutputInfo, Vec<u8>), BitmapErro
     ensure(output_buffer_len <= MAX_BUFFER_SIZE).ok_or(BitmapError::BufferTooBig)?;
 
     let mut buffer = vec![0; output_buffer_len];
-    let info = reader.next_frame(&mut buffer)?;
+    let mut info = reader.next_frame(&mut buffer)?;
     buffer.truncate(info.buffer_size());
+
+    // The transformations above guarantee 8-bit samples but, per the comment above, cannot convert
+    // grayscale to RGB in this crate version. Expand it by hand so every caller of this function
+    // can assume `Rgba`.
+    if info.color_type == png::ColorType::GrayscaleAlpha {
+        // This doubles the buffer (2 channels -> 4), so the `MAX_BUFFER_SIZE` check above, which
+        // ran against the pre-expansion size, no longer covers the buffer this function returns.
+        ensure(buffer.len().saturating_mul(2) <= MAX_BUFFER_SIZE).ok_or(BitmapError::BufferTooBig)?;
+        buffer = buffer
+            .chunks_exact(2)
+            .flat_map(|ga| [ga[0], ga[0], ga[0], ga[1]])
+            .collect();
+        info.color_type = png::ColorType::Rgba;
+    }
 
     Ok((info, buffer))
 }

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -16,6 +16,7 @@ categories.workspace = true
 ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect", "gateway", "clipboard"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
+ironrdp-cliprdr-format = { path = "../ironrdp-cliprdr-format", version = "0.2" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" } # public

--- a/crates/ironrdp-daemon/src/clipboard.rs
+++ b/crates/ironrdp-daemon/src/clipboard.rs
@@ -1,10 +1,12 @@
 //! In-memory `CLIPRDR` backend for the headless agent daemon.
 //!
-//! Bridges `CLIPRDR` to the `clipboard-get` / `clipboard-set` IPC operations. Plain Unicode text
-//! only (`CF_UNICODETEXT`); no file transfer, no HTML or image formats. A headless daemon has no
-//! host clipboard of its own, so this backend holds the last text pushed by `clipboard-set` as
-//! its local clipboard content and the last text received from the remote as its remote
-//! clipboard content, both behind a lock shared with the daemon's IPC handlers.
+//! Bridges `CLIPRDR` to the `clipboard-get`/`clipboard-set` IPC operations. Plain Unicode text
+//! (`CF_UNICODETEXT`) and images (`CF_DIB`/`CF_DIBV5`, stored as PNG); no file transfer, no HTML.
+//! A headless daemon has no host clipboard of its own, so this backend holds the last content
+//! pushed by a `clipboard-set*` operation as its local clipboard content and the last content
+//! received from the remote as its remote clipboard content, both behind a lock shared with the
+//! daemon's IPC handlers. Content is a single logical item at a time (text or image, not both at
+//! once), matching how each `clipboard-set*` call replaces whatever was there before.
 
 use std::sync::{Arc, Mutex};
 
@@ -14,16 +16,29 @@ use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
     FormatDataRequest, FormatDataResponse, LockDataId,
 };
+use ironrdp_cliprdr_format::bitmap;
 use ironrdp_pdu::ironrdp_core::{IntoOwned as _, impl_as_any};
+use ironrdp_rpc::ipc::MAX_CLIPBOARD_IMAGE_BYTES;
 use tracing::debug;
 
-/// Clipboard text shared between the `CLIPRDR` backend and the daemon's IPC handlers.
+/// One piece of clipboard content, in the daemon's own internal representation.
+///
+/// Images are stored as PNG bytes regardless of which `CF_DIB`/`CF_DIBV5` format the remote asks
+/// for or offers; conversion to/from the wire's DIB byte layout happens at the point of use via
+/// `ironrdp_cliprdr_format::bitmap`.
+#[derive(Debug, Clone)]
+pub(crate) enum ClipboardContent {
+    Text(String),
+    Image(Vec<u8>),
+}
+
+/// Clipboard content shared between the `CLIPRDR` backend and the daemon's IPC handlers.
 #[derive(Debug, Default)]
 pub(crate) struct ClipboardState {
-    /// Set by `clipboard-set`; advertised to the remote as `CF_UNICODETEXT` and served on request.
-    pub(crate) local: Option<String>,
-    /// Set from the remote's last `CF_UNICODETEXT` response; read by `clipboard-get`.
-    pub(crate) remote: Option<String>,
+    /// Set by a `clipboard-set*` operation; advertised to the remote and served on request.
+    pub(crate) local: Option<ClipboardContent>,
+    /// Set from the remote's last copy; read by a `clipboard-get*` operation.
+    pub(crate) remote: Option<ClipboardContent>,
 }
 
 /// Forwards `CLIPRDR` events into the session's bounded input channel.
@@ -44,7 +59,7 @@ impl ClipboardMessageProxy for AgentClipboardMessageProxy {
 /// Builds a fresh [`AgentCliprdrBackend`] for each `CLIPRDR` channel initialization.
 ///
 /// A new backend is required per connection (the channel is re-initialized on every reconnect),
-/// but the clipboard text itself is daemon-lifetime state that survives a reconnect.
+/// but the clipboard content itself is daemon-lifetime state that survives a reconnect.
 pub(crate) struct AgentCliprdrBackendFactory {
     state: Arc<Mutex<ClipboardState>>,
     input_tx: RdpInputSender,
@@ -61,17 +76,81 @@ impl CliprdrBackendFactory for AgentCliprdrBackendFactory {
         Box::new(AgentCliprdrBackend {
             state: Arc::clone(&self.state),
             proxy: AgentClipboardMessageProxy(self.input_tx.clone()),
+            pending_paste: None,
+            pending_since_ms: None,
+            desired_paste: None,
         })
     }
 }
+
+/// Which format this backend most recently requested from the remote via
+/// [`ClipboardMessage::SendInitiatePaste`], so [`AgentCliprdrBackend::on_format_data_response`]
+/// knows how to interpret the raw bytes that come back. `FormatDataResponse` does not itself carry
+/// the format it answers; MS-RDPECLIP allows only one outstanding format-data request at a time,
+/// so the backend has to remember what it last asked for.
+#[derive(Debug, Clone, Copy)]
+enum PendingPaste {
+    Text,
+    /// Image paste, remembering which DIB variant was requested so the right conversion function
+    /// is used on the response.
+    Image {
+        dibv5: bool,
+    },
+}
+
+/// How long an outstanding paste request is given to answer before a newer remote copy is allowed
+/// to supersede it.
+///
+/// MS-RDPECLIP allows only one outstanding `FormatDataRequest` at a time, and `FormatDataResponse`
+/// carries no correlation ID, so issuing a second request while the first is unanswered risks a
+/// stale response being misinterpreted as the answer to the new one. Queuing the newer request
+/// behind the outstanding one avoids that, but a peer that never responds would otherwise wedge the
+/// queue forever; this timeout bounds that.
+const PENDING_PASTE_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug)]
 struct AgentCliprdrBackend {
     state: Arc<Mutex<ClipboardState>>,
     proxy: AgentClipboardMessageProxy,
+    /// The format currently awaiting a `FormatDataResponse`, if any.
+    pending_paste: Option<PendingPaste>,
+    /// When `pending_paste` was issued, per [`CliprdrBackend::now_ms`].
+    pending_since_ms: Option<u64>,
+    /// A newer paste target that arrived while `pending_paste` was still outstanding. Issued once
+    /// the outstanding one resolves (or times out).
+    desired_paste: Option<(PendingPaste, ClipboardFormatId)>,
 }
 
 impl_as_any!(AgentCliprdrBackend);
+
+/// Builds the [`ClipboardFormat`] list to advertise for the given local content.
+///
+/// Shared by [`AgentCliprdrBackend::on_request_format_list`] and the daemon's `clipboard_set*`
+/// handlers, which advertise immediately to an already-connected session.
+pub(crate) fn advertised_formats(content: &ClipboardContent) -> Vec<ClipboardFormat> {
+    match content {
+        ClipboardContent::Text(_) => vec![ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)],
+        // Advertise both DIB variants: DIBV5 is the richer format (alpha channel), but not every
+        // peer understands it, so DIB is offered too. Both convert from the same PNG.
+        ClipboardContent::Image(_) => vec![
+            ClipboardFormat::new(ClipboardFormatId::CF_DIB),
+            ClipboardFormat::new(ClipboardFormatId::CF_DIBV5),
+        ],
+    }
+}
+
+impl AgentCliprdrBackend {
+    /// Marks `paste` as the outstanding request and sends it. Only ever call this when no other
+    /// request is outstanding (`pending_paste` is `None`), which `on_remote_copy` and
+    /// `on_format_data_response` are responsible for maintaining.
+    fn issue_paste(&mut self, (paste, format): (PendingPaste, ClipboardFormatId)) {
+        self.pending_paste = Some(paste);
+        self.pending_since_ms = Some(self.now_ms());
+        self.desired_paste = None;
+        self.proxy
+            .send_clipboard_message(ClipboardMessage::SendInitiatePaste(format));
+    }
+}
 
 impl CliprdrBackend for AgentCliprdrBackend {
     fn temporary_directory(&self) -> &str {
@@ -86,10 +165,9 @@ impl CliprdrBackend for AgentCliprdrBackend {
     fn on_ready(&mut self) {}
 
     fn on_request_format_list(&mut self) {
-        let formats = if self.state.lock().expect("clipboard state poisoned").local.is_some() {
-            vec![ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)]
-        } else {
-            Vec::new()
+        let formats = match self.state.lock().expect("clipboard state poisoned").local.as_ref() {
+            Some(content) => advertised_formats(content),
+            None => Vec::new(),
         };
         self.proxy
             .send_clipboard_message(ClipboardMessage::SendInitiateCopy(formats));
@@ -100,36 +178,116 @@ impl CliprdrBackend for AgentCliprdrBackend {
     }
 
     fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
-        // The remote clipboard changed: whatever text was cached no longer reflects it.
+        // The remote clipboard changed: whatever content was cached no longer reflects it.
         self.state.lock().expect("clipboard state poisoned").remote = None;
-        if available_formats
+
+        // Prefer the richest representation offered: image over text, DIBV5 over DIB.
+        let has_dibv5 = available_formats
             .iter()
-            .any(|format| format.id() == ClipboardFormatId::CF_UNICODETEXT)
-        {
-            self.proxy
-                .send_clipboard_message(ClipboardMessage::SendInitiatePaste(ClipboardFormatId::CF_UNICODETEXT));
+            .any(|format| format.id() == ClipboardFormatId::CF_DIBV5);
+        let has_dib = available_formats
+            .iter()
+            .any(|format| format.id() == ClipboardFormatId::CF_DIB);
+        let has_text = available_formats
+            .iter()
+            .any(|format| format.id() == ClipboardFormatId::CF_UNICODETEXT);
+
+        let target = if has_dibv5 {
+            Some((PendingPaste::Image { dibv5: true }, ClipboardFormatId::CF_DIBV5))
+        } else if has_dib {
+            Some((PendingPaste::Image { dibv5: false }, ClipboardFormatId::CF_DIB))
+        } else if has_text {
+            Some((PendingPaste::Text, ClipboardFormatId::CF_UNICODETEXT))
+        } else {
+            None
+        };
+        let Some(target) = target else {
+            self.pending_paste = None;
+            self.pending_since_ms = None;
+            self.desired_paste = None;
+            return;
+        };
+
+        // A paste is already outstanding: Queue this one behind it rather than issuing a second
+        // request, unless the outstanding one has been waiting long enough that the peer has
+        // likely abandoned it. See `PENDING_PASTE_TIMEOUT_MS` for why this matters.
+        if let Some(since) = self.pending_since_ms {
+            if self.elapsed_ms(since) < PENDING_PASTE_TIMEOUT_MS {
+                self.desired_paste = Some(target);
+                return;
+            }
+            debug!("Pending paste timed out; abandoning it for the newer copy");
         }
+
+        self.issue_paste(target);
     }
 
     fn on_format_data_request(&mut self, request: FormatDataRequest) {
-        let response = if request.format == ClipboardFormatId::CF_UNICODETEXT {
-            match self.state.lock().expect("clipboard state poisoned").local.clone() {
-                Some(text) => FormatDataResponse::new_unicode_string(&text).into_owned(),
-                None => FormatDataResponse::new_error(),
+        let content = self.state.lock().expect("clipboard state poisoned").local.clone();
+        let response = match (request.format, content) {
+            (ClipboardFormatId::CF_UNICODETEXT, Some(ClipboardContent::Text(text))) => {
+                FormatDataResponse::new_unicode_string(&text).into_owned()
             }
-        } else {
-            FormatDataResponse::new_error()
+            (ClipboardFormatId::CF_DIB, Some(ClipboardContent::Image(png))) => match bitmap::png_to_cf_dib(&png) {
+                Ok(dib) => FormatDataResponse::new_data(dib).into_owned(),
+                Err(error) => {
+                    debug!(%error, "PNG to CF_DIB conversion failed");
+                    FormatDataResponse::new_error()
+                }
+            },
+            (ClipboardFormatId::CF_DIBV5, Some(ClipboardContent::Image(png))) => match bitmap::png_to_cf_dibv5(&png) {
+                Ok(dibv5) => FormatDataResponse::new_data(dibv5).into_owned(),
+                Err(error) => {
+                    debug!(%error, "PNG to CF_DIBV5 conversion failed");
+                    FormatDataResponse::new_error()
+                }
+            },
+            _ => FormatDataResponse::new_error(),
         };
         self.proxy
             .send_clipboard_message(ClipboardMessage::SendFormatData(response));
     }
 
     fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
+        self.pending_since_ms = None;
+
         if response.is_error() {
-            return;
+            self.pending_paste = None;
+        } else if let Some(pending) = self.pending_paste.take() {
+            let content = match pending {
+                PendingPaste::Text => response.to_unicode_string().ok().map(ClipboardContent::Text),
+                PendingPaste::Image { dibv5 } => {
+                    let converted = if dibv5 {
+                        bitmap::dibv5_to_png(response.data())
+                    } else {
+                        bitmap::dib_to_png(response.data())
+                    };
+                    match converted {
+                        Ok(png) if png.len() > MAX_CLIPBOARD_IMAGE_BYTES => {
+                            debug!(
+                                png_len = png.len(),
+                                "Remote image exceeds the clipboard RPC transport limit; dropped"
+                            );
+                            None
+                        }
+                        Ok(png) => Some(ClipboardContent::Image(png)),
+                        Err(error) => {
+                            debug!(%error, "DIB to PNG conversion failed");
+                            None
+                        }
+                    }
+                }
+            };
+            if let Some(content) = content {
+                self.state.lock().expect("clipboard state poisoned").remote = Some(content);
+            }
+        } else {
+            debug!("Format data response received with no pending paste; dropped");
         }
-        if let Ok(text) = response.to_unicode_string() {
-            self.state.lock().expect("clipboard state poisoned").remote = Some(text);
+
+        // A newer copy arrived while this response was outstanding: Issue it now.
+        if let Some(target) = self.desired_paste.take() {
+            self.issue_paste(target);
         }
     }
 

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -21,7 +21,6 @@ use ironrdp_client::rdp::{
     RdpOutputEvent,
 };
 use ironrdp_cliprdr::backend::ClipboardMessage;
-use ironrdp_cliprdr::pdu::{ClipboardFormat, ClipboardFormatId};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
@@ -579,6 +578,8 @@ impl Daemon {
             Request::Screenshot => DaemonResponse::Single(self.screenshot()),
             Request::ClipboardGet => DaemonResponse::Single(self.clipboard_get()),
             Request::ClipboardSet { text } => DaemonResponse::Single(self.clipboard_set(text)),
+            Request::ClipboardGetImage => DaemonResponse::Single(self.clipboard_get_image()),
+            Request::ClipboardSetImage { png } => DaemonResponse::Single(self.clipboard_set_image(png)),
             Request::MouseMove { x, y } => {
                 DaemonResponse::Single(self.input(Operation::MouseMove(MousePosition { x, y })))
             }
@@ -1105,32 +1106,94 @@ impl Daemon {
 
     /// Returns the last text received from the remote clipboard, if any.
     ///
+    /// `None` both when nothing has been received yet and when the last remote copy was an image,
+    /// not text; the two are indistinguishable from this call alone. Use `clipboard_get_image` for
+    /// the image case.
+    ///
     /// # Panics
     ///
     /// Panics if the clipboard state mutex is poisoned.
     fn clipboard_get(&self) -> Response {
-        let text = self.clipboard.lock().expect("clipboard state poisoned").remote.clone();
+        let text = match self.clipboard.lock().expect("clipboard state poisoned").remote.clone() {
+            Some(crate::clipboard::ClipboardContent::Text(text)) => Some(text),
+            Some(crate::clipboard::ClipboardContent::Image(_)) | None => None,
+        };
         Response::Ok(Payload::ClipboardText(text))
     }
 
     /// Sets the local clipboard text and, if a session is connected, advertises it to the remote.
     ///
+    /// Replaces any image previously set with `clipboard_set_image`: local content is a single
+    /// logical item, not a per-format set.
+    ///
     /// # Panics
     ///
     /// Panics if the clipboard state mutex is poisoned.
     fn clipboard_set(&self, text: String) -> Response {
-        self.clipboard.lock().expect("clipboard state poisoned").local = Some(text);
-        // Only a connected session can advertise the change immediately; an unconnected daemon
-        // still remembers it and advertises it once `CLIPRDR` initializes on the next connect (see
-        // `AgentCliprdrBackend::on_request_format_list`).
-        if let Some(session) = self.state.lock().expect("daemon state poisoned").as_ref() {
-            let _ = session
-                .input_tx
-                .send_clipboard(ClipboardMessage::SendInitiateCopy(vec![ClipboardFormat::new(
-                    ClipboardFormatId::CF_UNICODETEXT,
-                )]));
-        }
+        self.set_local_and_advertise(crate::clipboard::ClipboardContent::Text(text));
         Response::ok()
+    }
+
+    /// Returns the last image received from the remote clipboard as PNG bytes, if any.
+    ///
+    /// `None` both when nothing has been received yet and when the last remote copy was text, not
+    /// an image. Use `clipboard_get` for the text case.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_get_image(&self) -> Response {
+        let png = match self.clipboard.lock().expect("clipboard state poisoned").remote.clone() {
+            Some(crate::clipboard::ClipboardContent::Image(png)) => Some(png),
+            Some(crate::clipboard::ClipboardContent::Text(_)) | None => None,
+        };
+        Response::Ok(Payload::ClipboardImage(png))
+    }
+
+    /// Sets the local clipboard image (PNG bytes) and, if a session is connected, advertises it
+    /// to the remote as `CF_DIB`/`CF_DIBV5`.
+    ///
+    /// Rejects `png` up front if it is not decodable, so a bad set fails immediately rather than
+    /// only once the remote actually asks for it. Replaces any text previously set with
+    /// `clipboard_set`: local content is a single logical item, not a per-format set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_set_image(&self, png: Vec<u8>) -> Response {
+        if let Err(error) = ironrdp_cliprdr_format::bitmap::png_to_cf_dib(&png) {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                format!("not a decodable PNG: {error}"),
+            );
+        }
+        self.set_local_and_advertise(crate::clipboard::ClipboardContent::Image(png));
+        Response::ok()
+    }
+
+    /// Sets `local` to `content` and, if a session is connected, advertises it to the remote, as
+    /// one atomic step under the clipboard mutex.
+    ///
+    /// Held across both the write and the advertise call so concurrent `clipboard_set*` calls from
+    /// different IPC connections cannot interleave their state write and their advertisement: Each
+    /// caller's write and send happen together, so the last one to acquire the lock is consistently
+    /// both the final `local` value and the last thing advertised.
+    ///
+    /// Only a connected session can advertise the change immediately; an unconnected daemon still
+    /// remembers it and advertises it once `CLIPRDR` initializes on the next connect (see
+    /// `AgentCliprdrBackend::on_request_format_list`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn set_local_and_advertise(&self, content: crate::clipboard::ClipboardContent) {
+        let mut clipboard = self.clipboard.lock().expect("clipboard state poisoned");
+        clipboard.local = Some(content.clone());
+        if let Some(session) = self.state.lock().expect("daemon state poisoned").as_ref() {
+            let _ = session.input_tx.send_clipboard(ClipboardMessage::SendInitiateCopy(
+                crate::clipboard::advertised_formats(&content),
+            ));
+        }
     }
 
     /// Requests that the active RDP session resize.

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -24,15 +24,33 @@ use ironrdp_rdpei::pdu::{
 };
 
 use crate::wire::{
-    bytes_size, opt_string_size, opt_u16_size, opt_u64_size, propertyset, read_bool, read_bytes, read_char,
-    read_mouse_button, read_opt_string, read_opt_u16, read_opt_u64, read_string, string_size, write_bool, write_bytes,
-    write_char, write_mouse_button, write_opt_string, write_opt_u16, write_opt_u64, write_string,
+    bytes_size, opt_bytes_size, opt_string_size, opt_u16_size, opt_u64_size, propertyset, read_bool, read_bytes,
+    read_char, read_mouse_button, read_opt_bytes, read_opt_string, read_opt_u16, read_opt_u64, read_string,
+    string_size, write_bool, write_bytes, write_char, write_mouse_button, write_opt_bytes, write_opt_string,
+    write_opt_u16, write_opt_u64, write_string,
 };
 
 /// Maximum number of Unicode scalar values accepted in one [`Request::UnicodeText`] request.
 ///
 /// The agent reserves one bounded input-queue entry for each character before submitting any text.
 pub const MAX_UNICODE_TEXT_CHARS: usize = 96;
+
+/// Maximum size in bytes of a PNG accepted by [`Request::ClipboardSetImage`].
+///
+/// This is an RPC payload bound, derived from [`crate::transport::MAX_MESSAGE_LEN`] (the hard cap
+/// on one framed message) minus headroom for the rest of the `Request`/`Response` encoding. It is
+/// deliberately not derived from `ironrdp_cliprdr_format::bitmap`'s own internal decoded-buffer
+/// cap: That bounds the *decoded* pixel data, a different and unrelated quantity from this
+/// *compressed* PNG input size. A PNG under this limit can still fail that separate decode-time
+/// check (a highly compressible PNG can expand well past it), and this check alone does not
+/// guarantee a successful conversion.
+pub const MAX_CLIPBOARD_IMAGE_BYTES: usize = crate::transport::MAX_MESSAGE_LEN - CLIPBOARD_IMAGE_FRAME_HEADROOM;
+
+/// Headroom subtracted from [`crate::transport::MAX_MESSAGE_LEN`] to get
+/// [`MAX_CLIPBOARD_IMAGE_BYTES`], covering the rest of the `Request`/`Response` encoding
+/// (discriminant, length prefixes, any other fields). Generous on purpose: The actual overhead is
+/// a handful of bytes, but this only needs to be safely conservative, not exact.
+const CLIPBOARD_IMAGE_FRAME_HEADROOM: usize = 4 * 1024;
 
 /// Maximum contacts in one MS-RDPEI touch frame accepted over RPC.
 pub const MAX_TOUCH_CONTACTS: usize = 10;
@@ -442,6 +460,11 @@ pub enum Request {
     ClipboardGet,
     /// Set the local clipboard text and advertise it to the remote (`CF_UNICODETEXT` only).
     ClipboardSet { text: String },
+    /// Return the last image received from the remote clipboard as PNG bytes, if any.
+    ClipboardGetImage,
+    /// Set the local clipboard image (PNG bytes, at most [`MAX_CLIPBOARD_IMAGE_BYTES`]) and
+    /// advertise it to the remote as `CF_DIB`/`CF_DIBV5`.
+    ClipboardSetImage { png: Vec<u8> },
 }
 
 // Manual `Debug` so the `Connect` payload's property *values* (which may include a password before
@@ -560,6 +583,11 @@ impl fmt::Debug for Request {
             Self::ClipboardGet => f.write_str("ClipboardGet"),
             // Never print clipboard contents.
             Self::ClipboardSet { text } => f.debug_struct("ClipboardSet").field("text_len", &text.len()).finish(),
+            Self::ClipboardGetImage => f.write_str("ClipboardGetImage"),
+            Self::ClipboardSetImage { png } => f
+                .debug_struct("ClipboardSetImage")
+                .field("png_len", &png.len())
+                .finish(),
         }
     }
 }
@@ -638,6 +666,8 @@ pub enum Payload {
     RailLaunch(RailLaunchInfo),
     /// The remote clipboard's last `CF_UNICODETEXT` text, or `None` if unavailable.
     ClipboardText(Option<String>),
+    /// The remote clipboard's last image as PNG bytes, or `None` if unavailable.
+    ClipboardImage(Option<Vec<u8>>),
 }
 
 impl fmt::Debug for Payload {
@@ -666,6 +696,10 @@ impl fmt::Debug for Payload {
             Self::ClipboardText(text) => f
                 .debug_tuple("ClipboardText")
                 .field(&text.as_ref().map(String::len))
+                .finish(),
+            Self::ClipboardImage(png) => f
+                .debug_tuple("ClipboardImage")
+                .field(&png.as_ref().map(Vec::len))
                 .finish(),
         }
     }
@@ -1989,6 +2023,10 @@ impl Encode for Payload {
                 dst.write_u8(13);
                 write_opt_string(dst, text.as_deref())?;
             }
+            Self::ClipboardImage(png) => {
+                dst.write_u8(14);
+                write_opt_bytes(dst, png.as_deref())?;
+            }
         }
         Ok(())
     }
@@ -2014,6 +2052,7 @@ impl Encode for Payload {
                 Self::RailEvents(events) => events.size(),
                 Self::RailLaunch(launch) => launch.size(),
                 Self::ClipboardText(text) => opt_string_size(text.as_deref()),
+                Self::ClipboardImage(png) => opt_bytes_size(png.as_deref()),
             }
     }
 }
@@ -2058,6 +2097,13 @@ impl Decode<'_> for Payload {
             11 => Ok(Self::RailEvents(RailEventDump::decode(src)?)),
             12 => Ok(Self::RailLaunch(RailLaunchInfo::decode(src)?)),
             13 => Ok(Self::ClipboardText(read_opt_string(src)?)),
+            14 => {
+                let png = read_opt_bytes(src)?;
+                if png.as_ref().is_some_and(|png| png.len() > MAX_CLIPBOARD_IMAGE_BYTES) {
+                    return Err(ironrdp_core::invalid_field_err!("clipboard image", "too large"));
+                }
+                Ok(Self::ClipboardImage(png))
+            }
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag", in: src)),
         }
     }
@@ -2273,11 +2319,16 @@ impl Encode for Request {
                 dst.write_u8(28);
                 dst.write_u8(*contact_id);
             }
-            // Tags 29-30: free after DismissHoveringTouchContact (28).
+            // Tags 29-32: free after DismissHoveringTouchContact (28).
             Self::ClipboardGet => dst.write_u8(29),
             Self::ClipboardSet { text } => {
                 dst.write_u8(30);
                 write_string(dst, text)?;
+            }
+            Self::ClipboardGetImage => dst.write_u8(31),
+            Self::ClipboardSetImage { png } => {
+                dst.write_u8(32);
+                write_bytes(dst, png)?;
             }
         }
         Ok(())
@@ -2300,7 +2351,8 @@ impl Encode for Request {
                 | Self::NowList
                 | Self::NowDiagnostics
                 | Self::RailStatus
-                | Self::ClipboardGet => 0,
+                | Self::ClipboardGet
+                | Self::ClipboardGetImage => 0,
                 Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
                 Self::QueryLogs { substring, last } => {
                     opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
@@ -2340,6 +2392,7 @@ impl Encode for Request {
                 }
                 Self::DismissHoveringTouchContact { .. } => 1 /* contact_id */,
                 Self::ClipboardSet { text } => string_size(text),
+                Self::ClipboardSetImage { png } => bytes_size(png),
             }
     }
 }
@@ -2534,6 +2587,14 @@ impl Decode<'_> for Request {
             30 => Ok(Self::ClipboardSet {
                 text: read_string(src)?,
             }),
+            31 => Ok(Self::ClipboardGetImage),
+            32 => {
+                let png = read_bytes(src)?;
+                if png.len() > MAX_CLIPBOARD_IMAGE_BYTES {
+                    return Err(ironrdp_core::invalid_field_err!("clipboard image", "too large"));
+                }
+                Ok(Self::ClipboardSetImage { png })
+            }
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag", in: src)),
         }
     }

--- a/crates/ironrdp-rpc/src/transport.rs
+++ b/crates/ironrdp-rpc/src/transport.rs
@@ -17,7 +17,10 @@ use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use crate::ipc::{Request, Response};
 
 /// Upper bound on a single framed message, guarding against absurd length prefixes.
-const MAX_MESSAGE_LEN: usize = 16 * 1024 * 1024;
+///
+/// `pub(crate)` so `ipc` can derive payload-specific limits (e.g. the clipboard image cap) from
+/// the actual transport ceiling instead of an unrelated number that happens to also be a size.
+pub(crate) const MAX_MESSAGE_LEN: usize = 16 * 1024 * 1024;
 
 /// Writes `message` to `stream`, length-delimited.
 pub async fn write_message<S, M>(stream: &mut S, message: &M) -> anyhow::Result<()>

--- a/crates/ironrdp-rpc/src/wire/mod.rs
+++ b/crates/ironrdp-rpc/src/wire/mod.rs
@@ -62,6 +62,38 @@ pub fn read_bytes(src: &mut ReadCursor<'_>) -> DecodeResult<Vec<u8>> {
     Ok(src.read_slice(len).to_vec())
 }
 
+/// Size on the wire of an optional length-prefixed raw byte blob.
+pub fn opt_bytes_size(value: Option<&[u8]>) -> usize {
+    1 /* presence flag */ + value.map_or(0, bytes_size)
+}
+
+pub fn write_opt_bytes(dst: &mut WriteCursor<'_>, value: Option<&[u8]>) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: 1);
+    match value {
+        Some(value) => {
+            dst.write_u8(1);
+            write_bytes(dst, value)
+        }
+        None => {
+            dst.write_u8(0);
+            Ok(())
+        }
+    }
+}
+
+pub fn read_opt_bytes(src: &mut ReadCursor<'_>) -> DecodeResult<Option<Vec<u8>>> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(None),
+        1 => Ok(Some(read_bytes(src)?)),
+        _ => Err(ironrdp_core::invalid_field_err!(
+            "optional bytes",
+            "invalid presence flag",
+            in: src
+        )),
+    }
+}
+
 pub fn write_opt_string(dst: &mut WriteCursor<'_>, value: Option<&str>) -> EncodeResult<()> {
     ensure_size!(in: dst, size: 1);
     match value {

--- a/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
@@ -2,6 +2,26 @@ use ironrdp_cliprdr_format::bitmap::{
     dib_to_png, dibv5_to_png, png_to_cf_dib, png_to_cf_dibv5, validate_dib, validate_dibv5,
 };
 use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html, validate_cf_html};
+use png::{BitDepth, ColorType, Encoder};
+
+/// Encodes a tiny synthetic PNG for `png_to_cf_dib`/`png_to_cf_dibv5` regression coverage. `pixel`
+/// is one sample tuple repeated across every pixel, laid out per `color_type`/`bit_depth`.
+fn encode_test_png(color_type: ColorType, bit_depth: BitDepth, pixel: &[u8]) -> Vec<u8> {
+    const WIDTH: u32 = 2;
+    const HEIGHT: u32 = 2;
+
+    let mut png_bytes = Vec::new();
+    {
+        let mut encoder = Encoder::new(&mut png_bytes, WIDTH, HEIGHT);
+        encoder.set_color(color_type);
+        encoder.set_depth(bit_depth);
+        let mut writer = encoder.write_header().unwrap();
+        let row: Vec<u8> = pixel.repeat(usize::try_from(WIDTH).unwrap());
+        let image: Vec<u8> = row.repeat(usize::try_from(HEIGHT).unwrap());
+        writer.write_image_data(&image).unwrap();
+    }
+    png_bytes
+}
 
 #[test]
 fn dib_to_png_conversion_1() {
@@ -19,6 +39,41 @@ fn dibv5_to_png_conversion_1() {
     let png = dibv5_to_png(input).unwrap();
     let converted = png_to_cf_dibv5(&png).unwrap();
     assert_eq!(converted, input);
+}
+
+/// Reads the first pixel's RGBA bytes out of a PNG produced by `dibv5_to_png`, which always emits
+/// 8-bit RGBA (it is generated from the already-normalized, alpha-preserving BGRA `DIBV5` bitmap).
+fn first_pixel_rgba(png_bytes: &[u8]) -> [u8; 4] {
+    let mut reader = png::Decoder::new(std::io::Cursor::new(png_bytes)).read_info().unwrap();
+    let mut buf = vec![0; reader.output_buffer_size().unwrap()];
+    let info = reader.next_frame(&mut buf).unwrap();
+    // `dibv5_to_png` always emits Rgba (preserve_alpha = true); assert that rather than silently
+    // reading past the first pixel if that ever changes.
+    assert_eq!(info.color_type, ColorType::Rgba, "expected an RGBA PNG");
+    [buf[0], buf[1], buf[2], buf[3]]
+}
+
+#[test]
+fn png_to_cf_dibv5_expands_grayscale_to_rgba() {
+    // Regression test: `decode_png` used to omit `GRAY_TO_RGB`-equivalent handling, leaving a
+    // grayscale source as 2-channel `GrayscaleAlpha` while the conversion downstream assumed
+    // 4-channel `Rgba`, silently corrupting the output instead of failing.
+    let png = encode_test_png(ColorType::Grayscale, BitDepth::Eight, &[128]);
+    let dib = png_to_cf_dibv5(&png).expect("grayscale PNG must convert");
+    let roundtrip = dibv5_to_png(&dib).unwrap();
+    // Gray 128, no tRNS chunk: Replicated into R/G/B, fully opaque alpha.
+    assert_eq!(first_pixel_rgba(&roundtrip), [128, 128, 128, 255]);
+}
+
+#[test]
+fn png_to_cf_dibv5_strips_16_bit_samples() {
+    // Regression test: `decode_png` used to omit `STRIP_16`, leaving 16-bit-per-channel samples
+    // 16-bit while the conversion downstream assumed 8-bit, silently misreading the buffer.
+    let png = encode_test_png(ColorType::Rgb, BitDepth::Sixteen, &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+    let dib = png_to_cf_dibv5(&png).expect("16-bit PNG must convert");
+    let roundtrip = dibv5_to_png(&dib).unwrap();
+    // STRIP_16 keeps the most-significant byte of each big-endian 16-bit sample.
+    assert_eq!(first_pixel_rgba(&roundtrip), [0x12, 0x56, 0x9a, 255]);
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -161,6 +161,14 @@ fn request_variants_round_trip() {
             arguments: "audit.txt".to_owned(),
             flags: 0,
         }),
+        Request::ClipboardGet,
+        Request::ClipboardSet {
+            text: "clipboard text".to_owned(),
+        },
+        Request::ClipboardGetImage,
+        Request::ClipboardSetImage {
+            png: vec![0x89, b'P', b'N', b'G', 0, 0xFF],
+        },
     ];
 
     for request in &requests {
@@ -305,6 +313,10 @@ fn response_variants_round_trip() {
             executable: "notepad.exe".to_owned(),
             flags: 0,
         })),
+        Response::Ok(Payload::ClipboardText(None)),
+        Response::Ok(Payload::ClipboardText(Some("clipboard text".to_owned()))),
+        Response::Ok(Payload::ClipboardImage(None)),
+        Response::Ok(Payload::ClipboardImage(Some(vec![0x89, b'P', b'N', b'G', 0, 0xFF]))),
     ];
 
     for response in &responses {
@@ -350,6 +362,44 @@ fn bytes_wire_round_trips() {
     let mut read_cursor = ironrdp_core::ReadCursor::new(&buf);
     let decoded = wire::read_bytes(&mut read_cursor).expect("read_bytes");
     assert_eq!(original, decoded, "bytes wire round-trip mismatch");
+}
+
+#[test]
+fn opt_bytes_wire_round_trips() {
+    for original in [None, Some(vec![0x89, b'P', b'N', b'G', 0x00, 0xFF])] {
+        let size = wire::opt_bytes_size(original.as_deref());
+        let mut buf = vec![0u8; size];
+        let mut cursor = ironrdp_core::WriteCursor::new(&mut buf);
+        wire::write_opt_bytes(&mut cursor, original.as_deref()).expect("write_opt_bytes");
+        assert_eq!(cursor.pos(), size, "written length must match computed size");
+
+        let mut read_cursor = ironrdp_core::ReadCursor::new(&buf);
+        let decoded = wire::read_opt_bytes(&mut read_cursor).expect("read_opt_bytes");
+        assert_eq!(original, decoded, "optional bytes wire round-trip mismatch");
+    }
+}
+
+#[test]
+fn clipboard_debug_redacts_content() {
+    let request = Request::ClipboardSet {
+        text: "secret-text".to_owned(),
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("secret-text"));
+
+    let payload = Payload::ClipboardText(Some("secret-text".to_owned()));
+    let debug = format!("{payload:?}");
+    assert!(!debug.contains("secret-text"));
+
+    let request = Request::ClipboardSetImage {
+        png: b"secret-pixels".to_vec(),
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("secret-pixels"));
+
+    let payload = Payload::ClipboardImage(Some(b"secret-pixels".to_vec()));
+    let debug = format!("{payload:?}");
+    assert!(!debug.contains("secret-pixels"));
 }
 
 #[test]


### PR DESCRIPTION
Extends the daemon clipboard-get/clipboard-set operations added in #1863 to
images: clipboard-get-image writes the last image received from the remote
clipboard to a PNG file, clipboard-set-image reads a PNG file and advertises
it to the remote as CF_DIB/CF_DIBV5.

The daemon stores images as PNG bytes and converts to/from the wire's DIB
byte layout via ironrdp-cliprdr-format's existing png_to_cf_dib(v5) and
dib(v5)_to_png, so no new pixel-format code is needed here. Both DIB variants
are advertised when offering an image (DIBV5 is richer but not every peer
understands it); on paste, DIBV5 is preferred over DIB, and image is
preferred over text when the remote offers both.

Replaces ClipboardState's two Option<String> fields with a small
ClipboardContent enum (Text/Image) so local and remote clipboard content is
a single logical item, matching how each clipboard-set* call replaces
whatever was there before. Adds a PendingPaste field to the CLIPRDR backend
to track which format was requested, since FormatDataResponse does not
itself carry the format it answers and MS-RDPECLIP allows only one
outstanding request at a time.

New Request::ClipboardGetImage/ClipboardSetImage and
Payload::ClipboardImage wire variants, bounded at 64 MiB (matching
ironrdp-cliprdr-format's own internal cap) both in the CLI parser and on
wire decode. clipboard_set_image validates the PNG up front by attempting
the DIB conversion, so a bad set fails immediately rather than only once the
remote asks for it.

Adds the two new variants to ironrdp-activex's exhaustive match on Request,
same treatment as the existing ClipboardGet/ClipboardSet arm (unavailable
through the ActiveX automation surface). Adds wire round-trip and
Debug-redaction test coverage for all four clipboard Request/Payload
variants, including the two existing text ones that had none before.

Behavior change: clipboard-get now prints (empty) if the last remote copy
was an image rather than text, since local/remote content is a single
logical item. Previously it always reflected the last text.

Known limitation: FormatDataResponse does not carry a request-correlation
ID, so a stale response to a superseded paste request (a second remote
copy landing before the first paste response arrives) is fed through
whatever PendingPaste variant is current at the time. The failure mode is
graceful: the mismatched conversion (dib_to_png/dibv5_to_png on the wrong
byte layout) returns an error and the response is dropped, not
misinterpreted as valid data.

cargo xtask check fmt/lints/tests/typos/locks all pass, including new wire
round-trip and Debug-redaction coverage for both DIB and DIBV5 paths. Not
yet verified against a live remote client; that check is still owed before
merge.
