### PR TITLE
ci(pr-automation): bound Helmcode concurrency

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -16,8 +16,8 @@ The pipeline performs these stages:
 1. Prepare a SHA-bound changed-file manifest, diff, pull request context, and read-only head tree.
 2. Classify risk, scope, legitimacy, duplicate likelihood, protocol relevance, and useful specialist reviewers.
 3. Apply workflow-controlled routing rules and persist the canonical review plan in the `AI classification` check.
-4. Run selected specialists sequentially in the order `protocol`, `skeptical`, then `code-compressor`.
-5. Validate each specialist result and write `validated-specialist-findings.json`.
+4. Run selected specialists in a three-job parallel matrix.
+5. Validate each specialist result and aggregate them in canonical order.
 6. Run the general reviewer as an independent reviewer and verifier.
 7. Validate its candidate dispositions, findings, locations, and provenance.
 8. Resolve validated state and publish through the serialized writer.
@@ -25,7 +25,7 @@ The pipeline performs these stages:
 Workflow routing selects the code-compressor for every eligible review.
 Protocol-related changes always require the protocol specialist.
 Medium- and high-risk changes always require the skeptical specialist.
-IronRDP configures sequential execution only, and model output cannot select parallelism.
+Workflow code fixes the matrix at three concurrent specialists, and model output cannot select parallelism.
 
 Specialists use one bounded candidate schema.
 Each candidate binds to the expected head SHA, a configured reviewer ID, a changed path, an optional added-line range, and a unique finding ID.
@@ -63,6 +63,7 @@ It loads a workflow-controlled agent configuration, prompt, output schema, metho
 It exposes only `read_file`, `list_files`, and `search_text`.
 It enforces turn, tool-call, path, byte, line, recursion, result, timeout, and retry limits.
 It validates JSON against the configured schema and permits one tools-disabled correction completion.
+The SDK retries retryable responses twice, honors supported `Retry-After` headers, and then fails closed.
 
 The action exposes no command execution, writes, Git operations, GitHub APIs, environment access, arbitrary network access, or generic URL fetching.
 It logs bounded metadata only and never logs prompts, pull request content, tool arguments, tool results, model responses, provider response bodies, or credentials.
@@ -143,8 +144,13 @@ The default author quota is five pull requests, established contributors can use
 ## State, publication, and failure behavior
 
 SHA-bound GitHub checks carry classification and review state between permission-isolated jobs.
+SHA-bound workflow artifacts carry evidence and validated results between review-pipeline jobs.
 Only the final writer mutates pull request state, and it serializes those mutations per pull request.
 Model-execution jobs have read-only or empty permissions.
+
+Two static classifier concurrency lanes allow at most two classifier jobs to invoke Helmcode at once.
+The reusable review workflow runs under one global caller-job lock and allows at most three specialist requests at once.
+Together these limits keep Helmcode usage within the five-request API-key limit.
 
 Inline comments target only validated added lines.
 Other findings appear in the review body.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -1,6 +1,6 @@
 # Pull request automation
 
-`.github/workflows/labeler.yml` classifies ready, open pull requests and runs at most two automated reviews.
+`.github/workflows/labeler.yml` classifies ready, open pull requests and calls `.github/workflows/review-pipeline.yml` for at most two automated reviews.
 Automatic routes stop at `ai-reviewed/2` unless a maintainer uses force mode.
 Model analysis fails closed when the reviewable pull request diff exceeds the 1 MiB evidence limit.
 The trusted `evidence-diff-attributes` policy represents reproducibly verified generated artifacts with binary-change markers.
@@ -16,8 +16,8 @@ The pipeline performs these stages:
 1. Prepare a SHA-bound changed-file manifest, diff, pull request context, and read-only head tree.
 2. Classify risk, scope, legitimacy, duplicate likelihood, protocol relevance, and useful specialist reviewers.
 3. Apply workflow-controlled routing rules and persist the canonical review plan in the `AI classification` check.
-4. Run selected specialists in a three-job parallel matrix.
-5. Validate each specialist result and aggregate them in canonical order.
+4. Run selected specialists as parallel matrix jobs, at most three at once.
+5. Validate each specialist result, then aggregate the results in the canonical order `protocol`, `skeptical`, `code-compressor`.
 6. Run the general reviewer as an independent reviewer and verifier.
 7. Validate its candidate dispositions, findings, locations, and provenance.
 8. Resolve validated state and publish through the serialized writer.
@@ -25,7 +25,7 @@ The pipeline performs these stages:
 Workflow routing selects the code-compressor for every eligible review.
 Protocol-related changes always require the protocol specialist.
 Medium- and high-risk changes always require the skeptical specialist.
-Workflow code fixes the matrix at three concurrent specialists, and model output cannot select parallelism.
+Model output cannot select parallelism.
 
 Specialists use one bounded candidate schema.
 Each candidate binds to the expected head SHA, a configured reviewer ID, a changed path, an optional added-line range, and a unique finding ID.
@@ -63,7 +63,7 @@ It loads a workflow-controlled agent configuration, prompt, output schema, metho
 It exposes only `read_file`, `list_files`, and `search_text`.
 It enforces turn, tool-call, path, byte, line, recursion, result, timeout, and retry limits.
 It validates JSON against the configured schema and permits one tools-disabled correction completion.
-The SDK retries retryable responses twice, honors supported `Retry-After` headers, and then fails closed.
+The SDK retries twice on retryable responses, honors supported `Retry-After` headers, and then fails closed.
 
 The action exposes no command execution, writes, Git operations, GitHub APIs, environment access, arbitrary network access, or generic URL fetching.
 It logs bounded metadata only and never logs prompts, pull request content, tool arguments, tool results, model responses, provider response bodies, or credentials.
@@ -82,7 +82,7 @@ Before model access, the script removes all symlinks and recursively removes den
 Those files remain visible in the authoritative diff as reviewable changes.
 The runtime rejects absolute paths, traversal, `.git`, symlinks, junctions, realpath escapes, binary files, oversized files, and paths outside explicit capabilities.
 
-The review job fetches bounded pull request discussion and line-location data with read-only GitHub permissions.
+The evidence job fetches bounded pull request discussion and line-location data with read-only GitHub permissions.
 It verifies the head before and after collection.
 Final publication rechecks the current head before mutation.
 
@@ -149,8 +149,8 @@ Only the final writer mutates pull request state, and it serializes those mutati
 Model-execution jobs have read-only or empty permissions.
 
 Two static classifier concurrency lanes allow at most two classifier jobs to invoke Helmcode at once.
-The reusable review workflow runs under one global caller-job lock and allows at most three specialist requests at once.
-Together these limits keep Helmcode usage within the five-request API-key limit.
+The reusable `.github/workflows/review-pipeline.yml` runs under one global caller-job lock and allows at most three specialist requests at once.
+The general reviewer starts only after all specialists finish, so these limits keep Helmcode usage within the five-request API-key limit.
 
 Inline comments target only validated added lines.
 Other findings appear in the review body.
@@ -184,7 +184,7 @@ Configuration fixes model selection, prompts, schemas, methodologies, filesystem
 Models cannot alter these values or the Helmcode endpoint.
 
 To restore GLM, update the base-branch `model` fields after the GLM key is available and the action's mocked provider and schema tests pass unchanged.
-Keep classification in a separate job while concurrency isolation remains useful.
+Keep classification in its own job so the static classifier lanes continue to bound Helmcode concurrency.
 
 ## Label setup
 

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -92,7 +92,7 @@ The protocol specialist reads the Microsoft Open Specifications as inert data un
 The workflow fetches the latest `awakecoding/openspecs` master without credentials and copies only allowlisted regular Markdown files.
 It excludes skills, instruction files, symlinks, submodules, executables, and lifecycle content.
 
-Citation validation uses the same corpus commit that the specialist read.
+Citation validation uses the same corpus commit that the specialist read, and the evidence job records its SHA in the job summary.
 Every protocol ID, section number, and heading must exist in that fetched commit.
 An unavailable corpus, protocol specialist, or protocol validation blocks publication for a mandatory protocol review.
 

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -89,11 +89,11 @@ Final publication rechecks the current head before mutation.
 ## Protocol corpus
 
 The protocol specialist reads the Microsoft Open Specifications as inert data under `review-sources/windows-protocols`.
-The workflow pins a reviewed `awakecoding/openspecs` commit, fetches that exact SHA without credentials, and copies only allowlisted regular Markdown files.
+The workflow fetches the latest `awakecoding/openspecs` master without credentials and copies only allowlisted regular Markdown files.
 It excludes skills, instruction files, symlinks, submodules, executables, and lifecycle content.
 
 Citation validation uses the same corpus commit that the specialist read.
-Every protocol ID, section number, and heading must exist at that exact commit.
+Every protocol ID, section number, and heading must exist in that fetched commit.
 An unavailable corpus, protocol specialist, or protocol validation blocks publication for a mandatory protocol review.
 
 ## Classification and review policy

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -3,6 +3,6 @@
 - On `429`, read Helmcode’s `Retry-After` header.
 - Wait that duration, or fall back to another duration if absent.
 - Retry the same request while preserving agent state.
-- Fail closed if receiving `429` 3 times in a row.
+- Fail closed after three consecutive `429` responses.
 
-This logic does not have to live in our code, the OpenAI SDK provides a `maxRetries` option which can be used.
+This logic does not have to live in our code because the OpenAI SDK provides a `maxRetries` option.

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -1,0 +1,8 @@
+## Graceful handling of 429
+
+- On `429`, read Helmcode’s `Retry-After` header.
+- Wait that duration, or fallback to another duration if absent.
+- Retry the same request while preserving agent state.
+- Fail closed if receiving `429` 3 times in a row.
+
+This logic does not have to live in our code, the OpenAI SDK provides a `maxRetries` option which can be used.

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -1,7 +1,7 @@
 ## Graceful handling of 429
 
 - On `429`, read Helmcode’s `Retry-After` header.
-- Wait that duration, or fallback to another duration if absent.
+- Wait that duration, or fall back to another duration if absent.
 - Retry the same request while preserving agent state.
 - Fail closed if receiving `429` 3 times in a row.
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -99,7 +99,7 @@ test("workflow uses bounded classifier lanes and one parallel review pipeline", 
     /git fetch --no-tags origin "\+\$WORKFLOW_SHA:refs\/remotes\/origin\/automation"/);
   assert.equal((reviewWorkflow.match(/ref: \$\{\{ github\.workflow_sha \}\}/g) || []).length, 4);
   assert.doesNotMatch(reviewWorkflow, /ref: master/);
-  assert.equal((reviewWorkflow.match(/overwrite: true/g) || []).length, 4);
+  assert.equal((reviewWorkflow.match(/overwrite: true/g) || []).length, 6);
 
   const classifier = workflowJob(workflow, "classifier");
   assert.match(workflowJob(workflow, "resolve-pr"),
@@ -118,10 +118,14 @@ test("workflow uses bounded classifier lanes and one parallel review pipeline", 
   const specialists = workflowJob(reviewWorkflow, "specialists");
   assert.match(specialists, /max-parallel: 3/);
   assert.match(specialists, /reviewer: \$\{\{ fromJSON\(inputs\.specialist-reviewers\) \}\}/);
+  assert.match(specialists, /if: matrix\.reviewer == 'protocol'/);
+  assert.match(specialists, /name: review-corpus-\$\{\{ inputs\.head-sha \}\}/);
   assert.match(specialists, /Upload validated specialist result/);
   const aggregate = workflowJob(reviewWorkflow, "aggregate");
   assert.match(aggregate, /needs: \[evidence, specialists\]/);
   assert.match(aggregate, /pattern: review-specialist-\$\{\{ inputs\.head-sha \}\}-\*/);
+  assert.match(aggregate, /continue-on-error: true/);
+  assert.match(aggregate, /failedRun\(reviewer, "specialist result unavailable"\)/);
   const general = workflowJob(reviewWorkflow, "general");
   assert.match(general, /needs: \[evidence, aggregate\]/);
   assert.match(general, /needs\.aggregate\.outputs\.ready == 'true'/);
@@ -135,6 +139,11 @@ test("workflow does not resolve or write state after cancellation", () => {
   for (const name of ["resolve-classification-state", "resolve-review-state", "write-state"]) {
     assert.match(workflowJob(workflow, name), /^    if: always\(\) && !cancelled\(\) &&/m);
   }
+  const reviewWorkflow = readReviewWorkflow();
+  assert.match(workflowJob(reviewWorkflow, "aggregate"),
+    /^    if: always\(\) && !cancelled\(\) &&/m);
+  assert.match(workflowJob(reviewWorkflow, "validate"),
+    /^    if: always\(\) && !cancelled\(\)$/m);
 });
 
 test("workflow isolates CI completion concurrency by source commit", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -94,6 +94,7 @@ test("workflow uses bounded classifier lanes and one parallel review pipeline", 
   assert.equal((combined.match(/secrets\.HELMCODE_GLM_API_KEY/g) || []).length, 3);
   assert.doesNotMatch(reviewWorkflow, /OPENSPECS_COMMIT/);
   assert.match(reviewWorkflow, /openspecs" fetch .*origin \+master:refs\/remotes\/origin\/master/);
+  assert.match(reviewWorkflow, /awakecoding\/openspecs@\$openspecs_sha.*GITHUB_STEP_SUMMARY/);
   assert.match(reviewWorkflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
   assert.match(reviewWorkflow,
     /git fetch --no-tags origin "\+\$WORKFLOW_SHA:refs\/remotes\/origin\/automation"/);

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -76,21 +76,52 @@ function readWorkflow(githubDirectory = path.join(__dirname, "..")) {
     .replace(/\r\n/g, "\n");
 }
 
-test("workflow uses one generic Helmcode action and one sequential review pipeline", () => {
+function readReviewWorkflow(githubDirectory = path.join(__dirname, "..")) {
+  return fs.readFileSync(path.join(githubDirectory, "workflows", "review-pipeline.yml"), "utf8")
+    .replace(/\r\n/g, "\n");
+}
+
+test("workflow uses bounded classifier lanes and one parallel review pipeline", () => {
   const workflow = readWorkflow();
-  assert.doesNotMatch(workflow, /core\.setOutput\("result"/);
-  assert.doesNotMatch(workflow, /^\s{6}result:\s+\$\{\{\s*steps\./m);
-  assert.doesNotMatch(workflow, /needs\.[\w-]+\.outputs\.result\b/);
-  assert.doesNotMatch(workflow, /anthropic|claude|sonnet|haiku|resilient-review-output/i);
-  assert.equal((workflow.match(/uses: \.\/\.github\/actions\/openai-agent/g) || []).length, 5);
-  assert.equal((workflow.match(/environment: llm-providers/g) || []).length, 2);
-  assert.equal((workflow.match(/secrets\.HELMCODE_GLM_API_KEY/g) || []).length, 5);
-  assert.match(workflow, /OPENSPECS_COMMIT: [0-9a-f]{40}/);
-  assert.doesNotMatch(workflow, /openspecs" fetch .*origin \+master/);
-  const pipeline = workflowJob(workflow, "review-pipeline");
-  const positions = ["id: protocol", "id: skeptical", "id: code-compressor", "id: general"]
-    .map((needle) => pipeline.indexOf(needle));
-  assert.deepEqual([...positions].sort((left, right) => left - right), positions);
+  const reviewWorkflow = readReviewWorkflow();
+  const combined = `${workflow}\n${reviewWorkflow}`;
+  assert.doesNotMatch(combined, /core\.setOutput\("result"/);
+  assert.doesNotMatch(combined, /^\s{6}result:\s+\$\{\{\s*steps\./m);
+  assert.doesNotMatch(combined, /needs\.[\w-]+\.outputs\.result\b/);
+  assert.doesNotMatch(combined, /anthropic|claude|sonnet|haiku|resilient-review-output/i);
+  assert.equal((combined.match(/uses: \.\/\.github\/actions\/openai-agent/g) || []).length, 3);
+  assert.equal((combined.match(/environment: llm-providers/g) || []).length, 3);
+  assert.equal((combined.match(/secrets\.HELMCODE_GLM_API_KEY/g) || []).length, 3);
+  assert.match(reviewWorkflow, /OPENSPECS_COMMIT: [0-9a-f]{40}/);
+  assert.doesNotMatch(reviewWorkflow, /openspecs" fetch .*origin \+master/);
+
+  const classifier = workflowJob(workflow, "classifier");
+  assert.match(workflowJob(workflow, "resolve-pr"),
+    /core\.setOutput\("classifier-lane", result\.prNumber \? \(Number\(result\.prNumber\) % 2\) \+ 1 : ""\)/);
+  assert.match(classifier, /group: llm-classifier-\$\{\{ needs\.resolve-pr\.outputs\.classifier-lane \}\}/);
+  assert.match(classifier, /cancel-in-progress: false/);
+  assert.match(classifier, /queue: max/);
+
+  const caller = workflowJob(workflow, "review-pipeline");
+  assert.match(caller, /group: llm-reviewer-pipeline/);
+  assert.match(caller, /cancel-in-progress: false/);
+  assert.match(caller, /queue: max/);
+  assert.match(caller, /uses: \.\/\.github\/workflows\/review-pipeline\.yml/);
+  assert.doesNotMatch(caller, /runs-on:/);
+
+  const specialists = workflowJob(reviewWorkflow, "specialists");
+  assert.match(specialists, /max-parallel: 3/);
+  assert.match(specialists, /reviewer: \$\{\{ fromJSON\(inputs\.specialist-reviewers\) \}\}/);
+  assert.match(specialists, /Upload validated specialist result/);
+  const aggregate = workflowJob(reviewWorkflow, "aggregate");
+  assert.match(aggregate, /needs: \[evidence, specialists\]/);
+  assert.match(aggregate, /pattern: review-specialist-\$\{\{ inputs\.head-sha \}\}-\*/);
+  const general = workflowJob(reviewWorkflow, "general");
+  assert.match(general, /needs: \[evidence, aggregate\]/);
+  assert.match(general, /needs\.aggregate\.outputs\.ready == 'true'/);
+  const validate = workflowJob(reviewWorkflow, "validate");
+  assert.match(validate, /needs: \[evidence, aggregate, general\]/);
+  assert.match(validate, /validateFinalReview/);
 });
 
 test("workflow does not resolve or write state after cancellation", () => {
@@ -155,7 +186,6 @@ test("workflow force mode bypasses model policy gates without changing automatic
 test("review skills own methodology while stage prompts own pipeline contracts", () => {
   const githubDirectory = path.join(__dirname, "..");
   const repositoryRoot = path.join(githubDirectory, "..");
-  const workflow = readWorkflow(githubDirectory);
   const prompt = (name) => fs.readFileSync(path.join(__dirname, "prompts", `${name}.md`), "utf8");
   const skill = (name) => fs.readFileSync(
     path.join(repositoryRoot, ".agents", "skills", name, "SKILL.md"),
@@ -176,6 +206,7 @@ test("review skills own methodology while stage prompts own pipeline contracts",
   const protocolSkill = skill("protocol-reviewer");
   const skepticalSkill = skill("skeptical-reviewer");
   const compressorSkill = skill("code-compressor");
+  const reviewWorkflow = readReviewWorkflow(githubDirectory);
 
   assert.match(protocolSkill, /windows-protocols/);
   assert.match(protocolPrompt, /review-sources\/windows-protocols/);
@@ -191,10 +222,10 @@ test("review skills own methodology while stage prompts own pipeline contracts",
     assert.match(stagePrompt, /Return only .*JSON/);
   }
   assert.match(skepticalPrompt, /pr-evidence\/pull-request-context\.json/);
-  const reviewPipeline = workflowJob(workflow, "review-pipeline");
-  assert.match(reviewPipeline, /issues: read/);
-  assert.match(reviewPipeline, /pull-requests: read/);
-  assert.match(reviewPipeline, /fetchReviewContext/);
+  const evidence = workflowJob(reviewWorkflow, "evidence");
+  assert.match(evidence, /issues: read/);
+  assert.match(evidence, /pull-requests: read/);
+  assert.match(evidence, /fetchReviewContext/);
 });
 
 test("review context is bounded and tied to the reviewed head", async () => {
@@ -289,12 +320,14 @@ test("review context is bounded and tied to the reviewed head", async () => {
 test("LLM evidence is bound to the resolved pull request base", () => {
   const githubDirectory = path.join(__dirname, "..");
   const workflow = readWorkflow(githubDirectory);
+  const reviewWorkflow = readReviewWorkflow(githubDirectory);
   const evidenceScript = fs.readFileSync(path.join(__dirname, "fetch-pr-evidence.sh"), "utf8");
-  for (const name of ["classifier", "review-pipeline"]) {
-    const job = workflowJob(workflow, name);
-    assert.match(job, /BASE_SHA: \$\{\{ needs\.resolve-pr\.outputs\.base-sha \}\}/);
-    assert.match(job, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
-  }
+  const classifier = workflowJob(workflow, "classifier");
+  assert.match(classifier, /BASE_SHA: \$\{\{ needs\.resolve-pr\.outputs\.base-sha \}\}/);
+  assert.match(classifier, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
+  const evidence = workflowJob(reviewWorkflow, "evidence");
+  assert.match(evidence, /BASE_SHA: \$\{\{ inputs\.base-sha \}\}/);
+  assert.match(evidence, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
   assert.match(evidenceScript, /\+\$base_sha:refs\/remotes\/origin\/pull-request-base/);
   assert.match(
     evidenceScript,
@@ -306,6 +339,7 @@ test("LLM evidence is bound to the resolved pull request base", () => {
 test("oversized evidence fails closed and leaves pull request guidance", () => {
   const githubDirectory = path.join(__dirname, "..");
   const workflow = readWorkflow(githubDirectory);
+  const reviewWorkflow = readReviewWorkflow(githubDirectory);
   const evidenceScript = fs.readFileSync(path.join(__dirname, "fetch-pr-evidence.sh"), "utf8");
   const evidenceAttributes = fs.readFileSync(path.join(__dirname, "evidence-diff-attributes"), "utf8");
   const reason = "pull request diff exceeds the 1 MiB evidence limit";
@@ -317,11 +351,14 @@ test("oversized evidence fails closed and leaves pull request guidance", () => {
   assert.match(evidenceScript, /failure-reason\.txt/);
   assert.match(evidenceScript, /exit 1/);
   assert.doesNotMatch(evidenceScript, /pull-request\.diff\.truncated/);
-  for (const name of ["classifier", "review-pipeline"]) {
-    const job = workflowJob(workflow, name);
-    assert.match(job, /id: evidence/);
-    assert.match(job, /steps\.evidence\.outputs\.failure-reason \|\|/);
-  }
+  const classifier = workflowJob(workflow, "classifier");
+  assert.match(classifier, /id: evidence/);
+  assert.match(classifier, /steps\.evidence\.outputs\.failure-reason \|\|/);
+  const evidence = workflowJob(reviewWorkflow, "evidence");
+  assert.match(evidence, /id: evidence/);
+  assert.match(evidence, /failure-reason: \$\{\{ steps\.evidence\.outputs\.failure-reason \}\}/);
+  assert.match(workflowJob(reviewWorkflow, "validate"),
+    /EVIDENCE_REASON: \$\{\{ needs\.evidence\.outputs\.failure-reason \}\}/);
 
   const deterministic = {
     ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/XXL",
@@ -583,7 +620,7 @@ test("specialist validation binds reviewer identity, SHA, paths, and protocol co
   }).ok, false);
 });
 
-test("specialist aggregate preserves explicit failures and canonical sequential order", () => {
+test("specialist aggregate preserves explicit failures and canonical reviewer order", () => {
   const valid = validateSpecialistRun(candidateReview("skeptical"), {
     reviewer: "skeptical", expectedSha: SHA,
     changedPaths: ["src/lib.rs"], changedLines: { "src/lib.rs": [4] },

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -94,6 +94,12 @@ test("workflow uses bounded classifier lanes and one parallel review pipeline", 
   assert.equal((combined.match(/secrets\.HELMCODE_GLM_API_KEY/g) || []).length, 3);
   assert.doesNotMatch(reviewWorkflow, /OPENSPECS_COMMIT/);
   assert.match(reviewWorkflow, /openspecs" fetch .*origin \+master:refs\/remotes\/origin\/master/);
+  assert.match(reviewWorkflow, /WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(reviewWorkflow,
+    /git fetch --no-tags origin "\+\$WORKFLOW_SHA:refs\/remotes\/origin\/automation"/);
+  assert.equal((reviewWorkflow.match(/ref: \$\{\{ github\.workflow_sha \}\}/g) || []).length, 4);
+  assert.doesNotMatch(reviewWorkflow, /ref: master/);
+  assert.equal((reviewWorkflow.match(/overwrite: true/g) || []).length, 4);
 
   const classifier = workflowJob(workflow, "classifier");
   assert.match(workflowJob(workflow, "resolve-pr"),

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -92,8 +92,8 @@ test("workflow uses bounded classifier lanes and one parallel review pipeline", 
   assert.equal((combined.match(/uses: \.\/\.github\/actions\/openai-agent/g) || []).length, 3);
   assert.equal((combined.match(/environment: llm-providers/g) || []).length, 3);
   assert.equal((combined.match(/secrets\.HELMCODE_GLM_API_KEY/g) || []).length, 3);
-  assert.match(reviewWorkflow, /OPENSPECS_COMMIT: [0-9a-f]{40}/);
-  assert.doesNotMatch(reviewWorkflow, /openspecs" fetch .*origin \+master/);
+  assert.doesNotMatch(reviewWorkflow, /OPENSPECS_COMMIT/);
+  assert.match(reviewWorkflow, /openspecs" fetch .*origin \+master:refs\/remotes\/origin\/master/);
 
   const classifier = workflowJob(workflow, "classifier");
   assert.match(workflowJob(workflow, "resolve-pr"),

--- a/.github/pr-automation/routing.js
+++ b/.github/pr-automation/routing.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// Persisted routes use this canonical sequential execution order.
+// Persisted routes and aggregates use this canonical reviewer order.
 const REVIEWER_ORDER = Object.freeze(["protocol", "skeptical", "code-compressor"]);
 const REVIEWER_IDS = new Set(REVIEWER_ORDER);
 const RISKS = new Set(["low", "medium", "high", "unknown"]);

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -1,0 +1,62 @@
+## Concurrency model
+
+We’re using Helmcode for the automated classifier and reviewer pipeline.
+We get at most 5 parallel requests.
+
+In order to use the 5 parallel requests as efficiently as possible:
+
+- Run at most two classifier agents in parallel.
+- Run at most one reviewer pipeline with at most 3 specialist reviews in parallel.
+
+All in all, we get at most 5 parallel requests at any time.
+
+For simplicity, use static concurrency lanes using the pull request number (as opposed to using an external semaphore service).
+
+```
+classifier-lane = (pr-number % 2) + 1 // = 1 or 2
+```
+
+At the classifier job level:
+
+```yaml
+concurrency:
+  group: llm-classifier-${{ classifier-lane }}
+  cancel-in-progress: false
+  queue: max
+```
+
+And for the reviewer pipeline job:
+
+```yml
+concurrency:
+  group: llm-reviewer-pipeline
+  cancel-in-progress: false
+  queue: max
+```
+
+`llm-reviewer-pipeline` group must lock the entire review pipeline, not each individual reviewer job.
+To that end, the review pipeline must live in a reusable workflow, and the `llm-reviewer-pipeline` concurrency is placed on its caller job.
+
+## Reviewer pipeline
+
+The reviewer pipeline is roughly defined as:
+
+```
+evidence -> specialist reviewers running in parallel -> general reviewer aggregating everything
+```
+
+The general reviewer independently inspects the pull request, attempts to falsify every candidate, and records exactly one `accepted`, `refined`, or `rejected` disposition per candidate.
+It can merge overlapping candidates and add findings that no specialist reported.
+Only the validated general-review result can be published.
+The published comments include the name of the specialist that found the finding.
+
+### Specialist reviewers
+
+Currently we define three specialist reviewers:
+
+- protocol
+- skeptical
+- code compressor
+
+They should run in parallel using a multi-job matrix.
+As discussed in the concurrency model section, we allow at most three specialist agents to run at once.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -3,16 +3,16 @@
 We’re using Helmcode for the automated classifier and reviewer pipeline.
 We get at most 5 parallel requests.
 
-In order to use the 5 parallel requests as efficiently as possible:
+To use the 5 parallel requests as efficiently as possible:
 
 - Run at most two classifier agents in parallel.
 - Run at most one reviewer pipeline with at most 3 specialist reviews in parallel.
 
-All in all, we get at most 5 parallel requests at any time.
+That totals at most 5 parallel requests at any time.
 
-For simplicity, use static concurrency lanes using the pull request number (as opposed to using an external semaphore service).
+For simplicity, derive static concurrency lanes from the pull request number instead of using an external semaphore service.
 
-```
+```text
 classifier-lane = (pr-number % 2) + 1 // = 1 or 2
 ```
 
@@ -27,21 +27,21 @@ concurrency:
 
 And for the reviewer pipeline job:
 
-```yml
+```yaml
 concurrency:
   group: llm-reviewer-pipeline
   cancel-in-progress: false
   queue: max
 ```
 
-`llm-reviewer-pipeline` group must lock the entire review pipeline, not each individual reviewer job.
-To that end, the review pipeline must live in a reusable workflow, and the `llm-reviewer-pipeline` concurrency is placed on its caller job.
+`llm-reviewer-pipeline` group must lock the entire review pipeline, not each reviewer job.
+The review pipeline must therefore live in a reusable workflow, with `llm-reviewer-pipeline` concurrency on its caller job.
 
 ## Reviewer pipeline
 
 The reviewer pipeline is roughly defined as:
 
-```
+```text
 evidence -> specialist reviewers running in parallel -> general reviewer aggregating everything
 ```
 
@@ -59,4 +59,4 @@ Currently we define three specialist reviewers:
 - code compressor
 
 They should run in parallel using a multi-job matrix.
-As discussed in the concurrency model section, we allow at most three specialist agents to run at once.
+We allow at most three specialist agents to run at once.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -58,6 +58,7 @@ jobs:
       review-requested: ${{ steps.resolve.outputs.review-requested }}
       classification-requested: ${{ steps.resolve.outputs.classification-requested }}
       review-route: ${{ steps.resolve.outputs.review-route }}
+      classifier-lane: ${{ steps.resolve.outputs.classifier-lane }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -89,6 +90,7 @@ jobs:
             core.setOutput("review-requested", result.reviewRequested === true);
             core.setOutput("classification-requested", result.classificationRequested === true);
             core.setOutput("review-route", result.reviewRoute === true);
+            core.setOutput("classifier-lane", result.prNumber ? (Number(result.prNumber) % 2) + 1 : "");
             core.info(JSON.stringify({ event: "pr-automation.resolve-pr", decision: result }));
             if (!result.ok) core.warning(`PR automation did not start: ${result.reason}`);
 
@@ -410,6 +412,10 @@ jobs:
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
     runs-on: ubuntu-latest
+    concurrency:
+      group: llm-classifier-${{ needs.resolve-pr.outputs.classifier-lane }}
+      cancel-in-progress: false
+      queue: max
     permissions:
       pull-requests: read
     environment: llm-providers
@@ -694,259 +700,21 @@ jobs:
       (needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       needs.review-gate.outputs.eligible == 'true'))
-    runs-on: ubuntu-latest
+    concurrency:
+      group: llm-reviewer-pipeline
+      cancel-in-progress: false
+      queue: max
     permissions:
+      contents: read
       issues: read
       pull-requests: read
-    environment: llm-providers
-    env:
-      OPENSPECS_COMMIT: 3a5ef220a6cc92453171e7b62129ed7740628c93
-    outputs:
-      output: ${{ steps.final.outputs.output }}
-      failure-reason: ${{ steps.evidence.outputs.failure-reason || steps.final.outputs.reason }}
-    steps:
-      - id: evidence
-        name: Prepare review evidence once
-        shell: bash
-        env:
-          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
-          BASE_SHA: ${{ needs.resolve-pr.outputs.base-sha }}
-        run: |
-          set -euo pipefail
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_GLOBAL=/dev/null
-          git init .
-          git config --local core.hooksPath /dev/null
-          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git fetch --no-tags origin +master:refs/remotes/origin/master
-          git checkout --detach origin/master
-          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"; then
-            reason="pull request evidence unavailable"
-            if test -f pr-evidence/failure-reason.txt; then
-              reason="$(cat pr-evidence/failure-reason.txt)"
-            fi
-            echo "failure-reason=$reason" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-      - name: Fetch bounded review and location context
-        uses: actions/github-script@v8
-        env:
-          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
-          PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
-        with:
-          script: |
-            const fs = require("node:fs");
-            const { addedLinesByPath, listPrFiles } = require("./.github/pr-automation/deterministic-analysis");
-            const { fetchReviewContext } = require("./.github/pr-automation/fetch-review-context");
-            const pullNumber = Number(process.env.PULL_REQUEST_NUMBER);
-            const expectedSha = process.env.HEAD_SHA;
-            const assertHead = async () => {
-              const { data } = await github.rest.pulls.get({
-                owner: context.repo.owner, repo: context.repo.repo, pull_number: pullNumber,
-              });
-              if (data.state !== "open" || data.head?.sha !== expectedSha) {
-                throw new Error("pull request head is no longer current");
-              }
-            };
-            await assertHead();
-            const reviewContext = await fetchReviewContext({
-              github, owner: context.repo.owner, repo: context.repo.repo,
-              pullNumber, expectedHeadSha: expectedSha,
-            });
-            const files = await listPrFiles(github, {
-              owner: context.repo.owner, repo: context.repo.repo, prNumber: pullNumber,
-            });
-            await assertHead();
-            fs.writeFileSync(
-              "pr-evidence/pull-request-context.json",
-              JSON.stringify(reviewContext, null, 2),
-            );
-            fs.writeFileSync(
-              "pr-evidence/validation-context.json",
-              JSON.stringify({
-                changed_paths: files.map((file) => file.filename),
-                changed_lines: addedLinesByPath(files),
-              }),
-            );
-            fs.writeFileSync(
-              "pr-automation-context.json",
-              JSON.stringify({ head_sha: expectedSha }),
-            );
-
-      - name: Fetch and sanitize the pinned protocol corpus
-        id: protocol-sources
-        if: contains(fromJSON(needs.review-gate.outputs.specialist-reviewers), 'protocol')
-        shell: bash
-        run: |
-          set -euo pipefail
-          export GIT_CONFIG_NOSYSTEM=1
-          export GIT_CONFIG_GLOBAL=/dev/null
-          git -C "$RUNNER_TEMP" init openspecs
-          git -C "$RUNNER_TEMP/openspecs" config --local core.hooksPath /dev/null
-          git -C "$RUNNER_TEMP/openspecs" remote add origin https://github.com/awakecoding/openspecs.git
-          git -C "$RUNNER_TEMP/openspecs" fetch --depth=1 --no-tags origin "$OPENSPECS_COMMIT"
-          git -C "$RUNNER_TEMP/openspecs" checkout --detach "$OPENSPECS_COMMIT"
-          openspecs_sha="$(git -C "$RUNNER_TEMP/openspecs" rev-parse HEAD)"
-          test "$openspecs_sha" = "$OPENSPECS_COMMIT"
-          bash ./.github/pr-automation/prepare-review-sources.sh \
-            "$RUNNER_TEMP/openspecs" "$openspecs_sha"
-          echo "openspecs-sha=$openspecs_sha" >> "$GITHUB_OUTPUT"
-
-      - id: protocol
-        name: Run protocol specialist
-        if: contains(fromJSON(needs.review-gate.outputs.specialist-reviewers), 'protocol')
-        continue-on-error: true
-        uses: ./.github/actions/openai-agent
-        with:
-          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
-          base-url: https://api.helmcode.com/v1
-          config-file: .github/pr-automation/agents/protocol.json
-
-      - id: skeptical
-        name: Run skeptical specialist
-        if: contains(fromJSON(needs.review-gate.outputs.specialist-reviewers), 'skeptical')
-        continue-on-error: true
-        uses: ./.github/actions/openai-agent
-        with:
-          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
-          base-url: https://api.helmcode.com/v1
-          config-file: .github/pr-automation/agents/skeptical.json
-
-      - id: code-compressor
-        name: Run code-compressor specialist
-        if: contains(fromJSON(needs.review-gate.outputs.specialist-reviewers), 'code-compressor')
-        continue-on-error: true
-        uses: ./.github/actions/openai-agent
-        with:
-          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
-          base-url: https://api.helmcode.com/v1
-          config-file: .github/pr-automation/agents/code-compressor.json
-
-      - id: aggregate
-        name: Build validated specialist findings
-        uses: actions/github-script@v8
-        env:
-          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
-          SPECIALIST_REVIEWERS: ${{ needs.review-gate.outputs.specialist-reviewers }}
-          GATE: ${{ needs.review-gate.outputs.gate }}
-          OPENSPECS_SHA: ${{ steps.protocol-sources.outputs.openspecs-sha }}
-          PROTOCOL_OUTPUT: ${{ steps.protocol.outputs.structured-output }}
-          PROTOCOL_REASON: ${{ steps.protocol.outputs.failure-reason }}
-          SKEPTICAL_OUTPUT: ${{ steps.skeptical.outputs.structured-output }}
-          SKEPTICAL_REASON: ${{ steps.skeptical.outputs.failure-reason }}
-          COMPRESSOR_OUTPUT: ${{ steps.code-compressor.outputs.structured-output }}
-          COMPRESSOR_REASON: ${{ steps.code-compressor.outputs.failure-reason }}
-        with:
-          script: |
-            const fs = require("node:fs");
-            const {
-              buildSpecialistAggregate, validateSpecialistRun,
-            } = require("./.github/pr-automation/review-pipeline");
-            const { corpusFromDirectory } = require("./.github/pr-automation/validate-protocol-review");
-            const selected = JSON.parse(process.env.SPECIALIST_REVIEWERS);
-            const gate = JSON.parse(process.env.GATE);
-            const validation = JSON.parse(fs.readFileSync(
-              "pr-evidence/validation-context.json", "utf8",
-            ));
-            const output = {
-              protocol: process.env.PROTOCOL_OUTPUT,
-              skeptical: process.env.SKEPTICAL_OUTPUT,
-              "code-compressor": process.env.COMPRESSOR_OUTPUT,
-            };
-            const reason = {
-              protocol: process.env.PROTOCOL_REASON,
-              skeptical: process.env.SKEPTICAL_REASON,
-              "code-compressor": process.env.COMPRESSOR_REASON,
-            };
-            const corpus = selected.includes("protocol")
-              ? corpusFromDirectory("review-sources/windows-protocols", {
-                expectedCorpusSha: process.env.OPENSPECS_SHA,
-              })
-              : undefined;
-            const runs = selected.map((reviewer) => validateSpecialistRun(
-              output[reviewer] || "",
-              {
-                reviewer, expectedSha: process.env.HEAD_SHA,
-                changedPaths: validation.changed_paths,
-                changedLines: validation.changed_lines,
-                corpus,
-                expectedCorpusSha: process.env.OPENSPECS_SHA,
-                failureReason: reason[reviewer],
-              },
-            ).value);
-            const result = buildSpecialistAggregate({
-              expectedSha: process.env.HEAD_SHA,
-              selectedReviewers: selected,
-              runs,
-              protocolRelated: gate.protocolRelated,
-              risk: gate.risk,
-            });
-            if (!result.ok) throw new Error(result.reason);
-            fs.writeFileSync(
-              "validated-specialist-findings.json",
-              JSON.stringify(result.value, null, 2),
-            );
-            core.setOutput("ready", result.mandatoryFailure === "");
-            core.setOutput("reason", result.mandatoryFailure);
-            core.info(JSON.stringify({
-              event: "pr-automation.specialists",
-              reviewers: result.value.reviewers.map(({ reviewer, status }) => ({ reviewer, status })),
-              mandatoryFailure: result.mandatoryFailure !== "",
-            }));
-
-      - id: general
-        name: Run independent general reviewer
-        if: steps.aggregate.outputs.ready == 'true'
-        continue-on-error: true
-        uses: ./.github/actions/openai-agent
-        with:
-          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
-          base-url: https://api.helmcode.com/v1
-          config-file: .github/pr-automation/agents/general-reviewer.json
-
-      - id: final
-        name: Validate final review
-        if: always()
-        uses: actions/github-script@v8
-        env:
-          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
-          RAW_OUTPUT: ${{ steps.general.outputs.structured-output }}
-          MODEL_REASON: ${{ steps.general.outputs.failure-reason }}
-          AGGREGATE_READY: ${{ steps.aggregate.outputs.ready }}
-          AGGREGATE_REASON: ${{ steps.aggregate.outputs.reason }}
-        with:
-          script: |
-            const fs = require("node:fs");
-            const { validateFinalReview } = require("./.github/pr-automation/validate-final-review");
-            const finish = (output, reason) => {
-              core.setOutput("output", output);
-              core.setOutput("reason", reason);
-              core.info(JSON.stringify({
-                event: "pr-automation.final-review",
-                valid: output !== "",
-                reason: output === "" ? reason : null,
-              }));
-            };
-            if (process.env.AGGREGATE_READY !== "true") {
-              return finish("", process.env.AGGREGATE_REASON || "specialist validation unavailable");
-            }
-            if (!process.env.RAW_OUTPUT) {
-              return finish("", process.env.MODEL_REASON || "general reviewer unavailable");
-            }
-            const validation = JSON.parse(fs.readFileSync(
-              "pr-evidence/validation-context.json", "utf8",
-            ));
-            const aggregate = JSON.parse(fs.readFileSync(
-              "validated-specialist-findings.json", "utf8",
-            ));
-            const result = validateFinalReview(process.env.RAW_OUTPUT, {
-              expectedSha: process.env.HEAD_SHA,
-              changedPaths: validation.changed_paths,
-              changedLines: validation.changed_lines,
-              specialistAggregate: aggregate,
-            });
-            finish(result.ok ? JSON.stringify(result.value) : "", result.ok ? "" : result.reason);
+    uses: ./.github/workflows/review-pipeline.yml
+    with:
+      pr-number: ${{ needs.resolve-pr.outputs.pr-number }}
+      head-sha: ${{ needs.resolve-pr.outputs.head-sha }}
+      base-sha: ${{ needs.resolve-pr.outputs.base-sha }}
+      gate: ${{ needs.review-gate.outputs.gate }}
+      specialist-reviewers: ${{ needs.review-gate.outputs.specialist-reviewers }}
 
   resolve-review-state:
     name: Resolve review state

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -1,0 +1,487 @@
+name: Automated review pipeline
+
+on:
+  workflow_call:
+    inputs:
+      pr-number:
+        description: Pull request number to review
+        required: true
+        type: string
+      head-sha:
+        description: Exact pull request head to review
+        required: true
+        type: string
+      base-sha:
+        description: Exact pull request base used for the review diff
+        required: true
+        type: string
+      gate:
+        description: Validated review gate state
+        required: true
+        type: string
+      specialist-reviewers:
+        description: Canonically ordered specialist reviewer IDs
+        required: true
+        type: string
+    outputs:
+      output:
+        description: Validated final review JSON
+        value: ${{ jobs.validate.outputs.output }}
+      failure-reason:
+        description: Bounded failure reason when no valid review was produced
+        value: ${{ jobs.validate.outputs.reason }}
+
+permissions: {}
+
+env:
+  OPENSPECS_COMMIT: 3a5ef220a6cc92453171e7b62129ed7740628c93
+
+jobs:
+  evidence:
+    name: Prepare review evidence
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    outputs:
+      failure-reason: ${{ steps.evidence.outputs.failure-reason }}
+      openspecs-sha: ${{ steps.protocol-sources.outputs.openspecs-sha }}
+    steps:
+      - id: evidence
+        name: Prepare SHA-bound pull request evidence
+        shell: bash
+        env:
+          HEAD_SHA: ${{ inputs.head-sha }}
+          BASE_SHA: ${{ inputs.base-sha }}
+        run: |
+          set -euo pipefail
+          export GIT_CONFIG_NOSYSTEM=1
+          export GIT_CONFIG_GLOBAL=/dev/null
+          git init .
+          git config --local core.hooksPath /dev/null
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --no-tags origin +master:refs/remotes/origin/master
+          git checkout --detach origin/master
+          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"; then
+            reason="pull request evidence unavailable"
+            if test -f pr-evidence/failure-reason.txt; then
+              reason="$(cat pr-evidence/failure-reason.txt)"
+            fi
+            echo "failure-reason=$reason" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Fetch bounded review and location context
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ inputs.head-sha }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pr-number }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const { addedLinesByPath, listPrFiles } = require("./.github/pr-automation/deterministic-analysis");
+            const { fetchReviewContext } = require("./.github/pr-automation/fetch-review-context");
+            const pullNumber = Number(process.env.PULL_REQUEST_NUMBER);
+            const expectedSha = process.env.HEAD_SHA;
+            const assertHead = async () => {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: pullNumber,
+              });
+              if (data.state !== "open" || data.head?.sha !== expectedSha) {
+                throw new Error("pull request head is no longer current");
+              }
+            };
+            await assertHead();
+            const reviewContext = await fetchReviewContext({
+              github, owner: context.repo.owner, repo: context.repo.repo,
+              pullNumber, expectedHeadSha: expectedSha,
+            });
+            const files = await listPrFiles(github, {
+              owner: context.repo.owner, repo: context.repo.repo, prNumber: pullNumber,
+            });
+            await assertHead();
+            fs.writeFileSync(
+              "pr-evidence/pull-request-context.json",
+              JSON.stringify(reviewContext, null, 2),
+            );
+            fs.writeFileSync(
+              "pr-evidence/validation-context.json",
+              JSON.stringify({
+                changed_paths: files.map((file) => file.filename),
+                changed_lines: addedLinesByPath(files),
+              }),
+            );
+            fs.writeFileSync(
+              "pr-automation-context.json",
+              JSON.stringify({ head_sha: expectedSha }),
+            );
+
+      - name: Fetch and sanitize the pinned protocol corpus
+        id: protocol-sources
+        if: contains(fromJSON(inputs.specialist-reviewers), 'protocol')
+        shell: bash
+        run: |
+          set -euo pipefail
+          export GIT_CONFIG_NOSYSTEM=1
+          export GIT_CONFIG_GLOBAL=/dev/null
+          git -C "$RUNNER_TEMP" init openspecs
+          git -C "$RUNNER_TEMP/openspecs" config --local core.hooksPath /dev/null
+          git -C "$RUNNER_TEMP/openspecs" remote add origin https://github.com/awakecoding/openspecs.git
+          git -C "$RUNNER_TEMP/openspecs" fetch --depth=1 --no-tags origin "$OPENSPECS_COMMIT"
+          git -C "$RUNNER_TEMP/openspecs" checkout --detach "$OPENSPECS_COMMIT"
+          openspecs_sha="$(git -C "$RUNNER_TEMP/openspecs" rev-parse HEAD)"
+          test "$openspecs_sha" = "$OPENSPECS_COMMIT"
+          bash ./.github/pr-automation/prepare-review-sources.sh \
+            "$RUNNER_TEMP/openspecs" "$openspecs_sha"
+          echo "openspecs-sha=$openspecs_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Remove Git metadata from the untrusted head
+        shell: bash
+        run: rm -rf pr-head/.git
+
+      - name: Upload review evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-evidence-${{ inputs.head-sha }}
+          path: |
+            pr-automation-context.json
+            pr-evidence
+            pr-head
+            review-sources
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+
+  specialists:
+    name: Review with ${{ matrix.reviewer }}
+    needs: evidence
+    if: needs.evidence.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: llm-providers
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        reviewer: ${{ fromJSON(inputs.specialist-reviewers) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          persist-credentials: false
+
+      - name: Download review evidence
+        uses: actions/download-artifact@v8
+        with:
+          name: review-evidence-${{ inputs.head-sha }}
+          path: .
+
+      - id: agent
+        name: Run ${{ matrix.reviewer }} specialist
+        continue-on-error: true
+        uses: ./.github/actions/openai-agent
+        with:
+          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
+          base-url: https://api.helmcode.com/v1
+          config-file: .github/pr-automation/agents/${{ matrix.reviewer }}.json
+
+      - id: validate
+        name: Validate specialist result
+        if: always()
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ inputs.head-sha }}
+          REVIEWER: ${{ matrix.reviewer }}
+          OPENSPECS_SHA: ${{ needs.evidence.outputs.openspecs-sha }}
+          RAW_OUTPUT: ${{ steps.agent.outputs.structured-output }}
+          MODEL_REASON: ${{ steps.agent.outputs.failure-reason }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const {
+              failedRun, validateSpecialistRun,
+            } = require("./.github/pr-automation/review-pipeline");
+            const { corpusFromDirectory } = require("./.github/pr-automation/validate-protocol-review");
+            const reviewer = process.env.REVIEWER;
+            let run;
+            try {
+              const validation = JSON.parse(fs.readFileSync(
+                "pr-evidence/validation-context.json", "utf8",
+              ));
+              const corpus = reviewer === "protocol"
+                ? corpusFromDirectory("review-sources/windows-protocols", {
+                  expectedCorpusSha: process.env.OPENSPECS_SHA,
+                })
+                : undefined;
+              run = validateSpecialistRun(process.env.RAW_OUTPUT || "", {
+                reviewer,
+                expectedSha: process.env.HEAD_SHA,
+                changedPaths: validation.changed_paths,
+                changedLines: validation.changed_lines,
+                corpus,
+                expectedCorpusSha: process.env.OPENSPECS_SHA,
+                failureReason: process.env.MODEL_REASON,
+              }).value;
+            } catch (error) {
+              core.warning(`Specialist validation unavailable: ${error.message}`);
+              run = failedRun(reviewer, "specialist validation unavailable").value;
+            }
+            fs.mkdirSync("specialist-results", { recursive: true });
+            fs.writeFileSync(
+              path.join("specialist-results", `${reviewer}.json`),
+              JSON.stringify(run, null, 2),
+            );
+            core.info(JSON.stringify({
+              event: "pr-automation.specialist",
+              reviewer,
+              status: run.status,
+            }));
+
+      - name: Upload validated specialist result
+        if: always() && steps.validate.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-specialist-${{ inputs.head-sha }}-${{ matrix.reviewer }}
+          path: specialist-results/${{ matrix.reviewer }}.json
+          if-no-files-found: error
+          retention-days: 1
+
+  aggregate:
+    name: Aggregate specialist findings
+    needs: [evidence, specialists]
+    if: always() && needs.evidence.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ready: ${{ steps.aggregate.outputs.ready }}
+      reason: ${{ steps.aggregate.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          persist-credentials: false
+
+      - name: Download specialist results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: review-specialist-${{ inputs.head-sha }}-*
+          path: specialist-results
+          merge-multiple: true
+
+      - id: aggregate
+        name: Build validated specialist findings
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ inputs.head-sha }}
+          SPECIALIST_REVIEWERS: ${{ inputs.specialist-reviewers }}
+          GATE: ${{ inputs.gate }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const { buildSpecialistAggregate } = require("./.github/pr-automation/review-pipeline");
+            const selected = JSON.parse(process.env.SPECIALIST_REVIEWERS);
+            const gate = JSON.parse(process.env.GATE);
+            const runs = selected.map((reviewer) => JSON.parse(fs.readFileSync(
+              path.join("specialist-results", `${reviewer}.json`), "utf8",
+            )));
+            const result = buildSpecialistAggregate({
+              expectedSha: process.env.HEAD_SHA,
+              selectedReviewers: selected,
+              runs,
+              protocolRelated: gate.protocolRelated,
+              risk: gate.risk,
+            });
+            if (!result.ok) throw new Error(result.reason);
+            fs.writeFileSync(
+              "validated-specialist-findings.json",
+              JSON.stringify(result.value, null, 2),
+            );
+            core.setOutput("ready", result.mandatoryFailure === "");
+            core.setOutput("reason", result.mandatoryFailure);
+            core.info(JSON.stringify({
+              event: "pr-automation.specialists",
+              reviewers: result.value.reviewers.map(({ reviewer, status }) => ({ reviewer, status })),
+              mandatoryFailure: result.mandatoryFailure !== "",
+            }));
+
+      - name: Upload specialist aggregate
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-aggregate-${{ inputs.head-sha }}
+          path: validated-specialist-findings.json
+          if-no-files-found: error
+          retention-days: 1
+
+  general:
+    name: Run independent general reviewer
+    needs: [evidence, aggregate]
+    if: needs.aggregate.result == 'success' && needs.aggregate.outputs.ready == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: llm-providers
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          persist-credentials: false
+
+      - name: Download review evidence
+        uses: actions/download-artifact@v8
+        with:
+          name: review-evidence-${{ inputs.head-sha }}
+          path: .
+
+      - name: Download specialist aggregate
+        uses: actions/download-artifact@v8
+        with:
+          name: review-aggregate-${{ inputs.head-sha }}
+          path: .
+
+      - id: agent
+        name: Run general reviewer
+        continue-on-error: true
+        uses: ./.github/actions/openai-agent
+        with:
+          api-key: ${{ secrets.HELMCODE_GLM_API_KEY }}
+          base-url: https://api.helmcode.com/v1
+          config-file: .github/pr-automation/agents/general-reviewer.json
+
+      - name: Persist general review result
+        if: always()
+        uses: actions/github-script@v8
+        env:
+          RAW_OUTPUT: ${{ steps.agent.outputs.structured-output }}
+          MODEL_REASON: ${{ steps.agent.outputs.failure-reason }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            fs.mkdirSync("general-review", { recursive: true });
+            fs.writeFileSync(
+              "general-review/result.json",
+              JSON.stringify({
+                output: process.env.RAW_OUTPUT || "",
+                reason: process.env.MODEL_REASON || "",
+              }),
+            );
+
+      - name: Upload general review result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-general-${{ inputs.head-sha }}
+          path: general-review/result.json
+          if-no-files-found: error
+          retention-days: 1
+
+  validate:
+    name: Validate final review
+    needs: [evidence, aggregate, general]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      output: ${{ steps.final.outputs.output }}
+      reason: ${{ steps.final.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          persist-credentials: false
+
+      - name: Download review evidence
+        if: >-
+          needs.aggregate.result == 'success' &&
+          needs.aggregate.outputs.ready == 'true' &&
+          needs.general.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: review-evidence-${{ inputs.head-sha }}
+          path: .
+
+      - name: Download specialist aggregate
+        if: >-
+          needs.aggregate.result == 'success' &&
+          needs.aggregate.outputs.ready == 'true' &&
+          needs.general.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: review-aggregate-${{ inputs.head-sha }}
+          path: .
+
+      - name: Download general review result
+        if: >-
+          needs.aggregate.result == 'success' &&
+          needs.aggregate.outputs.ready == 'true' &&
+          needs.general.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: review-general-${{ inputs.head-sha }}
+          path: general-review
+
+      - id: final
+        name: Validate general review
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ inputs.head-sha }}
+          EVIDENCE_RESULT: ${{ needs.evidence.result }}
+          EVIDENCE_REASON: ${{ needs.evidence.outputs.failure-reason }}
+          AGGREGATE_RESULT: ${{ needs.aggregate.result }}
+          AGGREGATE_READY: ${{ needs.aggregate.outputs.ready }}
+          AGGREGATE_REASON: ${{ needs.aggregate.outputs.reason }}
+          GENERAL_RESULT: ${{ needs.general.result }}
+        with:
+          script: |
+            const fs = require("node:fs");
+            const { validateFinalReview } = require("./.github/pr-automation/validate-final-review");
+            const finish = (output, reason) => {
+              core.setOutput("output", output);
+              core.setOutput("reason", reason);
+              core.info(JSON.stringify({
+                event: "pr-automation.final-review",
+                valid: output !== "",
+                reason: output === "" ? reason : null,
+              }));
+            };
+            if (process.env.EVIDENCE_RESULT !== "success") {
+              return finish("", process.env.EVIDENCE_REASON || "pull request evidence unavailable");
+            }
+            if (process.env.AGGREGATE_RESULT !== "success") {
+              return finish("", "specialist validation unavailable");
+            }
+            if (process.env.AGGREGATE_READY !== "true") {
+              return finish("", process.env.AGGREGATE_REASON || "specialist validation unavailable");
+            }
+            if (process.env.GENERAL_RESULT !== "success") {
+              return finish("", "general reviewer unavailable");
+            }
+            try {
+              const validation = JSON.parse(fs.readFileSync(
+                "pr-evidence/validation-context.json", "utf8",
+              ));
+              const aggregate = JSON.parse(fs.readFileSync(
+                "validated-specialist-findings.json", "utf8",
+              ));
+              const general = JSON.parse(fs.readFileSync("general-review/result.json", "utf8"));
+              if (!general.output) {
+                return finish("", general.reason || "general reviewer unavailable");
+              }
+              const result = validateFinalReview(general.output, {
+                expectedSha: process.env.HEAD_SHA,
+                changedPaths: validation.changed_paths,
+                changedLines: validation.changed_lines,
+                specialistAggregate: aggregate,
+              });
+              return finish(
+                result.ok ? JSON.stringify(result.value) : "",
+                result.ok ? "" : result.reason,
+              );
+            } catch (error) {
+              core.warning(`Final review validation unavailable: ${error.message}`);
+              return finish("", "final review validation unavailable");
+            }

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -131,6 +131,7 @@ jobs:
           bash ./.github/pr-automation/prepare-review-sources.sh \
             "$RUNNER_TEMP/openspecs" "$openspecs_sha"
           echo "openspecs-sha=$openspecs_sha" >> "$GITHUB_OUTPUT"
+          echo "Protocol corpus: \`awakecoding/openspecs@$openspecs_sha\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove Git metadata from the untrusted head
         shell: bash

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -144,7 +144,26 @@ jobs:
             pr-automation-context.json
             pr-evidence
             pr-head
-            review-sources
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+          overwrite: true
+
+      - name: Upload validation context
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-validation-${{ inputs.head-sha }}
+          path: pr-evidence/validation-context.json
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+
+      - name: Upload protocol corpus
+        if: contains(fromJSON(inputs.specialist-reviewers), 'protocol')
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-corpus-${{ inputs.head-sha }}
+          path: review-sources
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
@@ -175,6 +194,13 @@ jobs:
           name: review-evidence-${{ inputs.head-sha }}
           path: .
 
+      - name: Download protocol corpus
+        if: matrix.reviewer == 'protocol'
+        uses: actions/download-artifact@v8
+        with:
+          name: review-corpus-${{ inputs.head-sha }}
+          path: review-sources
+
       - id: agent
         name: Run ${{ matrix.reviewer }} specialist
         continue-on-error: true
@@ -198,13 +224,16 @@ jobs:
           script: |
             const fs = require("node:fs");
             const path = require("node:path");
-            const {
-              failedRun, validateSpecialistRun,
-            } = require("./.github/pr-automation/review-pipeline");
-            const { corpusFromDirectory } = require("./.github/pr-automation/validate-protocol-review");
             const reviewer = process.env.REVIEWER;
-            let run;
+            const failed = (reason) => ({ reviewer, status: "failed", reason });
+            let run = failed("specialist validation unavailable");
             try {
+              const {
+                validateSpecialistRun,
+              } = require("./.github/pr-automation/review-pipeline");
+              const {
+                corpusFromDirectory,
+              } = require("./.github/pr-automation/validate-protocol-review");
               const validation = JSON.parse(fs.readFileSync(
                 "pr-evidence/validation-context.json", "utf8",
               ));
@@ -213,7 +242,7 @@ jobs:
                   expectedCorpusSha: process.env.OPENSPECS_SHA,
                 })
                 : undefined;
-              run = validateSpecialistRun(process.env.RAW_OUTPUT || "", {
+              const result = validateSpecialistRun(process.env.RAW_OUTPUT || "", {
                 reviewer,
                 expectedSha: process.env.HEAD_SHA,
                 changedPaths: validation.changed_paths,
@@ -221,10 +250,10 @@ jobs:
                 corpus,
                 expectedCorpusSha: process.env.OPENSPECS_SHA,
                 failureReason: process.env.MODEL_REASON,
-              }).value;
+              });
+              run = result.value ?? failed(result.reason || "specialist validation unavailable");
             } catch (error) {
               core.warning(`Specialist validation unavailable: ${error.message}`);
-              run = failedRun(reviewer, "specialist validation unavailable").value;
             }
             fs.mkdirSync("specialist-results", { recursive: true });
             fs.writeFileSync(
@@ -250,7 +279,7 @@ jobs:
   aggregate:
     name: Aggregate specialist findings
     needs: [evidence, specialists]
-    if: always() && needs.evidence.result == 'success'
+    if: always() && !cancelled() && needs.evidence.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -264,6 +293,7 @@ jobs:
           persist-credentials: false
 
       - name: Download specialist results
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: review-specialist-${{ inputs.head-sha }}-*
@@ -281,12 +311,21 @@ jobs:
           script: |
             const fs = require("node:fs");
             const path = require("node:path");
-            const { buildSpecialistAggregate } = require("./.github/pr-automation/review-pipeline");
+            const {
+              buildSpecialistAggregate, failedRun,
+            } = require("./.github/pr-automation/review-pipeline");
             const selected = JSON.parse(process.env.SPECIALIST_REVIEWERS);
             const gate = JSON.parse(process.env.GATE);
-            const runs = selected.map((reviewer) => JSON.parse(fs.readFileSync(
-              path.join("specialist-results", `${reviewer}.json`), "utf8",
-            )));
+            const runs = selected.map((reviewer) => {
+              try {
+                return JSON.parse(fs.readFileSync(
+                  path.join("specialist-results", `${reviewer}.json`), "utf8",
+                ));
+              } catch (error) {
+                core.warning(`Specialist result unavailable for ${reviewer}: ${error.message}`);
+                return failedRun(reviewer, "specialist result unavailable").value;
+              }
+            });
             const result = buildSpecialistAggregate({
               expectedSha: process.env.HEAD_SHA,
               selectedReviewers: selected,
@@ -382,7 +421,7 @@ jobs:
   validate:
     name: Validate final review
     needs: [evidence, aggregate, general]
-    if: always()
+    if: always() && !cancelled()
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -395,31 +434,22 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
-      - name: Download review evidence
-        if: >-
-          needs.aggregate.result == 'success' &&
-          needs.aggregate.outputs.ready == 'true' &&
-          needs.general.result == 'success'
+      - name: Download validation context
+        if: needs.general.result == 'success'
         uses: actions/download-artifact@v8
         with:
-          name: review-evidence-${{ inputs.head-sha }}
-          path: .
+          name: review-validation-${{ inputs.head-sha }}
+          path: pr-evidence
 
       - name: Download specialist aggregate
-        if: >-
-          needs.aggregate.result == 'success' &&
-          needs.aggregate.outputs.ready == 'true' &&
-          needs.general.result == 'success'
+        if: needs.general.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: review-aggregate-${{ inputs.head-sha }}
           path: .
 
       - name: Download general review result
-        if: >-
-          needs.aggregate.result == 'success' &&
-          needs.aggregate.outputs.ready == 'true' &&
-          needs.general.result == 'success'
+        if: needs.general.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: review-general-${{ inputs.head-sha }}

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -33,9 +33,6 @@ on:
 
 permissions: {}
 
-env:
-  OPENSPECS_COMMIT: 3a5ef220a6cc92453171e7b62129ed7740628c93
-
 jobs:
   evidence:
     name: Prepare review evidence
@@ -116,7 +113,7 @@ jobs:
               JSON.stringify({ head_sha: expectedSha }),
             );
 
-      - name: Fetch and sanitize the pinned protocol corpus
+      - name: Fetch and sanitize the latest protocol corpus
         id: protocol-sources
         if: contains(fromJSON(inputs.specialist-reviewers), 'protocol')
         shell: bash
@@ -127,10 +124,9 @@ jobs:
           git -C "$RUNNER_TEMP" init openspecs
           git -C "$RUNNER_TEMP/openspecs" config --local core.hooksPath /dev/null
           git -C "$RUNNER_TEMP/openspecs" remote add origin https://github.com/awakecoding/openspecs.git
-          git -C "$RUNNER_TEMP/openspecs" fetch --depth=1 --no-tags origin "$OPENSPECS_COMMIT"
-          git -C "$RUNNER_TEMP/openspecs" checkout --detach "$OPENSPECS_COMMIT"
+          git -C "$RUNNER_TEMP/openspecs" fetch --depth=1 --no-tags origin +master:refs/remotes/origin/master
+          git -C "$RUNNER_TEMP/openspecs" checkout --detach origin/master
           openspecs_sha="$(git -C "$RUNNER_TEMP/openspecs" rev-parse HEAD)"
-          test "$openspecs_sha" = "$OPENSPECS_COMMIT"
           bash ./.github/pr-automation/prepare-review-sources.sh \
             "$RUNNER_TEMP/openspecs" "$openspecs_sha"
           echo "openspecs-sha=$openspecs_sha" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           HEAD_SHA: ${{ inputs.head-sha }}
           BASE_SHA: ${{ inputs.base-sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           export GIT_CONFIG_NOSYSTEM=1
@@ -57,8 +58,8 @@ jobs:
           git init .
           git config --local core.hooksPath /dev/null
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git fetch --no-tags origin +master:refs/remotes/origin/master
-          git checkout --detach origin/master
+          git fetch --no-tags origin "+$WORKFLOW_SHA:refs/remotes/origin/automation"
+          git checkout --detach origin/automation
           if ! bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"; then
             reason="pull request evidence unavailable"
             if test -f pr-evidence/failure-reason.txt; then
@@ -147,6 +148,7 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
+          overwrite: true
 
   specialists:
     name: Review with ${{ matrix.reviewer }}
@@ -164,7 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Download review evidence
@@ -243,6 +245,7 @@ jobs:
           path: specialist-results/${{ matrix.reviewer }}.json
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   aggregate:
     name: Aggregate specialist findings
@@ -257,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Download specialist results
@@ -311,6 +314,7 @@ jobs:
           path: validated-specialist-findings.json
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   general:
     name: Run independent general reviewer
@@ -323,7 +327,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Download review evidence
@@ -373,6 +377,7 @@ jobs:
           path: general-review/result.json
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   validate:
     name: Validate final review
@@ -387,7 +392,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Download review evidence


### PR DESCRIPTION
Reserve two static classifier lanes and serialize complete review pipelines so Helmcode never receives more than five concurrent requests per key.

Run selected specialists in a three-wide reusable-workflow matrix and transfer SHA-bound evidence and validated results between jobs with artifacts.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>