### PR TITLE
ci(pr-automation): fix GLM 5.3 model ID

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -9,7 +9,7 @@ The automation posts guidance on the pull request instead of invoking a model wi
 ## Review pipeline
 
 Classification and review use [Helmcode's OpenAI-compatible endpoint](https://api.helmcode.com/v1).
-The classifier and all reviewers use `glm-5.3`.
+The classifier and all reviewers use `glm5.3`.
 
 The pipeline performs these stages:
 

--- a/.github/pr-automation/agents/classifier.json
+++ b/.github/pr-automation/agents/classifier.json
@@ -1,6 +1,6 @@
 {
   "id": "classifier",
-  "model": "glm-5.3",
+  "model": "glm5.3",
   "prompt_file": ".github/pr-automation/prompts/classifier.md",
   "schema_file": ".github/pr-automation/schemas/classifier.json",
   "methodology_files": [],

--- a/.github/pr-automation/agents/code-compressor.json
+++ b/.github/pr-automation/agents/code-compressor.json
@@ -1,6 +1,6 @@
 {
   "id": "code-compressor",
-  "model": "glm-5.3",
+  "model": "glm5.3",
   "prompt_file": ".github/pr-automation/prompts/code-compressor.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/agents/general-reviewer.json
+++ b/.github/pr-automation/agents/general-reviewer.json
@@ -1,6 +1,6 @@
 {
   "id": "general-reviewer",
-  "model": "glm-5.3",
+  "model": "glm5.3",
   "prompt_file": ".github/pr-automation/prompts/general-reviewer.md",
   "schema_file": ".github/pr-automation/schemas/final-review.json",
   "allowed_roots": [

--- a/.github/pr-automation/agents/protocol.json
+++ b/.github/pr-automation/agents/protocol.json
@@ -1,6 +1,6 @@
 {
   "id": "protocol",
-  "model": "glm-5.3",
+  "model": "glm5.3",
   "prompt_file": ".github/pr-automation/prompts/protocol-reviewer.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/agents/skeptical.json
+++ b/.github/pr-automation/agents/skeptical.json
@@ -1,6 +1,6 @@
 {
   "id": "skeptical",
-  "model": "glm-5.3",
+  "model": "glm5.3",
   "prompt_file": ".github/pr-automation/prompts/skeptical.md",
   "schema_file": ".github/pr-automation/schemas/candidate-review.json",
   "methodology_files": [

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -224,7 +224,7 @@ test("review skills own methodology while stage prompts own pipeline contracts",
 
   for (const agent of ["classifier", "protocol", "skeptical", "code-compressor", "general-reviewer"]) {
     const config = JSON.parse(fs.readFileSync(path.join(__dirname, "agents", `${agent}.json`), "utf8"));
-    assert.equal(config.model, "glm-5.3");
+    assert.equal(config.model, "glm5.3");
     assert.equal(config.max_tool_calls > 0, true);
     if (["protocol", "skeptical", "code-compressor"].includes(agent)) {
       assert.equal(config.max_turns, 50);


### PR DESCRIPTION
Helmcode exposes GLM 5.3 as `glm5.3`, not `glm-5.3`.
Use the exact model ID so agent calls do not fail closed with HTTP 401.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>