### PR TITLE
ci(pr-automation): use DeepSeek temporarily

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -8,7 +8,7 @@ The automation posts guidance on the pull request instead of invoking a model wi
 ## Review pipeline
 
 Classification and review use [Helmcode's OpenAI-compatible endpoint](https://api.helmcode.com/v1).
-The classifier and all reviewers use `glm-5.2`.
+The classifier and all reviewers temporarily use `deepseek-v4-flash` until a GLM key is available.
 
 The pipeline performs these stages:
 
@@ -176,7 +176,7 @@ Agent configuration lives in `.github/pr-automation/agents` on the base branch.
 Configuration fixes model selection, prompts, schemas, methodologies, filesystem capabilities, and execution limits.
 Models cannot alter these values or the Helmcode endpoint.
 
-To migrate the agents to GLM-5.3, update the base-branch `model` fields after Helmcode exposes the model and the action's mocked provider and schema tests pass unchanged.
+To restore GLM, update the base-branch `model` fields after the GLM key is available and the action's mocked provider and schema tests pass unchanged.
 Keep classification in a separate job while concurrency isolation remains useful.
 
 ## Label setup

--- a/.github/pr-automation/agents/classifier.json
+++ b/.github/pr-automation/agents/classifier.json
@@ -1,6 +1,6 @@
 {
   "id": "classifier",
-  "model": "glm-5.2",
+  "model": "deepseek-v4-flash",
   "prompt_file": ".github/pr-automation/prompts/classifier.md",
   "schema_file": ".github/pr-automation/schemas/classifier.json",
   "methodology_files": [],

--- a/.github/pr-automation/agents/code-compressor.json
+++ b/.github/pr-automation/agents/code-compressor.json
@@ -1,6 +1,6 @@
 {
   "id": "code-compressor",
-  "model": "glm-5.2",
+  "model": "deepseek-v4-flash",
   "prompt_file": ".github/pr-automation/prompts/code-compressor.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/agents/general-reviewer.json
+++ b/.github/pr-automation/agents/general-reviewer.json
@@ -1,6 +1,6 @@
 {
   "id": "general-reviewer",
-  "model": "glm-5.2",
+  "model": "deepseek-v4-flash",
   "prompt_file": ".github/pr-automation/prompts/general-reviewer.md",
   "schema_file": ".github/pr-automation/schemas/final-review.json",
   "allowed_roots": [

--- a/.github/pr-automation/agents/protocol.json
+++ b/.github/pr-automation/agents/protocol.json
@@ -1,6 +1,6 @@
 {
   "id": "protocol",
-  "model": "glm-5.2",
+  "model": "deepseek-v4-flash",
   "prompt_file": ".github/pr-automation/prompts/protocol-reviewer.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/agents/skeptical.json
+++ b/.github/pr-automation/agents/skeptical.json
@@ -1,6 +1,6 @@
 {
   "id": "skeptical",
-  "model": "glm-5.2",
+  "model": "deepseek-v4-flash",
   "prompt_file": ".github/pr-automation/prompts/skeptical.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -164,7 +164,7 @@ test("review skills own methodology while stage prompts own pipeline contracts",
 
   for (const agent of ["classifier", "protocol", "skeptical", "code-compressor", "general-reviewer"]) {
     const config = JSON.parse(fs.readFileSync(path.join(__dirname, "agents", `${agent}.json`), "utf8"));
-    assert.equal(config.model, "glm-5.2");
+    assert.equal(config.model, "deepseek-v4-flash");
     assert.equal(config.max_tool_calls > 0, true);
   }
 


### PR DESCRIPTION
Use DeepSeek V4 Flash for classification and every review stage while the GLM key is unavailable.

Keep the existing Helmcode endpoint and credential wiring unchanged.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>