### PR TITLE
feat(agent): add clipboard HTML support

### DIFF
--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -448,7 +448,9 @@ async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Reques
         Request::ClipboardGet
         | Request::ClipboardSet { .. }
         | Request::ClipboardGetImage
-        | Request::ClipboardSetImage { .. } => Response::typed_error(
+        | Request::ClipboardSetImage { .. }
+        | Request::ClipboardGetHtml
+        | Request::ClipboardSetHtml { .. } => Response::typed_error(
             AgentErrorCategory::Unavailable,
             "clipboard access is unavailable through ActiveX",
         ),

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -23,10 +23,10 @@ use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
 use ironrdp_rpc::ipc::{
-    AgentError, KeyFilter, MAX_CLIPBOARD_IMAGE_BYTES, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, NowExecutionRequest,
-    NowStream, OperationEvent, OperationEventKind, OperationInfo, OperationState, Payload, PenContactRequest,
-    PenFrameRequest, PropValue, RailEvent, RailEventKind, RailExecuteRequest, Request, Response, TouchContactRequest,
-    TouchFrameRequest,
+    AgentError, KeyFilter, MAX_CLIPBOARD_HTML_BYTES, MAX_CLIPBOARD_IMAGE_BYTES, MAX_UNICODE_TEXT_CHARS,
+    NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo,
+    OperationState, Payload, PenContactRequest, PenFrameRequest, PropValue, RailEvent, RailEventKind,
+    RailExecuteRequest, Request, Response, TouchContactRequest, TouchFrameRequest,
 };
 use ironrdp_rpc::transport::{self, Endpoint};
 
@@ -121,6 +121,13 @@ enum Command {
     /// Set the local clipboard image from a PNG file and advertise it to the remote
     /// (`CF_DIB`/`CF_DIBV5`).
     ClipboardSetImage(ClipboardSetImageArgs),
+    /// Print the last HTML fragment received from the remote clipboard, if any.
+    ClipboardGetHtml,
+    /// Set the local clipboard HTML fragment and advertise it to the remote (`HTML Format`).
+    ClipboardSetHtml {
+        #[arg(long, value_parser = parse_clipboard_html)]
+        html: String,
+    },
     /// Send one MS-RDPEI touch contact sample (legal flag sets only).
     Touch {
         #[arg(long, default_value_t = 0)]
@@ -695,6 +702,16 @@ fn parse_unicode_text(input: &str) -> Result<String, String> {
     Ok(input.to_owned())
 }
 
+fn parse_clipboard_html(input: &str) -> Result<String, String> {
+    if input.len() > MAX_CLIPBOARD_HTML_BYTES {
+        return Err(format!(
+            "html must be at most {MAX_CLIPBOARD_HTML_BYTES} bytes, got {}",
+            input.len()
+        ));
+    }
+    Ok(input.to_owned())
+}
+
 #[cfg(windows)]
 fn parse_rdpdr_drive(input: &str) -> Result<ironrdp_daemon::daemon::RdpdrDriveConfig, String> {
     let (display_name, root_path) = input
@@ -985,6 +1002,8 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::TypeUnicode { text } => Request::UnicodeText { text },
         Command::ClipboardGet => Request::ClipboardGet,
         Command::ClipboardSet { text } => Request::ClipboardSet { text },
+        Command::ClipboardGetHtml => Request::ClipboardGetHtml,
+        Command::ClipboardSetHtml { html } => Request::ClipboardSetHtml { html },
         Command::Touch {
             contact_id,
             x,
@@ -2161,6 +2180,10 @@ fn print_payload(payload: Payload) {
         },
         // Handled out-of-band by the `ClipboardGetImage` command, never printed here.
         Payload::ClipboardImage(png) => println!("clipboard image ({} bytes)", png.as_ref().map_or(0, Vec::len)),
+        Payload::ClipboardHtml(html) => match html {
+            Some(html) => println!("{html}"),
+            None => println!("(empty)"),
+        },
     }
 }
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -2174,16 +2174,12 @@ fn print_payload(payload: Payload) {
         Payload::RailLaunch(launch) => {
             println!("queued RAIL launch {}: {}", launch.launch_id, launch.executable);
         }
-        Payload::ClipboardText(text) => match text {
+        Payload::ClipboardText(text) | Payload::ClipboardHtml(text) => match text {
             Some(text) => println!("{text}"),
             None => println!("(empty)"),
         },
         // Handled out-of-band by the `ClipboardGetImage` command, never printed here.
         Payload::ClipboardImage(png) => println!("clipboard image ({} bytes)", png.as_ref().map_or(0, Vec::len)),
-        Payload::ClipboardHtml(html) => match html {
-            Some(html) => println!("{html}"),
-            None => println!("(empty)"),
-        },
     }
 }
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -171,7 +171,9 @@ richest representation first, when the remote offers more than one.
                                       advertise it to the remote. Same before-connect behavior as
                                       `clipboard-set`.
 - `clipboard-get-html`               Print the last HTML fragment received from the remote
-                                      clipboard, or `(empty)` if none has arrived yet.
+                                      clipboard, or `(empty)` if the current remote item isn't
+                                      HTML (nothing has arrived, or the last copy was text or an
+                                      image).
 - `clipboard-set-html --html HTML`   Set the local clipboard HTML fragment and advertise it to the
                                       remote. Same before-connect behavior as `clipboard-set`.
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -154,9 +154,10 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Clipboard
 
-Text (`CF_UNICODETEXT`) and images (`CF_DIB`/`CF_DIBV5`, as PNG files); no files, no HTML. Local
-content is a single logical item: setting an image replaces a previously set text, and vice versa.
-A remote copy is requested as image over text when the remote offers both.
+Text (`CF_UNICODETEXT`), images (`CF_DIB`/`CF_DIBV5`, as PNG files), and HTML fragments
+(`HTML Format`); no file transfer. Local content is a single logical item: setting one replaces
+whatever was set before, regardless of kind. A remote copy is requested image over HTML over text,
+richest representation first, when the remote offers more than one.
 
 - `clipboard-get`                    Print the last text received from the remote clipboard, or
                                       `(empty)` if none has arrived yet. Requires an active session.
@@ -169,6 +170,10 @@ A remote copy is requested as image over text when the remote offers both.
 - `clipboard-set-image PATH`         Set the local clipboard image from the PNG at `PATH` and
                                       advertise it to the remote. Same before-connect behavior as
                                       `clipboard-set`.
+- `clipboard-get-html`               Print the last HTML fragment received from the remote
+                                      clipboard, or `(empty)` if none has arrived yet.
+- `clipboard-set-html --html HTML`   Set the local clipboard HTML fragment and advertise it to the
+                                      remote. Same before-connect behavior as `clipboard-set`.
 
 ## NOW remote execution (requires an active, connected RDP session)
 

--- a/crates/ironrdp-daemon/src/clipboard.rs
+++ b/crates/ironrdp-daemon/src/clipboard.rs
@@ -1,24 +1,25 @@
 //! In-memory `CLIPRDR` backend for the headless agent daemon.
 //!
 //! Bridges `CLIPRDR` to the `clipboard-get`/`clipboard-set` IPC operations. Plain Unicode text
-//! (`CF_UNICODETEXT`) and images (`CF_DIB`/`CF_DIBV5`, stored as PNG); no file transfer, no HTML.
+//! (`CF_UNICODETEXT`), images (`CF_DIB`/`CF_DIBV5`, stored as PNG), and HTML fragments (the
+//! registered `HTML Format`); no file transfer.
 //! A headless daemon has no host clipboard of its own, so this backend holds the last content
 //! pushed by a `clipboard-set*` operation as its local clipboard content and the last content
 //! received from the remote as its remote clipboard content, both behind a lock shared with the
-//! daemon's IPC handlers. Content is a single logical item at a time (text or image, not both at
-//! once), matching how each `clipboard-set*` call replaces whatever was there before.
+//! daemon's IPC handlers. Content is a single logical item at a time (text, image, or HTML, not
+//! several at once), matching how each `clipboard-set*` call replaces whatever was there before.
 
 use std::sync::{Arc, Mutex};
 
 use ironrdp_client::rdp::RdpInputSender;
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy, CliprdrBackend, CliprdrBackendFactory};
 use ironrdp_cliprdr::pdu::{
-    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
-    FormatDataRequest, FormatDataResponse, LockDataId,
+    ClipboardFormat, ClipboardFormatId, ClipboardFormatName, ClipboardGeneralCapabilityFlags, FileContentsRequest,
+    FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
-use ironrdp_cliprdr_format::bitmap;
+use ironrdp_cliprdr_format::{bitmap, html};
 use ironrdp_pdu::ironrdp_core::{IntoOwned as _, impl_as_any};
-use ironrdp_rpc::ipc::MAX_CLIPBOARD_IMAGE_BYTES;
+use ironrdp_rpc::ipc::{MAX_CLIPBOARD_HTML_BYTES, MAX_CLIPBOARD_IMAGE_BYTES};
 use tracing::debug;
 
 /// One piece of clipboard content, in the daemon's own internal representation.
@@ -30,6 +31,17 @@ use tracing::debug;
 pub(crate) enum ClipboardContent {
     Text(String),
     Image(Vec<u8>),
+    /// Plain HTML fragment text, not yet wrapped in the `CF_HTML` clipboard-fragment envelope;
+    /// wrapping happens at the point of use via `ironrdp_cliprdr_format::html`.
+    Html(String),
+}
+
+/// The format ID this backend assigns when advertising the registered `HTML Format` to the
+/// remote. Registered (named) formats have no fixed numeric ID: the offering side picks one and
+/// the receiver learns the ID-to-name mapping from the `FormatList`. `0xC000` is the low end of
+/// the private-use range (`ClipboardFormatId::is_registered`), matching common practice.
+fn html_format_id() -> ClipboardFormatId {
+    ClipboardFormatId::new(0xC000)
 }
 
 /// Clipboard content shared between the `CLIPRDR` backend and the daemon's IPC handlers.
@@ -96,6 +108,7 @@ enum PendingPaste {
     Image {
         dibv5: bool,
     },
+    Html,
 }
 
 /// How long an outstanding paste request is given to answer before a newer remote copy is allowed
@@ -136,6 +149,7 @@ pub(crate) fn advertised_formats(content: &ClipboardContent) -> Vec<ClipboardFor
             ClipboardFormat::new(ClipboardFormatId::CF_DIB),
             ClipboardFormat::new(ClipboardFormatId::CF_DIBV5),
         ],
+        ClipboardContent::Html(_) => vec![ClipboardFormat::new(html_format_id()).with_name(ClipboardFormatName::HTML)],
     }
 }
 
@@ -181,13 +195,19 @@ impl CliprdrBackend for AgentCliprdrBackend {
         // The remote clipboard changed: whatever content was cached no longer reflects it.
         self.state.lock().expect("clipboard state poisoned").remote = None;
 
-        // Prefer the richest representation offered: image over text, DIBV5 over DIB.
+        // Prefer the richest representation offered: image over HTML over text, DIBV5 over DIB.
         let has_dibv5 = available_formats
             .iter()
             .any(|format| format.id() == ClipboardFormatId::CF_DIBV5);
         let has_dib = available_formats
             .iter()
             .any(|format| format.id() == ClipboardFormatId::CF_DIB);
+        // The remote assigns its own ID to a registered format; match by name and use whatever ID
+        // it picked, not `html_format_id()` (that's only for formats *we* advertise).
+        let remote_html_id = available_formats
+            .iter()
+            .find(|format| format.name() == Some(&ClipboardFormatName::HTML))
+            .map(ClipboardFormat::id);
         let has_text = available_formats
             .iter()
             .any(|format| format.id() == ClipboardFormatId::CF_UNICODETEXT);
@@ -196,6 +216,8 @@ impl CliprdrBackend for AgentCliprdrBackend {
             Some((PendingPaste::Image { dibv5: true }, ClipboardFormatId::CF_DIBV5))
         } else if has_dib {
             Some((PendingPaste::Image { dibv5: false }, ClipboardFormatId::CF_DIB))
+        } else if let Some(html_id) = remote_html_id {
+            Some((PendingPaste::Html, html_id))
         } else if has_text {
             Some((PendingPaste::Text, ClipboardFormatId::CF_UNICODETEXT))
         } else {
@@ -242,6 +264,9 @@ impl CliprdrBackend for AgentCliprdrBackend {
                     FormatDataResponse::new_error()
                 }
             },
+            (id, Some(ClipboardContent::Html(fragment))) if id == html_format_id() => {
+                FormatDataResponse::new_data(html::plain_html_to_cf_html(&fragment).into_bytes()).into_owned()
+            }
             _ => FormatDataResponse::new_error(),
         };
         self.proxy
@@ -277,6 +302,20 @@ impl CliprdrBackend for AgentCliprdrBackend {
                         }
                     }
                 }
+                PendingPaste::Html => match html::cf_html_to_plain_html(response.data()) {
+                    Ok(fragment) if fragment.len() > MAX_CLIPBOARD_HTML_BYTES => {
+                        debug!(
+                            html_len = fragment.len(),
+                            "Remote HTML exceeds the clipboard RPC transport limit; dropped"
+                        );
+                        None
+                    }
+                    Ok(fragment) => Some(ClipboardContent::Html(fragment.to_owned())),
+                    Err(error) => {
+                        debug!(%error, "CF_HTML to plain HTML conversion failed");
+                        None
+                    }
+                },
             };
             if let Some(content) = content {
                 self.state.lock().expect("clipboard state poisoned").remote = Some(content);

--- a/crates/ironrdp-daemon/src/clipboard.rs
+++ b/crates/ironrdp-daemon/src/clipboard.rs
@@ -306,7 +306,7 @@ impl CliprdrBackend for AgentCliprdrBackend {
                     Ok(fragment) if fragment.len() > MAX_CLIPBOARD_HTML_BYTES => {
                         debug!(
                             html_len = fragment.len(),
-                            "Remote HTML exceeds the clipboard RPC transport limit; dropped"
+                            "Remote HTML exceeds the clipboard HTML size limit; dropped"
                         );
                         None
                     }

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -1108,9 +1108,9 @@ impl Daemon {
 
     /// Returns the last text received from the remote clipboard, if any.
     ///
-    /// `None` both when nothing has been received yet and when the last remote copy was an image,
-    /// not text; the two are indistinguishable from this call alone. Use `clipboard_get_image` for
-    /// the image case.
+    /// `None` when nothing has been received yet, or when the last remote copy was an image or
+    /// HTML, not text; the cases are indistinguishable from this call alone. Use
+    /// `clipboard_get_image` or `clipboard_get_html` for those cases.
     ///
     /// # Panics
     ///
@@ -1140,8 +1140,8 @@ impl Daemon {
 
     /// Returns the last image received from the remote clipboard as PNG bytes, if any.
     ///
-    /// `None` both when nothing has been received yet and when the last remote copy was text, not
-    /// an image. Use `clipboard_get` for the text case.
+    /// `None` when nothing has been received yet, or when the last remote copy was text or HTML,
+    /// not an image. Use `clipboard_get` or `clipboard_get_html` for those cases.
     ///
     /// # Panics
     ///

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -580,6 +580,8 @@ impl Daemon {
             Request::ClipboardSet { text } => DaemonResponse::Single(self.clipboard_set(text)),
             Request::ClipboardGetImage => DaemonResponse::Single(self.clipboard_get_image()),
             Request::ClipboardSetImage { png } => DaemonResponse::Single(self.clipboard_set_image(png)),
+            Request::ClipboardGetHtml => DaemonResponse::Single(self.clipboard_get_html()),
+            Request::ClipboardSetHtml { html } => DaemonResponse::Single(self.clipboard_set_html(html)),
             Request::MouseMove { x, y } => {
                 DaemonResponse::Single(self.input(Operation::MouseMove(MousePosition { x, y })))
             }
@@ -1116,7 +1118,9 @@ impl Daemon {
     fn clipboard_get(&self) -> Response {
         let text = match self.clipboard.lock().expect("clipboard state poisoned").remote.clone() {
             Some(crate::clipboard::ClipboardContent::Text(text)) => Some(text),
-            Some(crate::clipboard::ClipboardContent::Image(_)) | None => None,
+            Some(crate::clipboard::ClipboardContent::Image(_) | crate::clipboard::ClipboardContent::Html(_)) | None => {
+                None
+            }
         };
         Response::Ok(Payload::ClipboardText(text))
     }
@@ -1145,7 +1149,9 @@ impl Daemon {
     fn clipboard_get_image(&self) -> Response {
         let png = match self.clipboard.lock().expect("clipboard state poisoned").remote.clone() {
             Some(crate::clipboard::ClipboardContent::Image(png)) => Some(png),
-            Some(crate::clipboard::ClipboardContent::Text(_)) | None => None,
+            Some(crate::clipboard::ClipboardContent::Text(_) | crate::clipboard::ClipboardContent::Html(_)) | None => {
+                None
+            }
         };
         Response::Ok(Payload::ClipboardImage(png))
     }
@@ -1168,6 +1174,38 @@ impl Daemon {
             );
         }
         self.set_local_and_advertise(crate::clipboard::ClipboardContent::Image(png));
+        Response::ok()
+    }
+
+    /// Returns the last HTML fragment received from the remote clipboard, if any.
+    ///
+    /// `None` both when nothing has been received yet and when the last remote copy was text or
+    /// an image, not HTML.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_get_html(&self) -> Response {
+        let html = match self.clipboard.lock().expect("clipboard state poisoned").remote.clone() {
+            Some(crate::clipboard::ClipboardContent::Html(html)) => Some(html),
+            Some(crate::clipboard::ClipboardContent::Text(_) | crate::clipboard::ClipboardContent::Image(_)) | None => {
+                None
+            }
+        };
+        Response::Ok(Payload::ClipboardHtml(html))
+    }
+
+    /// Sets the local clipboard HTML fragment and, if a session is connected, advertises it to
+    /// the remote as the registered `HTML Format`.
+    ///
+    /// Replaces any text or image previously set with `clipboard_set`/`clipboard_set_image`:
+    /// local content is a single logical item, not a per-format set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the clipboard state mutex is poisoned.
+    fn clipboard_set_html(&self, html: String) -> Response {
+        self.set_local_and_advertise(crate::clipboard::ClipboardContent::Html(html));
         Response::ok()
     }
 

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -52,6 +52,12 @@ pub const MAX_CLIPBOARD_IMAGE_BYTES: usize = crate::transport::MAX_MESSAGE_LEN -
 /// a handful of bytes, but this only needs to be safely conservative, not exact.
 const CLIPBOARD_IMAGE_FRAME_HEADROOM: usize = 4 * 1024;
 
+/// Maximum size in bytes of an HTML fragment accepted by [`Request::ClipboardSetHtml`].
+///
+/// Generous for a clipboard fragment (a typical rich-text paste is a few KB) while still bounded;
+/// this is a plain-text CLI argument, not a file, so it stays well under the image cap.
+pub const MAX_CLIPBOARD_HTML_BYTES: usize = 256 * 1024;
+
 /// Maximum contacts in one MS-RDPEI touch frame accepted over RPC.
 pub const MAX_TOUCH_CONTACTS: usize = 10;
 
@@ -465,6 +471,11 @@ pub enum Request {
     /// Set the local clipboard image (PNG bytes, at most [`MAX_CLIPBOARD_IMAGE_BYTES`]) and
     /// advertise it to the remote as `CF_DIB`/`CF_DIBV5`.
     ClipboardSetImage { png: Vec<u8> },
+    /// Return the last HTML fragment received from the remote clipboard, if any.
+    ClipboardGetHtml,
+    /// Set the local clipboard HTML fragment (at most [`MAX_CLIPBOARD_HTML_BYTES`]) and advertise
+    /// it to the remote as the registered `HTML Format`.
+    ClipboardSetHtml { html: String },
 }
 
 // Manual `Debug` so the `Connect` payload's property *values* (which may include a password before
@@ -588,6 +599,11 @@ impl fmt::Debug for Request {
                 .debug_struct("ClipboardSetImage")
                 .field("png_len", &png.len())
                 .finish(),
+            Self::ClipboardGetHtml => f.write_str("ClipboardGetHtml"),
+            Self::ClipboardSetHtml { html } => f
+                .debug_struct("ClipboardSetHtml")
+                .field("html_len", &html.len())
+                .finish(),
         }
     }
 }
@@ -668,6 +684,8 @@ pub enum Payload {
     ClipboardText(Option<String>),
     /// The remote clipboard's last image as PNG bytes, or `None` if unavailable.
     ClipboardImage(Option<Vec<u8>>),
+    /// The remote clipboard's last HTML fragment, or `None` if unavailable.
+    ClipboardHtml(Option<String>),
 }
 
 impl fmt::Debug for Payload {
@@ -700,6 +718,10 @@ impl fmt::Debug for Payload {
             Self::ClipboardImage(png) => f
                 .debug_tuple("ClipboardImage")
                 .field(&png.as_ref().map(Vec::len))
+                .finish(),
+            Self::ClipboardHtml(html) => f
+                .debug_tuple("ClipboardHtml")
+                .field(&html.as_ref().map(String::len))
                 .finish(),
         }
     }
@@ -2027,6 +2049,10 @@ impl Encode for Payload {
                 dst.write_u8(14);
                 write_opt_bytes(dst, png.as_deref())?;
             }
+            Self::ClipboardHtml(html) => {
+                dst.write_u8(15);
+                write_opt_string(dst, html.as_deref())?;
+            }
         }
         Ok(())
     }
@@ -2053,6 +2079,7 @@ impl Encode for Payload {
                 Self::RailLaunch(launch) => launch.size(),
                 Self::ClipboardText(text) => opt_string_size(text.as_deref()),
                 Self::ClipboardImage(png) => opt_bytes_size(png.as_deref()),
+                Self::ClipboardHtml(html) => opt_string_size(html.as_deref()),
             }
     }
 }
@@ -2103,6 +2130,13 @@ impl Decode<'_> for Payload {
                     return Err(ironrdp_core::invalid_field_err!("clipboard image", "too large"));
                 }
                 Ok(Self::ClipboardImage(png))
+            }
+            15 => {
+                let html = read_opt_string(src)?;
+                if html.as_ref().is_some_and(|html| html.len() > MAX_CLIPBOARD_HTML_BYTES) {
+                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large"));
+                }
+                Ok(Self::ClipboardHtml(html))
             }
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag", in: src)),
         }
@@ -2330,6 +2364,11 @@ impl Encode for Request {
                 dst.write_u8(32);
                 write_bytes(dst, png)?;
             }
+            Self::ClipboardGetHtml => dst.write_u8(33),
+            Self::ClipboardSetHtml { html } => {
+                dst.write_u8(34);
+                write_string(dst, html)?;
+            }
         }
         Ok(())
     }
@@ -2352,7 +2391,8 @@ impl Encode for Request {
                 | Self::NowDiagnostics
                 | Self::RailStatus
                 | Self::ClipboardGet
-                | Self::ClipboardGetImage => 0,
+                | Self::ClipboardGetImage
+                | Self::ClipboardGetHtml => 0,
                 Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
                 Self::QueryLogs { substring, last } => {
                     opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
@@ -2393,6 +2433,7 @@ impl Encode for Request {
                 Self::DismissHoveringTouchContact { .. } => 1 /* contact_id */,
                 Self::ClipboardSet { text } => string_size(text),
                 Self::ClipboardSetImage { png } => bytes_size(png),
+                Self::ClipboardSetHtml { html } => string_size(html),
             }
     }
 }
@@ -2594,6 +2635,14 @@ impl Decode<'_> for Request {
                     return Err(ironrdp_core::invalid_field_err!("clipboard image", "too large"));
                 }
                 Ok(Self::ClipboardSetImage { png })
+            }
+            33 => Ok(Self::ClipboardGetHtml),
+            34 => {
+                let html = read_string(src)?;
+                if html.len() > MAX_CLIPBOARD_HTML_BYTES {
+                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large"));
+                }
+                Ok(Self::ClipboardSetHtml { html })
             }
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag", in: src)),
         }

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -2134,7 +2134,7 @@ impl Decode<'_> for Payload {
             15 => {
                 let html = read_opt_string(src)?;
                 if html.as_ref().is_some_and(|html| html.len() > MAX_CLIPBOARD_HTML_BYTES) {
-                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large"));
+                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large", in: src));
                 }
                 Ok(Self::ClipboardHtml(html))
             }
@@ -2640,7 +2640,7 @@ impl Decode<'_> for Request {
             34 => {
                 let html = read_string(src)?;
                 if html.len() > MAX_CLIPBOARD_HTML_BYTES {
-                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large"));
+                    return Err(ironrdp_core::invalid_field_err!("clipboard html", "too large", in: src));
                 }
                 Ok(Self::ClipboardSetHtml { html })
             }

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -169,6 +169,10 @@ fn request_variants_round_trip() {
         Request::ClipboardSetImage {
             png: vec![0x89, b'P', b'N', b'G', 0, 0xFF],
         },
+        Request::ClipboardGetHtml,
+        Request::ClipboardSetHtml {
+            html: "<b>clipboard html</b>".to_owned(),
+        },
     ];
 
     for request in &requests {
@@ -317,6 +321,8 @@ fn response_variants_round_trip() {
         Response::Ok(Payload::ClipboardText(Some("clipboard text".to_owned()))),
         Response::Ok(Payload::ClipboardImage(None)),
         Response::Ok(Payload::ClipboardImage(Some(vec![0x89, b'P', b'N', b'G', 0, 0xFF]))),
+        Response::Ok(Payload::ClipboardHtml(None)),
+        Response::Ok(Payload::ClipboardHtml(Some("<b>clipboard html</b>".to_owned()))),
     ];
 
     for response in &responses {
@@ -400,6 +406,16 @@ fn clipboard_debug_redacts_content() {
     let payload = Payload::ClipboardImage(Some(b"secret-pixels".to_vec()));
     let debug = format!("{payload:?}");
     assert!(!debug.contains("secret-pixels"));
+
+    let request = Request::ClipboardSetHtml {
+        html: "<b>secret-markup</b>".to_owned(),
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("secret-markup"));
+
+    let payload = Payload::ClipboardHtml(Some("<b>secret-markup</b>".to_owned()));
+    let debug = format!("{payload:?}");
+    assert!(!debug.contains("secret-markup"));
 }
 
 #[test]


### PR DESCRIPTION
#1877 (clipboard image support) merged: This PR now rebases cleanly onto
master and its own diff is HTML-only. It still depends on the
ClipboardContent enum #1877 introduced.

Extends the daemon clipboard-get/clipboard-set operations to HTML fragments:
clipboard-get-html prints the last HTML fragment received from the remote
clipboard, clipboard-set-html sets one and advertises it to the remote as
the registered HTML Format.

Stores the fragment as plain text (not yet CF_HTML-wrapped) and converts at
the point of use via ironrdp-cliprdr-format's existing
plain_html_to_cf_html/cf_html_to_plain_html, so no new markup handling is
needed here, mirroring the image PR's use of the crate's existing bitmap
conversions.

HTML Format is a registered, not fixed-ID, clipboard format: The offering
side picks a private-range ID (0xC000 here) and pairs it with the name; the
receiver learns the ID-to-name mapping from the FormatList. When receiving,
matches the remote's offer by name and uses whatever ID it assigned, not the
locally-chosen one, since those only apply to formats this backend itself
offers.

Extends the remote-copy priority order to image, then HTML, then text
(richest representation first), and the PendingPaste tracking added in
#1877 with an Html variant so a returned FormatDataResponse is decoded
correctly regardless of which of the three was requested. A remote HTML
fragment over the 256 KiB bound is dropped and logged rather than stored,
mirroring the oversized-image drop #1877's review round added, for the same
reason: An unbounded stored value would otherwise fail encoding once handed
back over the RPC transport.

New Request::ClipboardGetHtml/ClipboardSetHtml and Payload::ClipboardHtml
wire variants, bounded at 256 KiB in the CLI parser and on wire decode.
Extends ironrdp-activex's exhaustive match on Request with the same
treatment as the other clipboard operations. Extends the wire round-trip
and Debug-redaction test coverage added in #1877 to the two new variants.

cargo xtask check fmt/lints/tests/typos/locks all pass. Not yet verified
against a live remote client, same as #1877.
