### PR TITLE
ci(pr-automation): broaden automated review

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -115,7 +115,7 @@ The classifier controls `scope/cross-cutting`, `kind/technical-debt`, and docume
 Automatic review runs for every non-draft pull request that passes the remaining gates.
 `OWNER` and `MEMBER` authors are eligible without contributor history.
 Other human authors need one qualifying merged IronRDP pull request from the same immutable author.
-Qualifying pull requests are merged, are not labeled `trivial` or `reverted`, and do not have a title beginning with `revert`.
+A qualifying pull request is any pull request from that author merged into `master`.
 Automatic review requires successful CI for the exact classified head.
 After the first review, a later push starts the second review when CI succeeds for that new head.
 Duplicates at confidence 0.85 or greater, legitimacy triage, and `ai-reviewed/2` block automatic review.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -2,7 +2,7 @@
 
 `.github/workflows/labeler.yml` classifies ready, open pull requests and calls `.github/workflows/review-pipeline.yml` for at most two automated reviews.
 Automatic routes stop at `ai-reviewed/2` unless a maintainer uses force mode.
-Model analysis fails closed when the reviewable pull request diff exceeds the 1 MiB evidence limit.
+Model analysis fails closed when the reviewable pull request diff exceeds the applicable evidence limit.
 The trusted `evidence-diff-attributes` policy represents reproducibly verified generated artifacts with binary-change markers.
 The automation posts guidance on the pull request instead of invoking a model with partial evidence.
 
@@ -112,10 +112,14 @@ A model-suspected breaking change promotes `risk/low` to `risk/medium`.
 Path rules can add `scope/core`, `scope/web`, `scope/ffi`, and `scope/tooling`.
 The classifier controls `scope/cross-cutting`, `kind/technical-debt`, and documentation-only classification.
 
-Automatic review requires successful CI for the exact classified head and at least three qualifying merged IronRDP pull requests from the author.
-A second review requires a later push and matching successful CI.
-Duplicates, legitimacy triage, the terminal review count, and oversized changes without explicit opt-in block automatic review.
-Non-protocol `risk/low` changes without a breaking-change signal skip review.
+Automatic review runs for every non-draft pull request that passes the remaining gates.
+`OWNER` and `MEMBER` authors are eligible without contributor history.
+Other human authors need one qualifying merged IronRDP pull request from the same immutable author.
+Qualifying pull requests are merged, are not labeled `trivial` or `reverted`, and do not have a title beginning with `revert`.
+Automatic review requires successful CI for the exact classified head.
+After the first review, a later push starts the second review when CI succeeds for that new head.
+Duplicates at confidence 0.85 or greater, legitimacy triage, and `ai-reviewed/2` block automatic review.
+Unavailable or invalid classification fails closed to maintainer review.
 
 Bot-authored pull requests do not run automatic routes or label reconciliation.
 Force mode can override policy gates for an open pull request at its current head.
@@ -134,12 +138,14 @@ Size uses the larger bucket from counted changed lines or touched files:
 | `size/XL` | 900-1299 | 21-49 |
 | `size/XXL` | 1300 or more | 50 or more |
 
-`size/XXL` skips model execution unless a maintainer adds `ai-review/allow-oversized`.
-The opt-in waives only the size gate.
-CI, quota, duplicate, legitimacy, contributor-history, and review-count gates still apply.
+`size/XXL` is informational and does not block classification or review.
+The evidence diff limit is 1 MiB by default.
+Adding `ai-review/allow-oversized` retries classification with the model runtime's maximum 4 MiB evidence limit.
+Evidence above the applicable limit fails closed without sending a partial diff to a model.
 
-Fork-origin pull requests have daily UTC quotas.
-The default author quota is five pull requests, established contributors can use ten, and the best-effort repository-wide quota is 30.
+Fork-origin pull requests share a repository-wide quota of 50 pull requests per UTC day.
+`OWNER` and `MEMBER` pull requests are exempt and do not count toward the quota.
+Same-repository pull requests are also exempt.
 
 ## State, publication, and failure behavior
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -923,9 +923,10 @@ test("force is dispatch-only and bypasses draft and bot eligibility", async () =
   assert.equal(automaticBot.reason, "bot-authored pull request");
 });
 
-test("only the persistent oversized-review label starts automation from a label event", async () => {
+test("only oversized-review label changes start automation from label events", async () => {
   const workflow = readWorkflow();
-  assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review, edited, labeled\]/);
+  assert.match(workflow,
+    /types: \[opened, reopened, synchronize, ready_for_review, edited, labeled, unlabeled\]/);
   assert.match(workflowJob(workflow, "classifier"),
     /EVIDENCE_MAX_BYTES: \$\{\{ needs\.resolve-pr\.outputs\.evidence-max-bytes \}\}/);
   const classificationGate = workflowJob(workflow, "classification-gate");
@@ -940,14 +941,14 @@ test("only the persistent oversized-review label starts automation from a label 
     user: { node_id: "U_1", login: "contributor", type: "User" },
     head: { sha: SHA, repo: { full_name: "Devolutions/IronRDP" } }, base: { sha: "b".repeat(40) },
   });
-  const resolve = async (label) => resolvePr({
+  const resolve = async (label, action = "labeled", labels = [OVERSIZED_REVIEW_LABEL]) => resolvePr({
     github: { rest: { pulls: {
-      get: async () => ({ data: pullRequest([OVERSIZED_REVIEW_LABEL]) }),
-      list: async () => ({ data: [pullRequest([OVERSIZED_REVIEW_LABEL])] }),
+      get: async () => ({ data: pullRequest(labels) }),
+      list: async () => ({ data: [pullRequest(labels)] }),
     } } },
     context: {
       eventName: "pull_request_target", repo: { owner: "Devolutions", repo: "IronRDP" },
-      payload: { action: "labeled", label: { name: label }, pull_request: { number: 7 } },
+      payload: { action, label: { name: label }, pull_request: { number: 7 } },
     },
   });
 
@@ -957,7 +958,13 @@ test("only the persistent oversized-review label starts automation from a label 
   assert.equal(requested.reviewRequested, true);
   assert.equal(requested.force, false);
   assert.equal(requested.evidenceMaxBytes, 4 * 1024 * 1024);
+  const revoked = await resolve(OVERSIZED_REVIEW_LABEL, "unlabeled", []);
+  assert.equal(revoked.ok, true);
+  assert.equal(revoked.classificationRequested, true);
+  assert.equal(revoked.reviewRequested, false);
+  assert.equal(revoked.evidenceMaxBytes, 1024 * 1024);
   assert.equal((await resolve("size/XXL")).reason, "unrelated pull request label");
+  assert.equal((await resolve("size/XXL", "unlabeled", [])).reason, "unrelated pull request label");
 });
 
 test("deterministic semver outranks the model and a model-only break cannot stay low", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -17,7 +17,7 @@ const { resolveReviewerRoute, validateReviewerRoute } = require("./routing");
 const {
   resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
   EVIDENCE_LIMIT_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX,
-  OVERSIZED_MARKER, OVERSIZED_REVIEW_LABEL,
+  OVERSIZED_MARKER, OVERSIZED_REVIEW_LABEL, contributorEligibility,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const {
@@ -156,6 +156,20 @@ test("workflow isolates CI completion concurrency by source commit", () => {
   assert.doesNotMatch(workflow, /github\.event\.workflow_run\.pull_requests\[0\]\.number/);
 });
 
+test("automatic review requires exact-head CI and only reruns after a later push", () => {
+  const workflow = readWorkflow();
+  const reviewGate = workflowJob(workflow, "review-gate");
+  assert.match(reviewGate, /ref: headSha/);
+  assert.match(reviewGate, /head_sha: headSha/);
+  assert.match(reviewGate,
+    /workflowRuns\.some\(\(run\) => run\?\.name === "CI" && run\?\.conclusion === "success"\)/);
+  assert.match(reviewGate, /const secondReviewEligible = !labels\.includes\("ai-reviewed\/1"\) \|\| !reviewAtHead/);
+  assert.match(reviewGate,
+    /ok: classificationCheck && ciGreen && secondReviewEligible && policyEligible/);
+  assert.match(workflowJob(workflow, "classification-gate"), /'ai-reviewed\/2'/);
+  assert.match(workflowJob(workflow, "review-pipeline"), /review-gate\.outputs\.eligible == 'true'/);
+});
+
 test("workflow force mode bypasses model policy gates without changing automatic branches", () => {
   const workflow = readWorkflow();
   assert.match(workflow, /^\s{6}force:\n\s{8}description:/m);
@@ -172,10 +186,10 @@ test("workflow force mode bypasses model policy gates without changing automatic
   for (const automaticGate of [
     "classification-gate.outputs.available == 'true'",
     "classification-gate.outputs.required == 'true'",
-    "deterministic-analysis.outputs.size-label != 'size/XXL'",
     "fork-rate-limit.outputs.allowed == 'true'",
     "'ai-reviewed/2'",
   ]) assert.equal(classifierJob.includes(automaticGate), true, automaticGate);
+  assert.doesNotMatch(classifierJob, /size-label != 'size\/XXL'/);
   assert.match(classifierJob, /needs\.resolve-pr\.outputs\.force == 'true' \|\|/);
 
   const reviewGate = workflowJob(workflow, "review-gate");
@@ -340,10 +354,12 @@ test("LLM evidence is bound to the resolved pull request base", () => {
   const evidenceScript = fs.readFileSync(path.join(__dirname, "fetch-pr-evidence.sh"), "utf8");
   const classifier = workflowJob(workflow, "classifier");
   assert.match(classifier, /BASE_SHA: \$\{\{ needs\.resolve-pr\.outputs\.base-sha \}\}/);
-  assert.match(classifier, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
+  assert.match(classifier,
+    /fetch-pr-evidence\.sh \\\n\s+"\$HEAD_SHA" "\$BASE_SHA" "\$EVIDENCE_MAX_BYTES"/);
   const evidence = workflowJob(reviewWorkflow, "evidence");
   assert.match(evidence, /BASE_SHA: \$\{\{ inputs\.base-sha \}\}/);
-  assert.match(evidence, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
+  assert.match(evidence,
+    /fetch-pr-evidence\.sh \\\n\s+"\$HEAD_SHA" "\$BASE_SHA" "\$EVIDENCE_MAX_BYTES"/);
   assert.match(evidenceScript, /\+\$base_sha:refs\/remotes\/origin\/pull-request-base/);
   assert.match(
     evidenceScript,
@@ -352,7 +368,7 @@ test("LLM evidence is bound to the resolved pull request base", () => {
   assert.doesNotMatch(evidenceScript, /origin\/master/);
 });
 
-test("oversized evidence fails closed and leaves pull request guidance", () => {
+test("evidence caps are trusted, bounded, and fail closed with guidance", () => {
   const githubDirectory = path.join(__dirname, "..");
   const workflow = readWorkflow(githubDirectory);
   const reviewWorkflow = readReviewWorkflow(githubDirectory);
@@ -365,13 +381,20 @@ test("oversized evidence fails closed and leaves pull request guidance", () => {
   assert.match(evidenceAttributes, /^\* !diff$/m);
   assert.match(evidenceAttributes, /^\.github\/actions\/openai-agent\/dist\/\*\* -diff$/m);
   assert.match(evidenceScript, /failure-reason\.txt/);
+  assert.match(evidenceScript, /1048576\) limit_mib=1/);
+  assert.match(evidenceScript, /4194304\) limit_mib=4/);
+  assert.match(evidenceScript, /invalid evidence diff limit/);
+  assert.match(evidenceScript, /-gt "\$max_bytes"/);
   assert.match(evidenceScript, /exit 1/);
   assert.doesNotMatch(evidenceScript, /pull-request\.diff\.truncated/);
   const classifier = workflowJob(workflow, "classifier");
   assert.match(classifier, /id: evidence/);
+  assert.match(classifier,
+    /EVIDENCE_MAX_BYTES: \$\{\{ needs\.resolve-pr\.outputs\.evidence-max-bytes \}\}/);
   assert.match(classifier, /steps\.evidence\.outputs\.failure-reason \|\|/);
   const evidence = workflowJob(reviewWorkflow, "evidence");
   assert.match(evidence, /id: evidence/);
+  assert.match(evidence, /EVIDENCE_MAX_BYTES: \$\{\{ inputs\.evidence-max-bytes \}\}/);
   assert.match(evidence, /failure-reason: \$\{\{ steps\.evidence\.outputs\.failure-reason \}\}/);
   assert.match(workflowJob(reviewWorkflow, "validate"),
     /EVIDENCE_REASON: \$\{\{ needs\.evidence\.outputs\.failure-reason \}\}/);
@@ -386,18 +409,21 @@ test("oversized evidence fails closed and leaves pull request guidance", () => {
   });
   assert.equal(classification.failed, true);
   assert.deepEqual(classification.comments, [{
-    kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER,
+    kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER, limitMiB: 1,
   }]);
   assert.match(markerBody(classification.comments[0]), /No model was invoked with partial evidence/);
+  assert.match(markerBody(classification.comments[0]), /ai-review\/allow-oversized/);
 
   const reviewFailure = resolveReviewState({
     expectedSha: SHA, labels: [], gate: { force: true, head_sha: SHA },
-    reviewerReason: reason, force: true, reviewMarkerId: "1",
+    reviewerReason: "pull request diff exceeds the 4 MiB evidence limit",
+    force: true, reviewMarkerId: "1",
   });
   assert.equal(reviewFailure.failed, true);
   assert.deepEqual(reviewFailure.comments, [{
-    kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER,
+    kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER, limitMiB: 4,
   }]);
+  assert.match(markerBody(reviewFailure.comments[0]), /runtime maximum/);
 });
 
 test("every deterministic label is declared and the repository rules classify tooling changes", () => {
@@ -851,6 +877,7 @@ test("bot authors are excluded from automation", async () => {
   const human = await resolve({ node_id: "U_3", login: "contributor", type: "User" });
   assert.equal(human.ok, true);
   assert.equal(human.reviewRoute, true);
+  assert.equal(human.evidenceMaxBytes, 1024 * 1024);
 });
 
 test("force is dispatch-only and bypasses draft and bot eligibility", async () => {
@@ -900,7 +927,13 @@ test("only the persistent oversized-review label starts automation from a label 
   const workflow = readWorkflow();
   assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review, edited, labeled\]/);
   assert.match(workflowJob(workflow, "classifier"),
-    /contains\(fromJSON\(needs\.resolve-pr\.outputs\.labels\), 'ai-review\/allow-oversized'\)/);
+    /EVIDENCE_MAX_BYTES: \$\{\{ needs\.resolve-pr\.outputs\.evidence-max-bytes \}\}/);
+  const classificationGate = workflowJob(workflow, "classification-gate");
+  assert.match(classificationGate,
+    /RETRY_WITH_LARGER_EVIDENCE: \$\{\{ needs\.resolve-pr\.outputs\.review-requested \}\}/);
+  assert.match(classificationGate,
+    /process\.env\.RETRY_WITH_LARGER_EVIDENCE === "true"/);
+  assert.match(classificationGate, /decision: \{ available: true, required: true, largerEvidence: true \}/);
 
   const pullRequest = (labels = []) => ({
     number: 7, draft: false, state: "open", labels,
@@ -923,6 +956,7 @@ test("only the persistent oversized-review label starts automation from a label 
   assert.equal(requested.classificationRequested, true);
   assert.equal(requested.reviewRequested, true);
   assert.equal(requested.force, false);
+  assert.equal(requested.evidenceMaxBytes, 4 * 1024 * 1024);
   assert.equal((await resolve("size/XXL")).reason, "unrelated pull request label");
 });
 
@@ -1045,19 +1079,15 @@ test("successful classification preserves the first-time contributor label", () 
     ["contributor/first-time"]);
 });
 
-test("protocol relevance overrides risk suppression but no other exclusion", () => {
-  // Risk measures the human scrutiny a change needs, so it must not decide whether a protocol
-  // change is worth reviewing.
+test("all classified changes are reviewable unless a legitimacy or count gate blocks them", () => {
   assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: true }), true);
-  assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: false }), false);
+  assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: false }), true);
   assert.equal(reviewPolicyEligible({ labels: ["risk/low", "breaking-change"] }), true);
   assert.equal(reviewPolicyEligible({ labels: ["risk/medium"] }), true);
-  for (const blocking of ["size/XXL", "duplicate", "ai-reviewed/2", LEGITIMACY_LABEL]) {
+  assert.equal(reviewPolicyEligible({ labels: ["risk/high", "size/XXL"] }), true);
+  for (const blocking of ["duplicate", "ai-reviewed/2", LEGITIMACY_LABEL]) {
     assert.equal(reviewPolicyEligible({ labels: ["risk/high", blocking], protocolRelated: true }), false);
   }
-  assert.equal(reviewPolicyEligible({
-    labels: ["risk/high", "size/XXL", OVERSIZED_REVIEW_LABEL], protocolRelated: true,
-  }), true);
   assert.equal(reviewPolicyEligible({
     labels: ["risk/high"], protocolRelated: true, legitimacyStopped: true,
   }), false);
@@ -1085,17 +1115,17 @@ test("review publication applies the same policy the workflow spent its call on"
   }).failed, undefined);
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low"], gate: gate({ protocolRelated: false, risk: "low" }),
-  }).failed, true);
+  }).failed, undefined);
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low", "size/XXL"], gate: gate({ protocolRelated: true, risk: "low" }),
-  }).failed, true);
+  }).failed, undefined);
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low", "size/XXL", OVERSIZED_REVIEW_LABEL],
     gate: gate({ protocolRelated: true, risk: "low" }),
   }).failed, undefined);
 });
 
-test("persistent oversized-review label runs normal classification and review", () => {
+test("persistent oversized-review label does not alter normal classification", () => {
   const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [],
     sizeLabel: "size/XXL", sizeLabels: ["size/XL", "size/XXL"], firstTime: false };
   const state = resolveClassificationState({
@@ -1111,59 +1141,25 @@ test("persistent oversized-review label runs normal classification and review", 
   assert.equal(state.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
 });
 
-test("XXL guidance is posted once and withdrawn when the change shrinks", () => {
-  const deterministic = (sizeLabel) => ({ ok: true, pathLabels: [], ownedPathLabels: [],
-    sizeLabel, sizeLabels: ["size/XL", "size/XXL"], firstTime: false });
-  const state = (sizeLabel) => resolveClassificationState({
-    expectedSha: SHA, labels: [], deterministic: deterministic(sizeLabel), classifier: classifier(),
-    semver: { head_sha: SHA, status: "not-suspected" },
-  });
-  const oversized = state("size/XXL");
-  assert.deepEqual(oversized.comments.map((comment) => comment.kind), ["oversized"]);
-  assert.equal(oversized.removeCommentMarkers.includes(OVERSIZED_MARKER), false);
-  assert.equal(oversized.removeCommentMarkers.includes(LEGACY_XL_MARKER), true);
-  const body = markerBody(oversized.comments[0], "Devolutions", "IronRDP");
-  assert.match(body, /stacked-prs/);
-  assert.match(body, /size\/XXL/);
-  // A later push can drop the change below the threshold, and the guidance must not outlive it.
-  const shrunk = state("size/XL");
-  assert.deepEqual(shrunk.comments, []);
-  assert.equal(shrunk.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
-  assert.equal(shrunk.removeCommentMarkers.includes(LEGACY_XL_MARKER), true);
-});
-
-test("an oversized change retains deterministic labels without a classifier", () => {
-  // The workflow skips the classifier job for size/XXL, so no model output exists to validate here.
-  // Resolution must still succeed on deterministic evidence rather than degrading to a failure.
+test("size/XXL remains informational and does not suppress classification", () => {
   const deterministic = { ok: true, pathLabels: ["scope/core", "scope/web"],
     ownedPathLabels: ["scope/core", "scope/web", "scope/ffi"],
     sizeLabel: "size/XXL", sizeLabels: ["size/XL", "size/XXL"], firstTime: true };
   const state = resolveClassificationState({
-    expectedSha: SHA, labels: [], deterministic, classifier: undefined,
+    expectedSha: SHA, labels: [], deterministic, classifier: classifier(),
     semver: { head_sha: SHA, status: "suspected" },
   });
   assert.equal(state.failed, undefined);
-  assert.equal(state.oversized, true);
   const desired = state.labelSets.flatMap((set) => set.desired);
   assert.deepEqual(desired.sort(), ["breaking-change", "contributor/first-time", "risk/high",
     "scope/core", "scope/web", "size/XXL"]);
   assert.deepEqual(state.addLabels, ["maintainer-required"]);
-  assert.deepEqual(state.comments.map((comment) => comment.kind), ["oversized"]);
-  // The review gate only trusts a check announcing a completed classification.
-  assert.notEqual(state.check.title, "Classification complete");
-  assert.equal(state.check.machineState.automaticReviewEligible, false);
+  assert.deepEqual(state.comments, []);
+  assert.equal(state.check.title, "Classification complete");
+  assert.equal(state.check.machineState.automaticReviewEligible, true);
   assert.equal(parseCheckState(`${state.check.summary}\n\n${encodeCheckState(state.check.machineState)}`)
-    .automaticReviewEligible, false);
-  // No model ran, so a duplicate or legitimacy verdict from an earlier head is neither confirmed
-  // nor refuted and must be left in place.
-  assert.deepEqual(state.removeCommentMarkers, [EVIDENCE_LIMIT_MARKER, LEGACY_XL_MARKER]);
-
-  const unavailable = resolveClassificationState({
-    expectedSha: SHA, labels: [], deterministic, classifier: undefined,
-    semver: { head_sha: SHA, status: "unavailable" },
-  });
-  assert.equal(unavailable.oversized, true);
-  assert.deepEqual(unavailable.labelSets.at(-1).desired, ["risk/unknown"]);
+    .automaticReviewEligible, true);
+  assert.equal(state.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
 });
 
 test("a duplicate verdict is withdrawn once it no longer holds", () => {
@@ -1240,24 +1236,22 @@ test("legitimacy flags leave SHA-bound audit records for maintainer triage", () 
   assert.equal(cleared.labelSets.some((set) => set.owned.includes(LEGITIMACY_LABEL)), false);
 });
 
-test("quota decisions stop classification and review with a bounded human handoff", () => {
+test("global quota decisions stop classification and review with a bounded human handoff", () => {
   const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S", sizeLabels: ["size/S"],
     firstTime: false };
   const classification = resolveClassificationState({
     expectedSha: SHA, labels: [], deterministic, classifier: classifier(),
     semver: { head_sha: SHA, status: "not-suspected" },
-    rateLimit: { status: "limited", scope: "author", quota: 5, count: 6 },
+    rateLimit: { status: "limited", scope: "global", quota: 50, count: 51 },
   });
   assert.equal(classification.failed, true);
-  assert.deepEqual(classification.comments, [{
-    kind: "fork-quota", marker: "<!-- ironrdp-pr-automation:fork-llm-quota -->", quota: 5,
-  }]);
+  assert.equal(classification.comments[0].kind, "global-quota");
 
   const review = resolveReviewState({
     expectedSha: SHA, labels: ["risk/high"],
     gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
     contributor: { status: "eligible" },
-    rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
+    rateLimit: { status: "limited", scope: "global", quota: 50, count: 51 },
   });
   assert.equal(review.failed, true);
   assert.equal(review.comments[0].kind, "global-quota");
@@ -1274,7 +1268,7 @@ test("forced classification bypasses policy, quota, and cache but still validate
     deterministic,
     classifier: classifier(),
     classificationGate: { available: false, reason: "checks unavailable" },
-    rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
+    rateLimit: { status: "limited", scope: "global", quota: 50, count: 51 },
     semver: { head_sha: SHA, status: "not-suspected" },
     force: true,
   };
@@ -1308,7 +1302,7 @@ test("forced review bypasses eligibility while retaining publication gates", () 
       risk: "unknown", specialistReviewers: ["skeptical"],
     },
     contributor: { status: "ineligible" },
-    rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
+    rateLimit: { status: "limited", scope: "global", quota: 50, count: 51 },
     force: true,
     reviewMarkerId: "1234",
   };
@@ -1374,11 +1368,11 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(invalidGate.reason, "review gate unavailable: checks unavailable");
 
   const ineligible = resolveReviewState({
-    ...args, contributor: { status: "ineligible", merged: 1 },
+    ...args, contributor: { status: "ineligible", merged: 0 },
   });
   assert.equal(ineligible.ok, true);
   assert.equal(ineligible.failed, true);
-  assert.equal(ineligible.reason, "contributor history ineligible (merged: 1, required: 3)");
+  assert.equal(ineligible.reason, "contributor history ineligible (merged: 0, required: 1)");
 
   const unavailable = resolveReviewState({
     ...args, contributor: { status: "unavailable", reason: "GitHub API unavailable" },
@@ -1394,8 +1388,8 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(secondReview.reason, "second review is not eligible");
 
   const policy = resolveReviewState({
-    ...args, labels: ["risk/low"],
-    gate: { ...args.gate, ok: false, policyEligible: false, protocolRelated: false },
+    ...args, labels: ["risk/low", "duplicate"],
+    gate: { ...args.gate, policyEligible: false, protocolRelated: false },
   });
   assert.equal(policy.reason, "review is not eligible");
 });
@@ -1619,9 +1613,11 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.output.title, "Automated review complete");
 });
 
-test("oversized opt-in dispatches review from a cached classification", async () => {
+test("oversized opt-in reclassifies instead of reviewing cached evidence", async () => {
   const workflow = readWorkflow();
+  const classificationGate = workflowJob(workflow, "classification-gate");
   const requestReview = workflowJob(workflow, "request-review");
+  assert.match(classificationGate, /RETRY_WITH_LARGER_EVIDENCE/);
   assert.match(requestReview, /needs: \[resolve-pr, classification-gate\]/);
   assert.match(requestReview, /needs\.resolve-pr\.outputs\.review-requested == 'true'/);
   assert.match(requestReview, /needs\.classification-gate\.outputs\.available == 'true'/);
@@ -1842,41 +1838,47 @@ test("fork rate limit exempts same-repository branches", async () => {
   assert.deepEqual(result, { status: "allowed", scope: "same-repository" });
 });
 
-test("fork rate limit applies normal and established author quotas", async () => {
-  const normal = await forkRateLimit({
-    github: paginated({
-      closed: [[]],
-      all: [[pull(1), ...[2, 3, 4, 5, 6].map((number) => pull(number))]],
-    }),
-    owner: "Devolutions", repo: "IronRDP", pr: pull(1),
-  });
-  assert.deepEqual(normal, { status: "limited", scope: "author", quota: 5, count: 6 });
-
-  const merged = Array.from({ length: 15 }, (_, index) => pull(index + 10, {
-    merged_at: "2026-01-01T00:00:00Z",
-  }));
-  const established = await forkRateLimit({
-    github: paginated({
-      closed: [merged],
-      all: [[pull(1), ...Array.from({ length: 10 }, (_, index) => pull(index + 2))]],
-    }),
-    owner: "Devolutions", repo: "IronRDP", pr: pull(1),
-  });
-  assert.deepEqual(established, { status: "limited", scope: "author", quota: 10, count: 11 });
+test("owner and member authors bypass fork quota enforcement", async () => {
+  let requests = 0;
+  const github = {
+    paginate: { iterator: async function* () { requests += 1; yield { data: [] }; } },
+    rest: { pulls: { list: () => {} } },
+  };
+  for (const association of ["OWNER", "MEMBER"]) {
+    const result = await forkRateLimit({
+      github, owner: "Devolutions", repo: "IronRDP",
+      pr: pull(1, { author_association: association }),
+      author: { association },
+    });
+    assert.deepEqual(result, { status: "allowed", scope: "author-association" });
+  }
+  assert.equal(requests, 0);
 });
 
-test("fork rate limit applies the global fork quota and fails closed on API errors", async () => {
+test("fork rate limit applies a 50 PR global quota and excludes owner and member PRs", async () => {
+  const exempt = Array.from({ length: 10 }, (_, index) => pull(index + 100, {
+    author_association: index % 2 === 0 ? "OWNER" : "MEMBER",
+  }));
+  const allowed = await forkRateLimit({
+    github: paginated({
+      all: [[pull(1), ...exempt, ...Array.from({ length: 49 }, (_, index) => pull(index + 2))]],
+    }),
+    owner: "Devolutions", repo: "IronRDP", pr: pull(1),
+  });
+  assert.deepEqual(allowed, { status: "allowed", scope: "global", quota: 50, count: 50 });
+
   const global = await forkRateLimit({
     github: paginated({
-      closed: [[]],
-      all: [[pull(1), ...Array.from({ length: 30 }, (_, index) => pull(index + 2, {
+      all: [[pull(1), ...Array.from({ length: 50 }, (_, index) => pull(index + 2, {
         user: { node_id: `author-${index}`, login: `author-${index}`, type: "User" },
       }))]],
     }),
     owner: "Devolutions", repo: "IronRDP", pr: pull(1),
   });
-  assert.deepEqual(global, { status: "limited", scope: "global", quota: 30, count: 31 });
+  assert.deepEqual(global, { status: "limited", scope: "global", quota: 50, count: 51 });
+});
 
+test("fork rate limit fails closed on API errors", async () => {
   const unavailable = await forkRateLimit({
     github: {
       paginate: { iterator: () => { throw new Error("offline"); } },
@@ -1887,32 +1889,22 @@ test("fork rate limit applies the global fork quota and fails closed on API erro
   assert.deepEqual(unavailable, { status: "unavailable", scope: "unknown", reason: "GitHub API unavailable" });
 });
 
-test("fork rate limit excludes same-repository PRs and remains bound to the creation day", async () => {
+test("fork rate limit excludes same-repository PRs from the global count", async () => {
   const sameRepository = pull(2, {
     head: { repo: { full_name: "Devolutions/IronRDP" } },
-    user: { node_id: "author", login: "author", type: "User" },
   });
-  const createdOnLimitedDay = pull(1, { created_at: "2026-08-02T12:00:00Z" });
   const result = await forkRateLimit({
     github: paginated({
-      closed: [[]],
-      all: [[
-        sameRepository,
-        createdOnLimitedDay,
-        ...Array.from({ length: 5 }, (_, index) => pull(index + 3, {
-          created_at: "2026-08-02T11:00:00Z",
-        })),
-      ]],
+      all: [[pull(1), sameRepository]],
     }),
-    owner: "Devolutions", repo: "IronRDP",     pr: createdOnLimitedDay,
+    owner: "Devolutions", repo: "IronRDP", pr: pull(1),
   });
-  assert.deepEqual(result, { status: "limited", scope: "author", quota: 5, count: 6 });
+  assert.deepEqual(result, { status: "allowed", scope: "global", quota: 50, count: 1 });
 });
 
 test("fork rate limit uses a half-open UTC day window", async () => {
   const result = await forkRateLimit({
     github: paginated({
-      closed: [[]],
       all: [[
         pull(1, { created_at: "2026-08-03T00:00:00Z" }),
         pull(2, { created_at: "2026-08-03T23:59:59Z" }),
@@ -1922,5 +1914,51 @@ test("fork rate limit uses a half-open UTC day window", async () => {
     owner: "Devolutions", repo: "IronRDP",
     pr: pull(1, { created_at: "2026-08-03T00:00:00Z" }),
   });
-  assert.deepEqual(result, { status: "allowed", scope: "author", quota: 5, count: 2 });
+  assert.deepEqual(result, { status: "allowed", scope: "global", quota: 50, count: 2 });
+});
+
+test("owner and member authors are eligible without contributor history", async () => {
+  const unavailable = {
+    paginate: { iterator: () => { throw new Error("must not query history"); } },
+    rest: { pulls: { list: () => {} } },
+  };
+  for (const association of ["OWNER", "MEMBER"]) {
+    assert.deepEqual(await contributorEligibility({
+      github: unavailable, owner: "Devolutions", repo: "IronRDP",
+      author: { association, login: "maintainer", type: "User" }, currentPrNumber: 1,
+    }), { status: "eligible", association });
+  }
+});
+
+test("other human authors need one qualifying merged pull request", async () => {
+  const history = [
+    pull(2, { merged_at: "2026-01-01T00:00:00Z", labels: ["trivial"] }),
+    pull(3, { merged_at: "2026-01-01T00:00:00Z", labels: ["reverted"] }),
+    pull(4, { merged_at: "2026-01-01T00:00:00Z", title: "Revert bad change" }),
+    pull(5, {
+      merged_at: "2026-01-01T00:00:00Z",
+      user: { node_id: "different-author", login: "author", type: "User" },
+    }),
+    pull(6),
+    pull(7, {
+      merged_at: "2026-01-01T00:00:00Z",
+      user: { node_id: "author", login: "renamed-author", type: "User" },
+    }),
+  ];
+  const author = { nodeId: "author", login: "author", type: "User", association: "CONTRIBUTOR" };
+  assert.deepEqual(await contributorEligibility({
+    github: paginated({ closed: [history] }), owner: "Devolutions", repo: "IronRDP",
+    author, currentPrNumber: 1,
+  }), { status: "eligible", merged: 1 });
+  assert.deepEqual(await contributorEligibility({
+    github: paginated({ closed: [history.slice(0, 5)] }), owner: "Devolutions", repo: "IronRDP",
+    author, currentPrNumber: 1,
+  }), { status: "ineligible", merged: 0 });
+});
+
+test("bot authors remain ineligible regardless of association", async () => {
+  assert.deepEqual(await contributorEligibility({
+    github: paginated({}), owner: "Devolutions", repo: "IronRDP",
+    author: { association: "MEMBER", login: "service[bot]", type: "Bot" }, currentPrNumber: 1,
+  }), { status: "ineligible", reason: "bot author" });
 });

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1826,6 +1826,7 @@ function pull(number, changes = {}) {
     number, created_at: "2026-08-03T12:00:00Z", merged_at: null, title: "change", labels: [],
     user: { node_id: "author", login: "author", type: "User" },
     head: { repo: { full_name: "contributor/IronRDP" } },
+    base: { ref: "master" },
     ...changes,
   };
 }
@@ -1930,28 +1931,32 @@ test("owner and member authors are eligible without contributor history", async 
   }
 });
 
-test("other human authors need one qualifying merged pull request", async () => {
-  const history = [
+test("other human authors need one same-author pull request merged into master", async () => {
+  const author = { nodeId: "author", login: "author", type: "User", association: "CONTRIBUTOR" };
+  for (const candidate of [
     pull(2, { merged_at: "2026-01-01T00:00:00Z", labels: ["trivial"] }),
     pull(3, { merged_at: "2026-01-01T00:00:00Z", labels: ["reverted"] }),
     pull(4, { merged_at: "2026-01-01T00:00:00Z", title: "Revert bad change" }),
     pull(5, {
       merged_at: "2026-01-01T00:00:00Z",
-      user: { node_id: "different-author", login: "author", type: "User" },
-    }),
-    pull(6),
-    pull(7, {
-      merged_at: "2026-01-01T00:00:00Z",
       user: { node_id: "author", login: "renamed-author", type: "User" },
     }),
-  ];
-  const author = { nodeId: "author", login: "author", type: "User", association: "CONTRIBUTOR" };
+  ]) {
+    assert.deepEqual(await contributorEligibility({
+      github: paginated({ closed: [[candidate]] }), owner: "Devolutions", repo: "IronRDP",
+      author, currentPrNumber: 1,
+    }), { status: "eligible", merged: 1 });
+  }
+
   assert.deepEqual(await contributorEligibility({
-    github: paginated({ closed: [history] }), owner: "Devolutions", repo: "IronRDP",
-    author, currentPrNumber: 1,
-  }), { status: "eligible", merged: 1 });
-  assert.deepEqual(await contributorEligibility({
-    github: paginated({ closed: [history.slice(0, 5)] }), owner: "Devolutions", repo: "IronRDP",
+    github: paginated({ closed: [[
+      pull(6),
+      pull(7, { merged_at: "2026-01-01T00:00:00Z", base: { ref: "release" } }),
+      pull(8, {
+        merged_at: "2026-01-01T00:00:00Z",
+        user: { node_id: "different-author", login: "author", type: "User" },
+      }),
+    ]] }), owner: "Devolutions", repo: "IronRDP",
     author, currentPrNumber: 1,
   }), { status: "ineligible", merged: 0 });
 });

--- a/.github/pr-automation/fetch-pr-evidence.sh
+++ b/.github/pr-automation/fetch-pr-evidence.sh
@@ -8,13 +8,22 @@
 # This is shared by every stage because the instruction-file removal below is a security boundary that duplicated scripts would eventually drift from.
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: fetch-pr-evidence.sh <head-sha> <base-sha>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: fetch-pr-evidence.sh <head-sha> <base-sha> <max-diff-bytes>" >&2
   exit 1
 fi
 
 head_sha="$1"
 base_sha="$2"
+max_bytes="$3"
+case "$max_bytes" in
+  1048576) limit_mib=1 ;;
+  4194304) limit_mib=4 ;;
+  *)
+    echo "error: invalid evidence diff limit" >&2
+    exit 1
+    ;;
+esac
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_CONFIG_GLOBAL=/dev/null
@@ -48,11 +57,9 @@ git -C pr-head diff --no-color --find-renames --name-status \
 git -C pr-head diff --no-color --find-renames --unified=3 \
   origin/pull-request-base...origin/pull-request-head > pr-evidence/pull-request.diff
 
-# Partial diffs cannot support complete classification or review, including when a maintainer opts
-# an oversized pull request into automation.
-max_bytes=$((1024 * 1024))
+# Partial diffs cannot support complete classification or review.
 if [ "$(wc -c < pr-evidence/pull-request.diff)" -gt "$max_bytes" ]; then
-  reason="pull request diff exceeds the 1 MiB evidence limit"
+  reason="pull request diff exceeds the $limit_mib MiB evidence limit"
   printf '%s\n' "$reason" > pr-evidence/failure-reason.txt
   printf 'error: %s\n' "$reason" >&2
   exit 1

--- a/.github/pr-automation/fork-rate-limit.js
+++ b/.github/pr-automation/fork-rate-limit.js
@@ -1,11 +1,7 @@
 "use strict";
 
-const { qualifyingMergedPrs } = require("./resolve-state");
-
-const AUTHOR_QUOTA = 5;
-const ESTABLISHED_AUTHOR_QUOTA = 10;
-const ESTABLISHED_MERGED_PRS = 15;
-const GLOBAL_QUOTA = 30;
+const GLOBAL_QUOTA = 50;
+const QUOTA_EXEMPT_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
 
 function unavailable(reason) {
   return { status: "unavailable", scope: "unknown", reason };
@@ -36,27 +32,18 @@ async function forkRateLimit({ github, owner, repo, pr, author } = {}) {
   if (!github?.paginate?.iterator || !github?.rest?.pulls?.list || typeof owner !== "string" || typeof repo !== "string" ||
       !pr || typeof pr !== "object") return unavailable("invalid rate-limit input");
   if (isSameRepository(pr, owner, repo)) return { status: "allowed", scope: "same-repository" };
+  if (QUOTA_EXEMPT_ASSOCIATIONS.has(pr.author_association ?? author?.association)) {
+    return { status: "allowed", scope: "author-association" };
+  }
 
-  const authorNodeId = author?.nodeId ?? pr.user?.node_id;
   const currentPrNumber = pr.number;
   const currentCreatedAt = timestamp(pr.created_at);
   const range = utcDayRange(currentCreatedAt);
-  if (typeof authorNodeId !== "string" || !authorNodeId || !Number.isSafeInteger(currentPrNumber) ||
-      currentPrNumber <= 0 || !range) {
+  if (!Number.isSafeInteger(currentPrNumber) || currentPrNumber <= 0 || !range) {
     return unavailable("invalid pull request data");
   }
 
-  let merged;
-  try {
-    merged = await qualifyingMergedPrs({
-      github, owner, repo, authorNodeId, currentPrNumber, stopAt: ESTABLISHED_MERGED_PRS,
-    });
-  } catch {
-    return unavailable("GitHub API unavailable");
-  }
-  const quota = merged >= ESTABLISHED_MERGED_PRS ? ESTABLISHED_AUTHOR_QUOTA : AUTHOR_QUOTA;
-  let authorCount = 1; // Include the current fork PR, which is necessarily in its creation-day window.
-  let globalCount = 1;
+  let globalCount = 1; // Include the current non-member fork PR in its creation-day window.
 
   try {
     for await (const response of github.paginate.iterator(github.rest.pulls.list, {
@@ -70,24 +57,22 @@ async function forkRateLimit({ github, owner, repo, pr, author } = {}) {
         const createdAt = timestamp(candidate.created_at);
         if (createdAt === null) throw new Error("invalid pull request timestamp");
         if (createdAt < range.start) {
-          return { status: "allowed", scope: "author", quota, count: authorCount };
+          return { status: "allowed", scope: "global", quota: GLOBAL_QUOTA, count: globalCount };
         }
         if (createdAt >= range.end || candidate.number === currentPrNumber) continue;
 
         const isFork = !isSameRepository(candidate, owner, repo);
-        if (isFork && candidate.user?.node_id === authorNodeId) authorCount += 1;
-        if (isFork) globalCount += 1;
-        if (authorCount > quota) return { status: "limited", scope: "author", quota, count: authorCount };
+        if (isFork && !QUOTA_EXEMPT_ASSOCIATIONS.has(candidate.author_association)) globalCount += 1;
         if (globalCount > GLOBAL_QUOTA) return { status: "limited", scope: "global", quota: GLOBAL_QUOTA, count: globalCount };
       }
     }
   } catch {
     return unavailable("GitHub API unavailable");
   }
-  return { status: "allowed", scope: "author", quota, count: authorCount };
+  return { status: "allowed", scope: "global", quota: GLOBAL_QUOTA, count: globalCount };
 }
 
 module.exports = {
-  AUTHOR_QUOTA, ESTABLISHED_AUTHOR_QUOTA, ESTABLISHED_MERGED_PRS, GLOBAL_QUOTA,
+  GLOBAL_QUOTA,
   forkRateLimit, isSameRepository, utcDayRange,
 };

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -127,6 +127,6 @@
   {
     "name": "ai-review/allow-oversized",
     "color": "fbca04",
-    "description": "Allows normal automated review of an oversized pull request"
+    "description": "Raises the automated-review evidence diff limit from 1 MiB to 4 MiB"
   }
 ]

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -100,9 +100,13 @@ async function resolvePr({ github, context, inputs = {} }) {
   const authorIsBot = pr.user?.type === "Bot" || /\[bot\]$/i.test(authorLogin) ||
     authorLogin.toLowerCase() === "devolutionsbot";
   if (authorIsBot && !force) return noResult("bot-authored pull request", route);
+  const labels = (pr.labels || [])
+    .map((label) => typeof label === "string" ? label : label.name)
+    .filter(Boolean);
   return {
     ok: true, route, prNumber: pr.number, headSha: pr.head.sha, baseSha: pr.base.sha,
-    labels: (pr.labels || []).map((label) => typeof label === "string" ? label : label.name).filter(Boolean),
+    labels,
+    evidenceMaxBytes: labels.includes(OVERSIZED_REVIEW_LABEL) ? 4 * 1024 * 1024 : 1024 * 1024,
     author: {
       nodeId: pr.user?.node_id || null, login: pr.user?.login || null, type: pr.user?.type || null,
       association: pr.author_association || null,

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -62,8 +62,10 @@ async function resolvePr({ github, context, inputs = {} }) {
   try {
     if (route === "classification") {
       // State writes also emit `labeled` events, so only the explicit maintainer opt-in may start
-      // automation through that event.
-      if (context.payload.action === "labeled" && context.payload.label?.name !== OVERSIZED_REVIEW_LABEL) {
+      // automation through label events. Removing the opt-in must restart classification so the
+      // shared PR concurrency group cancels any queued or running use of the larger evidence cap.
+      if (["labeled", "unlabeled"].includes(context.payload.action) &&
+          context.payload.label?.name !== OVERSIZED_REVIEW_LABEL) {
         return noResult("unrelated pull request label", route);
       }
       const number = positiveNumber(context.payload.pull_request?.number);

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -206,11 +206,6 @@ function resolveClassificationState({
   };
 }
 
-function isExcludedHistory(pr) {
-  const labels = labelsOf(pr.labels);
-  return labels.has("trivial") || labels.has("reverted") || /^revert\b/i.test(pr.title || "");
-}
-
 function isBot(user) {
   return user?.type === "Bot" || /\[bot\]$/i.test(user?.login || "");
 }
@@ -229,8 +224,8 @@ async function qualifyingMergedPrs({ github, owner, repo, authorNodeId, currentP
           (typeof pr.merged_at !== "string" || Number.isNaN(Date.parse(pr.merged_at)))) {
         throw new Error("invalid pull request timestamp");
       }
-      if (pr.number === currentPrNumber || !pr.merged_at || pr.user?.node_id !== authorNodeId ||
-          isBot(pr.user) || isExcludedHistory(pr)) continue;
+      if (pr.number === currentPrNumber || !pr.merged_at || pr.base?.ref !== "master" ||
+          pr.user?.node_id !== authorNodeId || isBot(pr.user)) continue;
       merged += 1;
       if (merged >= stopAt) return merged;
     }
@@ -358,6 +353,6 @@ module.exports = {
   AI_COUNTS, DUPLICATE_MARKER, EVIDENCE_LIMIT_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER,
   LEGACY_XL_MARKER, LEGITIMACY_LABEL,
   LEGITIMACY_MARKER_PREFIX, OVERSIZED_REVIEW_LABEL, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS,
-  contributorEligibility, isExcludedHistory, qualifyingMergedPrs, resolveClassificationState,
+  contributorEligibility, qualifyingMergedPrs, resolveClassificationState,
   resolveReviewState, reviewPolicyEligible,
 };

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -18,8 +18,9 @@ const LEGACY_XL_MARKER = "<!-- ironrdp-pr-automation:xl -->";
 const FORK_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-quota -->";
 const GLOBAL_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-global-budget -->";
 const EVIDENCE_LIMIT_MARKER = "<!-- ironrdp-pr-automation:evidence-limit -->";
-const EVIDENCE_LIMIT_REASON = "pull request diff exceeds the 1 MiB evidence limit";
-const ELIGIBLE_MERGED_PRS = 3;
+const EVIDENCE_LIMIT_REASON = /^pull request diff exceeds the (1|4) MiB evidence limit$/;
+const ELIGIBLE_MERGED_PRS = 1;
+const ELIGIBLE_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
 
 function labelsOf(labels) {
   return new Set((labels || []).map((label) => typeof label === "string" ? label : label?.name).filter(Boolean));
@@ -31,16 +32,14 @@ function boundStatus(value, expectedSha, allowed) {
 
 function quotaComment(rateLimit) {
   if (rateLimit?.status !== "limited") return null;
-  if (rateLimit.scope === "author" && Number.isSafeInteger(rateLimit.quota)) {
-    return { kind: "fork-quota", marker: FORK_QUOTA_MARKER, quota: rateLimit.quota };
-  }
   if (rateLimit.scope === "global") return { kind: "global-quota", marker: GLOBAL_QUOTA_MARKER };
   return null;
 }
 
 function evidenceLimitComment(reason) {
-  return reason === EVIDENCE_LIMIT_REASON
-    ? { kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER }
+  const match = typeof reason === "string" ? EVIDENCE_LIMIT_REASON.exec(reason) : null;
+  return match
+    ? { kind: "evidence-limit", marker: EVIDENCE_LIMIT_MARKER, limitMiB: Number(match[1]) }
     : null;
 }
 
@@ -81,8 +80,11 @@ function failedClassification(expectedSha, deterministic, reason, rateLimit, sem
         : []),
     ],
     addLabels: ["maintainer-required"], comments,
-    removeCommentMarkers: comments.some((comment) => comment.kind === "evidence-limit")
-      ? [] : [EVIDENCE_LIMIT_MARKER],
+    removeCommentMarkers: [
+      ...(comments.some((comment) => comment.kind === "evidence-limit") ? [] : [EVIDENCE_LIMIT_MARKER]),
+      FORK_QUOTA_MARKER,
+      ...(comments.some((comment) => comment.kind === "global-quota") ? [] : [GLOBAL_QUOTA_MARKER]),
+    ],
     check: {
       name: "AI classification",
       externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
@@ -92,36 +94,6 @@ function failedClassification(expectedSha, deterministic, reason, rateLimit, sem
         risk: semverStatus === "suspected" ? "high" : "unknown",
       }),
       conclusion: "neutral",
-    },
-  };
-}
-
-// A size/XXL pull request is excluded from automated review before any model runs, so the classifier
-// is never invoked and no model-derived label can be produced. The deterministic signals are still
-// published together with the split guidance, and the check title is deliberately not
-// "Classification complete" so the review gate refuses to open the review route.
-function oversizedClassification(expectedSha, deterministic, semverStatus) {
-  return {
-    ok: true, mode: "classification", expectedSha, oversized: true,
-    labelSets: [
-      ...deterministicLabelSets(deterministic),
-      ...(semverStatus === "unavailable"
-        ? [] : [{ owned: ["breaking-change"], desired: semverStatus === "suspected" ? ["breaking-change"] : [] }]),
-      { owned: RISK, desired: [semverStatus === "suspected" ? "risk/high" : "risk/unknown"] },
-    ],
-    addLabels: ["maintainer-required"],
-    comments: [{ kind: "oversized", marker: OVERSIZED_MARKER }],
-    // Duplicate and legitimacy verdicts are model-derived. No model ran, so a previously posted
-    // verdict is neither confirmed nor refuted here and is left untouched.
-    removeCommentMarkers: [EVIDENCE_LIMIT_MARKER, LEGACY_XL_MARKER],
-    check: {
-      name: "AI classification",
-      externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
-      title: "Deterministic labelling only",
-      summary: "This pull request is too large for automated review, so no model was invoked.",
-      machineState: classificationMachineState({
-        risk: semverStatus === "suspected" ? "high" : "unknown",
-      }),
     },
   };
 }
@@ -138,13 +110,6 @@ function resolveClassificationState({
     return failedClassification(expectedSha, deterministic, "terminal AI review count", failureRateLimit);
   }
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
-  // Checked before the classifier is consulted unless a maintainer has opted the pull request into
-  // normal oversized review, avoiding a model call and quota charge for the default exclusion.
-  const oversized = deterministic?.ok && deterministic.sizeLabel === "size/XXL" &&
-    !existing.has(OVERSIZED_REVIEW_LABEL);
-  if (!forced && oversized) {
-    return oversizedClassification(expectedSha, deterministic, semverStatus);
-  }
   if (!forced && rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", failureRateLimit, semverStatus);
   }
@@ -209,7 +174,6 @@ function resolveClassificationState({
       kind: "duplicate", marker: DUPLICATE_MARKER,
       url: model.duplicate.similar_pr_url, rationale: model.duplicate.rationale,
     }] : []),
-    ...(oversized && !forced ? [{ kind: "oversized", marker: OVERSIZED_MARKER }] : []),
   ];
   const auditComments = [
     ...(legitimacyStopped ? [{
@@ -225,7 +189,10 @@ function resolveClassificationState({
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
       EVIDENCE_LIMIT_MARKER,
-      ...(oversized && !forced ? [LEGACY_XL_MARKER] : [OVERSIZED_MARKER, LEGACY_XL_MARKER]),
+      FORK_QUOTA_MARKER,
+      GLOBAL_QUOTA_MARKER,
+      OVERSIZED_MARKER,
+      LEGACY_XL_MARKER,
     ],
     check: {
       name: "AI classification",
@@ -272,7 +239,13 @@ async function qualifyingMergedPrs({ github, owner, repo, authorNodeId, currentP
 }
 
 async function contributorEligibility({ github, owner, repo, author, currentPrNumber }) {
-  if (!author?.nodeId || author.type === "Bot" || /\[bot\]$/i.test(author.login || "")) {
+  if (author?.type === "Bot" || /\[bot\]$/i.test(author?.login || "")) {
+    return { status: "ineligible", reason: "bot author" };
+  }
+  if (ELIGIBLE_ASSOCIATIONS.has(author?.association)) {
+    return { status: "eligible", association: author.association };
+  }
+  if (!author?.nodeId) {
     return { status: "ineligible", reason: "bot or missing immutable author" };
   }
   try {
@@ -299,8 +272,11 @@ function resolveReviewState({
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
       labelSets: [], addLabels: ["maintainer-required"], comments,
-      removeCommentMarkers: comments.some((comment) => comment.kind === "evidence-limit")
-        ? [] : [EVIDENCE_LIMIT_MARKER],
+      removeCommentMarkers: [
+        ...(comments.some((comment) => comment.kind === "evidence-limit") ? [] : [EVIDENCE_LIMIT_MARKER]),
+        FORK_QUOTA_MARKER,
+        ...(comments.some((comment) => comment.kind === "global-quota") ? [] : [GLOBAL_QUOTA_MARKER]),
+      ],
       ...(report ? { check: {
         name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}`,
         title: "Automated review unavailable",
@@ -345,7 +321,7 @@ function resolveReviewState({
       return fail("second review is not eligible");
     }
     if (!reviewPolicyEligible({
-      labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
+      labels, legitimacyStopped: gate.legitimacyStopped,
     })) return fail("review is not eligible");
     if (!gate.ok) return fail("review gate unavailable");
   }
@@ -368,7 +344,9 @@ function resolveReviewState({
     removeLabels: nextCount === "ai-reviewed/1" && hasFindings ? ["maintainer-required"] : [],
     comments: hasFindings ? [{ kind: "review", marker: reviewMarker,
       review: reviewerResult.value }] : [],
-    removeCommentMarkers: [EVIDENCE_LIMIT_MARKER],
+    removeCommentMarkers: [
+      EVIDENCE_LIMIT_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER,
+    ],
     check: { name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}` },
     expectedReviewCount,
     forced,

--- a/.github/pr-automation/routing.js
+++ b/.github/pr-automation/routing.js
@@ -48,13 +48,11 @@ function labelsOf(labels) {
   return new Set((labels || []).map((label) => typeof label === "string" ? label : label?.name).filter(Boolean));
 }
 
-function reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated } = {}) {
+function reviewPolicyEligible({ labels, legitimacyStopped } = {}) {
   const present = labelsOf(labels);
-  const oversized = present.has("size/XXL") && !present.has("ai-review/allow-oversized");
-  if (present.has("ai-reviewed/2") || present.has("duplicate") || oversized ||
+  if (present.has("ai-reviewed/2") || present.has("duplicate") ||
       present.has("triage/legitimacy") || legitimacyStopped === true) return false;
-  if (protocolRelated === true) return true;
-  return !(present.has("risk/low") && !present.has("breaking-change"));
+  return true;
 }
 
 module.exports = {

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -46,20 +46,17 @@ function markerBody(comment, owner, repo) {
   if (comment.kind === "duplicate") {
     return `${comment.marker}\n\nPotential duplicate detected: ${escapeMarkdown(comment.url)}.\n\n${escapeMarkdown(comment.rationale)}\n\nMaintainer review is required.`;
   }
-  if (comment.kind === "oversized") {
-    return `${comment.marker}\n\nThis pull request is \`size/XXL\`, so automated review is disabled for it: a change this large is hard to review well in one piece, whether by a human or a model.\n\nPlease split it into focused pull requests that can each be reviewed on their own. When the parts build on each other, [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) let you open each one on top of the last without waiting for the one below to merge. Stacks require every branch to live in this repository, so from a fork, please open separate pull requests instead.\n\nAutomated review resumes once the change is below the \`size/XXL\` threshold.`;
-  }
   if (comment.kind === "legitimacy") {
     return `${comment.marker}\n\nAutomated review stopped because commit \`${escapeMarkdown(comment.sha)}\` has strong indicators requiring maintainer triage.\n\n${escapeMarkdown(comment.reason)}\n\nThis comment remains as an audit record if later classifications differ. Maintainer review is required.`;
-  }
-  if (comment.kind === "fork-quota") {
-    return `${comment.marker}\n\nAutomated classification and review capacity is unavailable because this fork account has reached its daily UTC quota of ${comment.quota} pull requests.\n\nSee the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md). Maintainer review is required.`;
   }
   if (comment.kind === "global-quota") {
     return `${comment.marker}\n\nAutomated classification and review capacity for fork pull requests has reached its daily UTC limit.\n\nSee the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md). Maintainer review is required.`;
   }
   if (comment.kind === "evidence-limit") {
-    return `${comment.marker}\n\nAutomated model analysis stopped because this pull request's diff exceeds the 1 MiB evidence limit. No model was invoked with partial evidence.\n\nPlease split the change into focused pull requests or reduce generated content before requesting automated review again. Maintainer review is required.`;
+    const guidance = comment.limitMiB === 1
+      ? "A maintainer can add `ai-review/allow-oversized` to retry with the runtime maximum of 4 MiB. Otherwise, split the change into focused pull requests or reduce generated content."
+      : "The 4 MiB limit is the model runtime maximum. Please split the change into focused pull requests or reduce generated content.";
+    return `${comment.marker}\n\nAutomated model analysis stopped because this pull request's diff exceeds the ${comment.limitMiB} MiB evidence limit. No model was invoked with partial evidence.\n\n${guidance} Maintainer review is required.`;
   }
   throw new Error("unsupported issue comment");
 }
@@ -113,7 +110,7 @@ function assertReviewPolicy(labels, state) {
     : null;
   if (currentReviewCount !== state.expectedReviewCount ||
       (!state.forced && !reviewPolicyEligible({
-        labels: [...labels], protocolRelated: state.protocolRelated,
+        labels: [...labels],
       }))) {
     throw new StalePolicyError();
   }

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -68,7 +68,7 @@ Run automated review after CI succeeds for the exact classified head.
 Run the second review after a later push reaches green exact-head CI, and stop automatic review at `ai-reviewed/2`.
 
 `OWNER` and `MEMBER` authors are always eligible.
-Other authors need one merged pull request from the same immutable human author, excluding `trivial`, `reverted`, and revert-titled pull requests.
+Other authors need one pull request from the same immutable human author merged into `master`.
 
 Block review for duplicates at confidence 0.85 or greater and likely non-legitimate changes.
 Unavailable or invalid classification fails closed to maintainer review.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -60,3 +60,26 @@ Currently we define three specialist reviewers:
 
 They should run in parallel using a multi-job matrix.
 We allow at most three specialist agents to run at once.
+
+## Activation policy
+
+Classify every non-draft, human-authored pull request that passes the integrity and capacity gates.
+Run automated review after CI succeeds for the exact classified head.
+Run the second review after a later push reaches green exact-head CI, and stop automatic review at `ai-reviewed/2`.
+
+`OWNER` and `MEMBER` authors are always eligible.
+Other authors need one merged pull request from the same immutable human author, excluding `trivial`, `reverted`, and revert-titled pull requests.
+
+Block review for duplicates at confidence 0.85 or greater and likely non-legitimate changes.
+Unavailable or invalid classification fails closed to maintainer review.
+Risk and protocol relevance select reviewers but do not suppress review.
+
+Fork pull requests share a quota of 50 per UTC day.
+Exclude `OWNER` and `MEMBER` pull requests from enforcement and counting, and preserve the same-repository exemption.
+
+Keep `size/XXL` informational.
+Use a 1 MiB evidence diff limit by default and a 4 MiB limit when `ai-review/allow-oversized` is present.
+Adding that label must retry classification.
+Evidence above the applicable limit fails closed without partial model input.
+
+Force mode bypasses policy gates but not evidence, validation, filesystem, citation, publication, or stale-head safeguards.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -59,6 +59,7 @@ jobs:
       classification-requested: ${{ steps.resolve.outputs.classification-requested }}
       review-route: ${{ steps.resolve.outputs.review-route }}
       classifier-lane: ${{ steps.resolve.outputs.classifier-lane }}
+      evidence-max-bytes: ${{ steps.resolve.outputs.evidence-max-bytes }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -91,6 +92,7 @@ jobs:
             core.setOutput("classification-requested", result.classificationRequested === true);
             core.setOutput("review-route", result.reviewRoute === true);
             core.setOutput("classifier-lane", result.prNumber ? (Number(result.prNumber) % 2) + 1 : "");
+            core.setOutput("evidence-max-bytes", result.evidenceMaxBytes ?? "");
             core.info(JSON.stringify({ event: "pr-automation.resolve-pr", decision: result }));
             if (!result.ok) core.warning(`PR automation did not start: ${result.reason}`);
 
@@ -121,6 +123,7 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           FORCE: ${{ needs.resolve-pr.outputs.force }}
+          RETRY_WITH_LARGER_EVIDENCE: ${{ needs.resolve-pr.outputs.review-requested }}
         with:
           script: |
             const { SCHEMA_VERSION, parseCheckState } = require("./.github/pr-automation/validate-classifier");
@@ -132,6 +135,16 @@ jobs:
               core.info(JSON.stringify({
                 event: "pr-automation.classification-gate",
                 decision: { available: true, required: true, force: true },
+              }));
+              return;
+            }
+            if (process.env.RETRY_WITH_LARGER_EVIDENCE === "true") {
+              core.setOutput("required", true);
+              core.setOutput("available", true);
+              core.setOutput("reason", "");
+              core.info(JSON.stringify({
+                event: "pr-automation.classification-gate",
+                decision: { available: true, required: true, largerEvidence: true },
               }));
               return;
             }
@@ -406,8 +419,6 @@ jobs:
       (needs.resolve-pr.outputs.force == 'true' ||
       (needs.classification-gate.outputs.available == 'true' &&
       needs.classification-gate.outputs.required == 'true' &&
-      (needs.deterministic-analysis.outputs.size-label != 'size/XXL' ||
-      contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-review/allow-oversized')) &&
       needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
@@ -430,6 +441,7 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           BASE_SHA: ${{ needs.resolve-pr.outputs.base-sha }}
+          EVIDENCE_MAX_BYTES: ${{ needs.resolve-pr.outputs.evidence-max-bytes }}
         run: |
           set -euo pipefail
           export GIT_CONFIG_NOSYSTEM=1
@@ -439,7 +451,8 @@ jobs:
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git fetch --no-tags origin +master:refs/remotes/origin/master
           git checkout --detach origin/master
-          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"; then
+          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh \
+            "$HEAD_SHA" "$BASE_SHA" "$EVIDENCE_MAX_BYTES"; then
             reason="pull request evidence unavailable"
             if test -f pr-evidence/failure-reason.txt; then
               reason="$(cat pr-evidence/failure-reason.txt)"
@@ -664,7 +677,7 @@ jobs:
                 })).data.workflow_runs;
               const ciGreen = workflowRuns.some((run) => run?.name === "CI" && run?.conclusion === "success");
               const secondReviewEligible = !labels.includes("ai-reviewed/1") || !reviewAtHead;
-              const policyEligible = reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated });
+              const policyEligible = reviewPolicyEligible({ labels, legitimacyStopped });
               const contributor = await contributorEligibility({
                 github, owner: context.repo.owner, repo: context.repo.repo, author,
                 currentPrNumber: prNumber,
@@ -715,6 +728,7 @@ jobs:
       base-sha: ${{ needs.resolve-pr.outputs.base-sha }}
       gate: ${{ needs.review-gate.outputs.gate }}
       specialist-reviewers: ${{ needs.review-gate.outputs.specialist-reviewers }}
+      evidence-max-bytes: ${{ needs.resolve-pr.outputs.evidence-max-bytes }}
 
   resolve-review-state:
     name: Resolve review state

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: Pull request automation
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, edited, labeled]
+    types: [opened, reopened, synchronize, ready_for_review, edited, labeled, unlabeled]
   workflow_run:
     workflows: [CI]
     types: [completed]

--- a/.github/workflows/review-pipeline.yml
+++ b/.github/workflows/review-pipeline.yml
@@ -23,6 +23,10 @@ on:
         description: Canonically ordered specialist reviewer IDs
         required: true
         type: string
+      evidence-max-bytes:
+        description: Trusted maximum evidence diff size
+        required: true
+        type: string
     outputs:
       output:
         description: Validated final review JSON
@@ -50,6 +54,7 @@ jobs:
         env:
           HEAD_SHA: ${{ inputs.head-sha }}
           BASE_SHA: ${{ inputs.base-sha }}
+          EVIDENCE_MAX_BYTES: ${{ inputs.evidence-max-bytes }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
@@ -60,7 +65,8 @@ jobs:
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git fetch --no-tags origin "+$WORKFLOW_SHA:refs/remotes/origin/automation"
           git checkout --detach origin/automation
-          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"; then
+          if ! bash ./.github/pr-automation/fetch-pr-evidence.sh \
+            "$HEAD_SHA" "$BASE_SHA" "$EVIDENCE_MAX_BYTES"; then
             reason="pull request evidence unavailable"
             if test -f pr-evidence/failure-reason.txt; then
               reason="$(cat pr-evidence/failure-reason.txt)"


### PR DESCRIPTION
Run automated review for every eligible non-draft pull request and lower contributor history to one same-author pull request merged into master while exempting owners and members.

Replace author quotas with a 50-PR repository-wide fork quota and let the oversized opt-in raise complete diff evidence from 1 MiB to the runtime maximum of 4 MiB.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>