### PR TITLE
feat(usb)!: support SuperSpeed packet sizes

### DIFF
--- a/crates/ironrdp-testsuite-core/tests/usb.rs
+++ b/crates/ironrdp-testsuite-core/tests/usb.rs
@@ -7,6 +7,7 @@ use ironrdp_usb::descriptor::{
 };
 use ironrdp_usb::endpoint::{EndpointAddress, EndpointAddressErrorKind, EndpointNumber, MaxPacketSize};
 use ironrdp_usb::{Direction, TransferType, UsbSpeed};
+use rstest::rstest;
 
 /// Minimal conforming device descriptor, as defined by USB 2.0 Table 9-8.
 const DEVICE_DESCRIPTOR: [u8; 18] = [
@@ -409,72 +410,64 @@ fn max_packet_size_rejects_the_reserved_high_bandwidth_encoding() {
     );
 }
 
-#[test]
-fn validates_low_speed_packet_sizes() {
-    assert!(MaxPacketSize::from_raw(8).is_valid_for_usb2(UsbSpeed::Low, TransferType::Control));
-    assert!(!MaxPacketSize::from_raw(16).is_valid_for_usb2(UsbSpeed::Low, TransferType::Control));
-
-    assert!(MaxPacketSize::from_raw(1).is_valid_for_usb2(UsbSpeed::Low, TransferType::Interrupt));
-    assert!(MaxPacketSize::from_raw(8).is_valid_for_usb2(UsbSpeed::Low, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(0).is_valid_for_usb2(UsbSpeed::Low, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(9).is_valid_for_usb2(UsbSpeed::Low, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(0x0808).is_valid_for_usb2(UsbSpeed::Low, TransferType::Interrupt));
-
-    assert!(!MaxPacketSize::from_raw(8).is_valid_for_usb2(UsbSpeed::Low, TransferType::Bulk));
-    assert!(!MaxPacketSize::from_raw(8).is_valid_for_usb2(UsbSpeed::Low, TransferType::Isochronous));
+#[rstest]
+#[case::low_control(UsbSpeed::Low, TransferType::Control, &[8], &[16])]
+#[case::low_interrupt(UsbSpeed::Low, TransferType::Interrupt, &[1, 8], &[0, 9, 0x0808])]
+#[case::low_bulk(UsbSpeed::Low, TransferType::Bulk, &[], &[8])]
+#[case::low_isochronous(UsbSpeed::Low, TransferType::Isochronous, &[], &[8])]
+#[case::full_control(UsbSpeed::Full, TransferType::Control, &[8, 16, 32, 64], &[0, 1, 7, 9, 63, 65, 512])]
+#[case::full_bulk(UsbSpeed::Full, TransferType::Bulk, &[8, 16, 32, 64], &[0, 1, 7, 9, 63, 65, 512])]
+#[case::full_isochronous(UsbSpeed::Full, TransferType::Isochronous, &[0, 1023], &[1024])]
+#[case::full_interrupt(UsbSpeed::Full, TransferType::Interrupt, &[1, 64], &[0, 65, 0x0840])]
+#[case::high_control(UsbSpeed::High, TransferType::Control, &[64], &[32])]
+#[case::high_bulk(UsbSpeed::High, TransferType::Bulk, &[512], &[64, 1024])]
+#[case::high_isochronous(
+    UsbSpeed::High,
+    TransferType::Isochronous,
+    &[0, 1, 1024, 0x0c00, 0x1400],
+    &[1025, 0x0800, 0x1c00, 0x2400]
+)]
+#[case::high_interrupt(
+    UsbSpeed::High,
+    TransferType::Interrupt,
+    &[1, 1024, 0x0c00, 0x1400],
+    &[0, 1025, 0x1c00, 0x2400]
+)]
+#[case::super_control(UsbSpeed::Super, TransferType::Control, &[512], &[64])]
+#[case::super_bulk(UsbSpeed::Super, TransferType::Bulk, &[1024], &[512])]
+#[case::super_isochronous(UsbSpeed::Super, TransferType::Isochronous, &[0, 1, 1024], &[1025, 0x0c00])]
+#[case::super_interrupt(UsbSpeed::Super, TransferType::Interrupt, &[1, 1024], &[0, 1025, 0x0c00])]
+#[case::super_plus_control(UsbSpeed::SuperPlus, TransferType::Control, &[512], &[64])]
+#[case::super_plus_bulk(UsbSpeed::SuperPlus, TransferType::Bulk, &[1024], &[512])]
+#[case::super_plus_isochronous(UsbSpeed::SuperPlus, TransferType::Isochronous, &[0, 1, 1024], &[1025, 0x0c00])]
+#[case::super_plus_interrupt(UsbSpeed::SuperPlus, TransferType::Interrupt, &[1, 1024], &[0, 1025, 0x0c00])]
+fn valid_speed_packet_sizes(
+    #[case] speed: UsbSpeed,
+    #[case] transfer_type: TransferType,
+    #[case] valid: &[u16],
+    #[case] invalid: &[u16],
+) {
+    for &raw in valid {
+        assert!(
+            MaxPacketSize::from_raw(raw).is_valid_for(speed, transfer_type),
+            "{raw:#06x} must be a valid {speed:?} {transfer_type:?} packet size"
+        );
+    }
+    for &raw in invalid {
+        assert!(
+            !MaxPacketSize::from_raw(raw).is_valid_for(speed, transfer_type),
+            "{raw:#06x} must be rejected as a {speed:?} {transfer_type:?} packet size"
+        );
+    }
 }
 
-#[test]
-fn validates_full_speed_packet_sizes() {
-    for packet_size in [8, 16, 32, 64] {
-        assert!(MaxPacketSize::from_raw(packet_size).is_valid_for_usb2(UsbSpeed::Full, TransferType::Control));
-        assert!(MaxPacketSize::from_raw(packet_size).is_valid_for_usb2(UsbSpeed::Full, TransferType::Bulk));
-    }
-    for packet_size in [0, 1, 7, 9, 63, 65, 512] {
-        assert!(!MaxPacketSize::from_raw(packet_size).is_valid_for_usb2(UsbSpeed::Full, TransferType::Control));
-        assert!(!MaxPacketSize::from_raw(packet_size).is_valid_for_usb2(UsbSpeed::Full, TransferType::Bulk));
-    }
-
-    assert!(MaxPacketSize::from_raw(0).is_valid_for_usb2(UsbSpeed::Full, TransferType::Isochronous));
-    assert!(MaxPacketSize::from_raw(1023).is_valid_for_usb2(UsbSpeed::Full, TransferType::Isochronous));
-    assert!(!MaxPacketSize::from_raw(1024).is_valid_for_usb2(UsbSpeed::Full, TransferType::Isochronous));
-
-    assert!(MaxPacketSize::from_raw(1).is_valid_for_usb2(UsbSpeed::Full, TransferType::Interrupt));
-    assert!(MaxPacketSize::from_raw(64).is_valid_for_usb2(UsbSpeed::Full, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(0).is_valid_for_usb2(UsbSpeed::Full, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(65).is_valid_for_usb2(UsbSpeed::Full, TransferType::Interrupt));
-    assert!(!MaxPacketSize::from_raw(0x0840).is_valid_for_usb2(UsbSpeed::Full, TransferType::Interrupt));
-}
-
-#[test]
-fn validates_high_speed_packet_sizes() {
-    assert!(MaxPacketSize::from_raw(64).is_valid_for_usb2(UsbSpeed::High, TransferType::Control));
-    assert!(!MaxPacketSize::from_raw(32).is_valid_for_usb2(UsbSpeed::High, TransferType::Control));
-
-    assert!(MaxPacketSize::from_raw(512).is_valid_for_usb2(UsbSpeed::High, TransferType::Bulk));
-    assert!(!MaxPacketSize::from_raw(64).is_valid_for_usb2(UsbSpeed::High, TransferType::Bulk));
-    assert!(!MaxPacketSize::from_raw(1024).is_valid_for_usb2(UsbSpeed::High, TransferType::Bulk));
-
-    for transfer_type in [TransferType::Isochronous, TransferType::Interrupt] {
-        assert!(MaxPacketSize::from_raw(1).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(MaxPacketSize::from_raw(1024).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(MaxPacketSize::from_raw(0x0c00).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(MaxPacketSize::from_raw(0x1400).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(!MaxPacketSize::from_raw(1025).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(!MaxPacketSize::from_raw(0x1c00).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-        assert!(!MaxPacketSize::from_raw(0x2400).is_valid_for_usb2(UsbSpeed::High, transfer_type));
-    }
-    assert!(MaxPacketSize::from_raw(0).is_valid_for_usb2(UsbSpeed::High, TransferType::Isochronous));
-    assert!(!MaxPacketSize::from_raw(0x0800).is_valid_for_usb2(UsbSpeed::High, TransferType::Isochronous));
-    assert!(!MaxPacketSize::from_raw(0).is_valid_for_usb2(UsbSpeed::High, TransferType::Interrupt));
-}
-
-#[test]
-fn usb2_validation_rejects_superspeed_semantics() {
-    for speed in [UsbSpeed::Super, UsbSpeed::SuperPlus] {
-        assert!(!MaxPacketSize::from_raw(512).is_valid_for_usb2(speed, TransferType::Control));
-        assert!(!MaxPacketSize::from_raw(1024).is_valid_for_usb2(speed, TransferType::Isochronous));
-        assert!(!MaxPacketSize::from_raw(1024).is_valid_for_usb2(speed, TransferType::Bulk));
-        assert!(!MaxPacketSize::from_raw(1024).is_valid_for_usb2(speed, TransferType::Interrupt));
-    }
+#[rstest]
+#[case::superspeed(UsbSpeed::Super)]
+#[case::superspeed_plus(UsbSpeed::SuperPlus)]
+fn superspeed_payload_is_a_single_packet(#[case] speed: UsbSpeed) {
+    // The burst lives in the companion descriptor, so the payload is one packet.
+    assert_eq!(
+        MaxPacketSize::from_raw(1024).max_payload(speed, TransferType::Bulk),
+        Some(1024)
+    );
 }

--- a/crates/ironrdp-testsuite-core/tests/usb.rs
+++ b/crates/ironrdp-testsuite-core/tests/usb.rs
@@ -170,13 +170,27 @@ fn device_descriptor_validate_rejects_non_decimal_bcd_nibbles() {
 }
 
 #[test]
-fn endpoint_zero_max_packet_size_is_speed_dependent() {
-    let descriptor = DeviceDescriptor::parse(&DEVICE_DESCRIPTOR).unwrap();
-    assert_eq!(descriptor.endpoint_zero_max_packet_size(UsbSpeed::High), Ok(64));
-    assert_eq!(descriptor.endpoint_zero_max_packet_size(UsbSpeed::Full), Ok(64));
-    assert!(descriptor.endpoint_zero_max_packet_size(UsbSpeed::Low).is_err());
-    // SuperSpeed encodes the size as an exponent, so only 9 (meaning 512) is valid.
-    assert!(descriptor.endpoint_zero_max_packet_size(UsbSpeed::Super).is_err());
+fn endpoint_zero_max_packet_size_decodes_by_encoding() {
+    for (encoded, expected) in [(8, 8), (64, 64), (DeviceDescriptor::SUPERSPEED_MAX_PACKET_SIZE_0, 512)] {
+        let mut bytes = DEVICE_DESCRIPTOR;
+        bytes[7] = encoded;
+        let descriptor = DeviceDescriptor::parse(&bytes).unwrap();
+
+        assert_eq!(descriptor.endpoint_zero_max_packet_size(), Ok(expected));
+    }
+}
+
+#[test]
+fn endpoint_zero_max_packet_size_rejects_an_unknown_encoding() {
+    // Neither a literal USB 2.0 size nor the SuperSpeed exponent.
+    for encoded in [0, 10] {
+        let mut bytes = DEVICE_DESCRIPTOR;
+        bytes[7] = encoded;
+        let descriptor = DeviceDescriptor::parse(&bytes).unwrap();
+
+        let error = descriptor.endpoint_zero_max_packet_size().unwrap_err();
+        assert_eq!(error.encoded_max_packet_size_0(), encoded);
+    }
 }
 
 #[test]

--- a/crates/ironrdp-usb/README.md
+++ b/crates/ironrdp-usb/README.md
@@ -12,8 +12,10 @@ The crate itself does not allocate.
 Parsing is limited to byte layouts defined by USB itself, such as setup packets and descriptors.
 Parsing usbredir packets, RDPEUSB PDUs, or any other transport framing belongs in the corresponding protocol crate.
 
-The typed descriptor model currently follows the device framework of [USB 2.0], described in its chapter 9.
-USB 3.x values and descriptor identities remain representable and losslessly traversable, but detailed SuperSpeed descriptor semantics are intentionally deferred until a non-RDPEUSB consumer requires them.
+The typed descriptor model follows the device framework of [USB 2.0], described in its chapter 9.
+Packet-size semantics also cover SuperSpeed, for which USB 3.2 states the endpoint limits and the `bMaxPacketSize0` encoding differently.
+Typed views of the SuperSpeed-specific descriptors, the endpoint companions and the binary device object store, are deferred until a consumer requires them.
+Their identities are defined, and they remain losslessly traversable as raw descriptors.
 
 This crate is part of the [IronRDP] project.
 

--- a/crates/ironrdp-usb/src/control.rs
+++ b/crates/ironrdp-usb/src/control.rs
@@ -132,6 +132,20 @@ pub mod standard_request {
     pub const SET_ISOCHRONOUS_DELAY: u8 = 0x31;
 }
 
+/// Standard feature selectors, carried in `wValue` of `CLEAR_FEATURE` and
+/// `SET_FEATURE` ([USB 2.0] Table 9-6).
+///
+/// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
+pub mod standard_feature {
+    /// Halt condition of the addressed endpoint. The only selector a `CLEAR_FEATURE`
+    /// or `SET_FEATURE` with an endpoint recipient may name.
+    pub const ENDPOINT_HALT: u16 = 0;
+    /// Device-side remote wakeup, addressed to the device.
+    pub const DEVICE_REMOTE_WAKEUP: u16 = 1;
+    /// High-speed electrical test mode, addressed to the device.
+    pub const TEST_MODE: u16 = 2;
+}
+
 /// A USB control-transfer setup packet (exactly eight bytes on the wire).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SetupPacket {

--- a/crates/ironrdp-usb/src/descriptor/device.rs
+++ b/crates/ironrdp-usb/src/descriptor/device.rs
@@ -8,7 +8,7 @@ use super::{
     DEVICE_DESCRIPTOR_MIN_LENGTH, DescriptorError, DescriptorErrorKind, DescriptorField, DeviceDescriptorError,
     RawDescriptor, descriptor_type, invalid_field, le_u16, require_minimum_length, validate_class_code,
 };
-use crate::{BcdVersion, ClassCode};
+use crate::{BcdVersion, ClassCode, UsbSpeed};
 
 /// Standard USB device descriptor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +141,21 @@ impl<'a> DeviceDescriptor<'a> {
             encoded @ (8 | 16 | 32 | 64) => Ok(u16::from(encoded)),
             encoded => Err(DeviceDescriptorError::new(encoded)),
         }
+    }
+
+    /// Whether `bMaxPacketSize0` is one the negotiated `speed` admits.
+    #[must_use]
+    pub fn is_endpoint_zero_valid_for(self, speed: UsbSpeed) -> bool {
+        matches!(
+            (speed, self.max_packet_size_0_raw()),
+            (UsbSpeed::Low, 8)
+                | (UsbSpeed::Full, 8 | 16 | 32 | 64)
+                | (UsbSpeed::High, 64)
+                | (
+                    UsbSpeed::Super | UsbSpeed::SuperPlus,
+                    Self::SUPERSPEED_MAX_PACKET_SIZE_0
+                )
+        )
     }
 }
 

--- a/crates/ironrdp-usb/src/descriptor/device.rs
+++ b/crates/ironrdp-usb/src/descriptor/device.rs
@@ -8,7 +8,7 @@ use super::{
     DEVICE_DESCRIPTOR_MIN_LENGTH, DescriptorError, DescriptorErrorKind, DescriptorField, DeviceDescriptorError,
     RawDescriptor, descriptor_type, invalid_field, le_u16, require_minimum_length, validate_class_code,
 };
-use crate::{BcdVersion, ClassCode, UsbSpeed};
+use crate::{BcdVersion, ClassCode};
 
 /// Standard USB device descriptor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,6 +73,14 @@ impl<'a> DeviceDescriptor<'a> {
         self.raw.as_bytes()
     }
 
+    /// The only `bMaxPacketSize0` a SuperSpeed device may report.
+    ///
+    /// USB 3.2 9.6.1 states the field as the base-2 exponent of the packet
+    /// size and admits this single value, so its presence proves the device
+    /// enumerated at SuperSpeed: no slower speed may use it, because USB 2.0
+    /// states the size literally and admits only 8, 16, 32 and 64.
+    pub const SUPERSPEED_MAX_PACKET_SIZE_0: u8 = 9;
+
     #[must_use]
     pub fn usb_version(self) -> BcdVersion {
         BcdVersion::from_raw(le_u16(self.as_bytes(), 2))
@@ -126,27 +134,13 @@ impl<'a> DeviceDescriptor<'a> {
         self.as_bytes()[17]
     }
 
-    /// Interpret `bMaxPacketSize0` using negotiated bus speed.
-    ///
-    /// `bcdUSB` is deliberately not used as a substitute for speed: a USB 3.x
-    /// capable device can enumerate using USB 2.0 endpoint-zero semantics.
-    pub fn endpoint_zero_max_packet_size(self, speed: UsbSpeed) -> Result<u16, DeviceDescriptorError> {
-        let encoded = self.max_packet_size_0_raw();
-        let valid = match speed {
-            UsbSpeed::Low => encoded == 8,
-            UsbSpeed::Full => matches!(encoded, 8 | 16 | 32 | 64),
-            UsbSpeed::High => encoded == 64,
-            UsbSpeed::Super | UsbSpeed::SuperPlus => encoded == 9,
-        };
-        if !valid {
-            return Err(DeviceDescriptorError::new(speed, encoded));
+    /// Interpret `bMaxPacketSize0`.
+    pub fn endpoint_zero_max_packet_size(self) -> Result<u16, DeviceDescriptorError> {
+        match self.max_packet_size_0_raw() {
+            Self::SUPERSPEED_MAX_PACKET_SIZE_0 => Ok(1 << Self::SUPERSPEED_MAX_PACKET_SIZE_0),
+            encoded @ (8 | 16 | 32 | 64) => Ok(u16::from(encoded)),
+            encoded => Err(DeviceDescriptorError::new(encoded)),
         }
-
-        Ok(if speed.is_superspeed() {
-            1u16 << encoded
-        } else {
-            u16::from(encoded)
-        })
     }
 }
 

--- a/crates/ironrdp-usb/src/descriptor/error.rs
+++ b/crates/ironrdp-usb/src/descriptor/error.rs
@@ -3,7 +3,6 @@
 use core::fmt;
 
 use super::super::endpoint::EndpointAddress;
-use crate::UsbSpeed;
 
 /// Field associated with an invalid descriptor value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -220,24 +219,17 @@ impl fmt::Display for DescriptorError {
 
 impl core::error::Error for DescriptorError {}
 
-/// Speed-dependent device-descriptor semantic error.
+/// `bMaxPacketSize0` matches neither endpoint-zero packet size encoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DeviceDescriptorError {
-    speed: UsbSpeed,
     encoded_max_packet_size_0: u8,
 }
 
 impl DeviceDescriptorError {
-    pub(super) const fn new(speed: UsbSpeed, encoded_max_packet_size_0: u8) -> Self {
+    pub(super) const fn new(encoded_max_packet_size_0: u8) -> Self {
         Self {
-            speed,
             encoded_max_packet_size_0,
         }
-    }
-
-    #[must_use]
-    pub const fn speed(self) -> UsbSpeed {
-        self.speed
     }
 
     #[must_use]
@@ -248,11 +240,7 @@ impl DeviceDescriptorError {
 
 impl fmt::Display for DeviceDescriptorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "invalid bMaxPacketSize0 {} for {:?} speed",
-            self.encoded_max_packet_size_0, self.speed
-        )
+        write!(f, "invalid bMaxPacketSize0 {}", self.encoded_max_packet_size_0)
     }
 }
 

--- a/crates/ironrdp-usb/src/descriptor/mod.rs
+++ b/crates/ironrdp-usb/src/descriptor/mod.rs
@@ -34,10 +34,28 @@ pub use raw::{DescriptorIter, RawDescriptor, descriptor_type};
 
 use crate::ClassCode;
 
-const DEVICE_DESCRIPTOR_MIN_LENGTH: usize = 18;
-const CONFIGURATION_DESCRIPTOR_MIN_LENGTH: usize = 9;
-const INTERFACE_DESCRIPTOR_MIN_LENGTH: usize = 9;
-const ENDPOINT_DESCRIPTOR_MIN_LENGTH: usize = 7;
+/// `bLength` of a standard device descriptor ([USB 2.0] 9.6.1).
+///
+/// The descriptor is fixed size, so this is also how many bytes a
+/// `GET_DESCRIPTOR` must ask for to read one whole.
+///
+/// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
+pub const DEVICE_DESCRIPTOR_MIN_LENGTH: usize = 18;
+/// `bLength` of a configuration descriptor header ([USB 2.0] 9.6.3).
+///
+/// Only the header is fixed size: it declares `wTotalLength`, the size of the
+/// whole descriptor set that follows it.
+///
+/// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
+pub const CONFIGURATION_DESCRIPTOR_MIN_LENGTH: usize = 9;
+/// `bLength` of an interface descriptor ([USB 2.0] 9.6.5).
+///
+/// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
+pub const INTERFACE_DESCRIPTOR_MIN_LENGTH: usize = 9;
+/// `bLength` of an endpoint descriptor ([USB 2.0] 9.6.6).
+///
+/// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
+pub const ENDPOINT_DESCRIPTOR_MIN_LENGTH: usize = 7;
 
 fn require_minimum_length(
     offset: usize,

--- a/crates/ironrdp-usb/src/endpoint.rs
+++ b/crates/ironrdp-usb/src/endpoint.rs
@@ -321,6 +321,10 @@ impl MaxPacketSize {
     /// Table 5-1 together with the high-bandwidth encoding from Section 9.6.6.
     /// A SuperSpeed endpoint takes its limits from USB 3.2 Section 9.6.6.
     ///
+    /// Interface-level rules are outside this predicate; callers must separately
+    /// enforce the zero-bandwidth requirement for isochronous endpoints in
+    /// alternate setting zero.
+    ///
     /// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
     #[must_use]
     pub const fn is_valid_for(self, speed: UsbSpeed, transfer_type: TransferType) -> bool {
@@ -362,16 +366,14 @@ impl MaxPacketSize {
 
     /// Maximum payload bytes moved by one scheduled service of this endpoint.
     ///
-    /// A high-speed high-bandwidth isochronous or interrupt endpoint is served
-    /// by up to three back-to-back transactions within one microframe
-    /// ([USB 2.0] 5.9), so its payload is the packet size multiplied by the
-    /// total transaction count encoded in `wMaxPacketSize` bits 12..11
-    /// ([USB 2.0] 9.6.6). Every other speed and transfer type moves one packet
-    /// per transaction, SuperSpeed included: USB 3.2 carries an endpoint's
-    /// burst in its companion descriptor rather than in `wMaxPacketSize`.
+    /// A high-speed high-bandwidth isochronous or interrupt endpoint is served by up to three
+    /// back-to-back transactions within one microframe ([USB 2.0] 5.9), and that count is encoded
+    /// in `wMaxPacketSize` bits 12..11 ([USB 2.0] 9.6.6), so it is included here. Every other speed
+    /// and transfer type contributes a single packet.
     ///
-    /// `None` when the encoding is not valid for `speed` and `transfer_type`;
-    /// [`Self::is_valid_for`] defines exactly the same precondition.
+    /// `This is the whole service payload at USB 2.0 speeds only. None` when the encoding is not
+    /// valid for `speed` and `transfer_type`; [`Self::is_valid_for`] defines exactly the same
+    /// precondition.
     ///
     /// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
     #[must_use]

--- a/crates/ironrdp-usb/src/endpoint.rs
+++ b/crates/ironrdp-usb/src/endpoint.rs
@@ -315,18 +315,15 @@ impl MaxPacketSize {
     }
 
     /// Whether this value satisfies the speed- and transfer-type-dependent
-    /// endpoint limits defined by [USB 2.0].
+    /// endpoint limits for `speed`.
     ///
-    /// This includes the packet-size limits from USB 2.0 Table 5-1 and the
-    /// high-bandwidth encoding from Section 9.6.6. SuperSpeed values return
-    /// `false`: their endpoint semantics are defined by USB 3.x instead.
-    /// Interface-level rules are intentionally outside this predicate; in
-    /// particular, callers must separately enforce the zero-bandwidth
-    /// requirement for isochronous endpoints in alternate setting zero.
+    /// At USB 2.0 speeds these are the packet-size limits from [USB 2.0]
+    /// Table 5-1 together with the high-bandwidth encoding from Section 9.6.6.
+    /// A SuperSpeed endpoint takes its limits from USB 3.2 Section 9.6.6.
     ///
     /// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
     #[must_use]
-    pub const fn is_valid_for_usb2(self, speed: UsbSpeed, transfer_type: TransferType) -> bool {
+    pub const fn is_valid_for(self, speed: UsbSpeed, transfer_type: TransferType) -> bool {
         let raw = self.raw();
         let packet_size = self.packet_size();
         let additional_transactions = self.additional_transactions_raw();
@@ -352,7 +349,14 @@ impl MaxPacketSize {
             (UsbSpeed::High, TransferType::Interrupt) => {
                 additional_transactions <= 2 && matches!(packet_size, 1..=1024)
             }
-            (UsbSpeed::Super | UsbSpeed::SuperPlus, _) => false,
+            (UsbSpeed::Super | UsbSpeed::SuperPlus, TransferType::Control) => raw == 512,
+            (UsbSpeed::Super | UsbSpeed::SuperPlus, TransferType::Bulk) => raw == 1024,
+            (UsbSpeed::Super | UsbSpeed::SuperPlus, TransferType::Isochronous) => {
+                raw == 0 || (additional_transactions == 0 && matches!(packet_size, 1..=1024))
+            }
+            (UsbSpeed::Super | UsbSpeed::SuperPlus, TransferType::Interrupt) => {
+                additional_transactions == 0 && matches!(packet_size, 1..=1024)
+            }
         }
     }
 
@@ -363,15 +367,16 @@ impl MaxPacketSize {
     /// ([USB 2.0] 5.9), so its payload is the packet size multiplied by the
     /// total transaction count encoded in `wMaxPacketSize` bits 12..11
     /// ([USB 2.0] 9.6.6). Every other speed and transfer type moves one packet
-    /// per transaction.
+    /// per transaction, SuperSpeed included: USB 3.2 carries an endpoint's
+    /// burst in its companion descriptor rather than in `wMaxPacketSize`.
     ///
     /// `None` when the encoding is not valid for `speed` and `transfer_type`;
-    /// [`Self::is_valid_for_usb2`] defines exactly the same precondition.
+    /// [`Self::is_valid_for`] defines exactly the same precondition.
     ///
     /// [USB 2.0]: https://www.usb.org/document-library/usb-20-specification
     #[must_use]
-    pub const fn usb2_max_payload(self, speed: UsbSpeed, transfer_type: TransferType) -> Option<u16> {
-        if !self.is_valid_for_usb2(speed, transfer_type) {
+    pub const fn max_payload(self, speed: UsbSpeed, transfer_type: TransferType) -> Option<u16> {
+        if !self.is_valid_for(speed, transfer_type) {
             return None;
         }
 
@@ -382,7 +387,7 @@ impl MaxPacketSize {
             _ => 1,
         };
 
-        // `is_valid_for_usb2` bounds the packet size by 1024 and the additional
+        // `is_valid_for` bounds the packet size by 1024 and the additional
         // transactions by two, so the product is at most 3072.
         Some(self.packet_size() * transactions)
     }


### PR DESCRIPTION
`ironrdp-usb` could not describe a SuperSpeed device: `is_valid_for_usb2` rejected every SuperSpeed endpoint, and `endpoint_zero_max_packet_size` required a bus speed to read `bMaxPacketSize0`.

That speed parameter added nothing. USB 3.2 Section 9.6.1 admits only 9 there, as a base-2 exponent, while USB 2.0 admits only 8, 16, 32 and 64, stated literally, so the two encodings are disjoint and the value identifies itself. Requiring a speed only let a caller contradict the descriptor, which is exactly what a transport that cannot express SuperSpeed ends up doing.

Endpoint zero now decodes from the value alone, and the endpoint predicate carries the USB 3.2 Section 9.6.6 limits, so `is_valid_for_usb2` and `usb2_max_payload` lose their USB 2.0 names.

@elmarco has helped test with a USB 3 device from FreeRDP.