### PR TITLE
ci(pr-automation): redispatch explicit retries

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -857,6 +857,7 @@ test("only oversized-review label changes start automation from label events", a
   assert.equal(revoked.classificationRequested, true);
   assert.equal(revoked.reviewRequested, false);
   assert.equal(revoked.evidenceMaxBytes, 1024 * 1024);
+  assert.equal((await resolve("breaking-change")).reason, "unrelated pull request label");
   assert.equal((await resolve("size/XXL")).reason, "unrelated pull request label");
   assert.equal((await resolve("size/XXL", "unlabeled", [])).reason, "unrelated pull request label");
 });
@@ -1514,13 +1515,28 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.output.title, "Automated review complete");
 });
 
-test("writer dispatches new but not forced completed classifications", async () => {
-  const writeClassification = async (dispatchReview) => {
+test("writer dispatches every requested completed classification attempt", async () => {
+  const writeClassification = async ({ dispatchReview, existing = false }) => {
+    let creates = 0;
     let dispatches = 0;
+    const machineState = {
+      protocolRelated: false, risk: "low", specialistReviewers: [],
+      automaticReviewEligible: true,
+    };
     const github = {
-      paginate: { iterator: async function* () { yield { data: [] }; } },
+      paginate: { iterator: async function* () {
+        yield { data: existing ? [{
+          id: 7,
+          external_id: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
+          conclusion: "success",
+          output: {
+            title: "Classification complete",
+            summary: `Validated classification.\n\n${encodeCheckState(machineState)}`,
+          },
+        }] : [] };
+      } },
       rest: {
-        checks: { listForRef: () => {}, create: async () => {} },
+        checks: { listForRef: () => {}, create: async () => { creates += 1; } },
         pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
         issues: { get: async () => ({ data: { labels: [] } }) },
         repos: { createDispatchEvent: async () => { dispatches += 1; } },
@@ -1534,18 +1550,65 @@ test("writer dispatches new but not forced completed classifications", async () 
         check: {
           name: "AI classification", externalId: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
           title: "Classification complete", summary: "Validated classification.",
-          machineState: {
-            protocolRelated: false, risk: "low", specialistReviewers: [],
-            automaticReviewEligible: true,
-          },
+          machineState,
         },
       },
     });
-    return dispatches;
+    return { creates, dispatches };
   };
 
-  assert.equal(await writeClassification(true), 1);
-  assert.equal(await writeClassification(false), 0);
+  assert.deepEqual(await writeClassification({ dispatchReview: true }), { creates: 1, dispatches: 1 });
+  assert.deepEqual(await writeClassification({ dispatchReview: true, existing: true }), {
+    creates: 0, dispatches: 1,
+  });
+  assert.deepEqual(await writeClassification({ dispatchReview: false, existing: true }), {
+    creates: 0, dispatches: 0,
+  });
+  assert.deepEqual(await writeClassification({ existing: true }), { creates: 0, dispatches: 0 });
+});
+
+test("writer does not dispatch a completed classification after the head changes", async () => {
+  let headReads = 0;
+  let dispatches = 0;
+  const machineState = {
+    protocolRelated: false, risk: "low", specialistReviewers: [],
+    automaticReviewEligible: true,
+  };
+  const github = {
+    paginate: { iterator: async function* () {
+      yield { data: [{
+        id: 7,
+        external_id: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
+        conclusion: "success",
+        output: {
+          title: "Classification complete",
+          summary: `Validated classification.\n\n${encodeCheckState(machineState)}`,
+        },
+      }] };
+    } },
+    rest: {
+      checks: { listForRef: () => {} },
+      pulls: { get: async () => {
+        headReads += 1;
+        return { data: { state: "open", head: { sha: headReads === 1 ? SHA : OTHER_SHA } } };
+      } },
+      issues: { get: async () => ({ data: { labels: [] } }) },
+      repos: { createDispatchEvent: async () => { dispatches += 1; } },
+    },
+  };
+
+  await assert.rejects(writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "classification", expectedSha: SHA, labelSets: [], addLabels: [],
+      comments: [], removeCommentMarkers: [], dispatchReview: true,
+      check: {
+        name: "AI classification", externalId: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
+        title: "Classification complete", summary: "Validated classification.", machineState,
+      },
+    },
+  }), StaleHeadError);
+  assert.equal(dispatches, 0);
 });
 
 test("writer deduplicates one forced review invocation but publishes a later one", async () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -119,6 +119,21 @@ test("automatic review requires exact-head CI and only reruns after a later push
   assert.match(workflowJob(workflow, "review-pipeline"), /review-gate\.outputs\.eligible == 'true'/);
 });
 
+test("cached and reclassified retries use exclusive dispatch paths", () => {
+  const workflow = readWorkflow();
+  const requestReview = workflowJob(workflow, "request-review");
+  const resolveClassification = workflowJob(workflow, "resolve-classification-state");
+  const writer = workflowJob(workflow, "write-state");
+
+  assert.match(requestReview, /needs\.resolve-pr\.outputs\.review-requested == 'true'/);
+  assert.match(requestReview, /needs\.classification-gate\.outputs\.required == 'false'/);
+  assert.match(requestReview, /dispatchClassificationComplete/);
+  assert.match(resolveClassification, /needs\.classification-gate\.outputs\.required == 'true'/);
+  assert.match(writer,
+    /REVIEW_REQUESTED: \$\{\{ needs\.resolve-pr\.outputs\.review-requested \}\}/);
+  assert.match(writer, /reviewRequested: process\.env\.REVIEW_REQUESTED === "true"/);
+});
+
 test("review skills own methodology while stage prompts own pipeline contracts", () => {
   const githubDirectory = path.join(__dirname, "..");
   const repositoryRoot = path.join(githubDirectory, "..");
@@ -1515,9 +1530,12 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.output.title, "Automated review complete");
 });
 
-test("writer dispatches every requested completed classification attempt", async () => {
-  const writeClassification = async ({ dispatchReview, existing = false }) => {
+test("classification dispatch remains edge-triggered except for explicit retries", async () => {
+  const writeClassification = async ({
+    dispatchReview = true, existing = "none", reviewRequested = false,
+  }) => {
     let creates = 0;
+    let updates = 0;
     let dispatches = 0;
     const machineState = {
       protocolRelated: false, risk: "low", specialistReviewers: [],
@@ -1525,18 +1543,24 @@ test("writer dispatches every requested completed classification attempt", async
     };
     const github = {
       paginate: { iterator: async function* () {
-        yield { data: existing ? [{
+        yield { data: existing === "none" ? [] : [{
           id: 7,
           external_id: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
           conclusion: "success",
           output: {
             title: "Classification complete",
-            summary: `Validated classification.\n\n${encodeCheckState(machineState)}`,
+            summary: existing === "same"
+              ? `Validated classification.\n\n${encodeCheckState(machineState)}`
+              : "Previous classification state.",
           },
-        }] : [] };
+        }] };
       } },
       rest: {
-        checks: { listForRef: () => {}, create: async () => { creates += 1; } },
+        checks: {
+          listForRef: () => {},
+          create: async () => { creates += 1; },
+          update: async () => { updates += 1; },
+        },
         pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
         issues: { get: async () => ({ data: { labels: [] } }) },
         repos: { createDispatchEvent: async () => { dispatches += 1; } },
@@ -1553,18 +1577,24 @@ test("writer dispatches every requested completed classification attempt", async
           machineState,
         },
       },
+      reviewRequested,
     });
-    return { creates, dispatches };
+    return { creates, updates, dispatches };
   };
 
-  assert.deepEqual(await writeClassification({ dispatchReview: true }), { creates: 1, dispatches: 1 });
-  assert.deepEqual(await writeClassification({ dispatchReview: true, existing: true }), {
-    creates: 0, dispatches: 1,
+  assert.deepEqual(await writeClassification({}), { creates: 1, updates: 0, dispatches: 1 });
+  assert.deepEqual(await writeClassification({ existing: "changed" }), {
+    creates: 0, updates: 1, dispatches: 1,
   });
-  assert.deepEqual(await writeClassification({ dispatchReview: false, existing: true }), {
-    creates: 0, dispatches: 0,
+  assert.deepEqual(await writeClassification({ existing: "same", reviewRequested: true }), {
+    creates: 0, updates: 0, dispatches: 1,
   });
-  assert.deepEqual(await writeClassification({ existing: true }), { creates: 0, dispatches: 0 });
+  assert.deepEqual(await writeClassification({ existing: "same" }), {
+    creates: 0, updates: 0, dispatches: 0,
+  });
+  assert.deepEqual(await writeClassification({ dispatchReview: false, reviewRequested: true }), {
+    creates: 1, updates: 0, dispatches: 0,
+  });
 });
 
 test("writer does not dispatch a completed classification after the head changes", async () => {
@@ -1607,6 +1637,7 @@ test("writer does not dispatch a completed classification after the head changes
         title: "Classification complete", summary: "Validated classification.", machineState,
       },
     },
+    reviewRequested: true,
   }), StaleHeadError);
   assert.equal(dispatches, 0);
 });

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -20,6 +20,7 @@ const {
   OVERSIZED_MARKER, OVERSIZED_REVIEW_LABEL, contributorEligibility,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
+const { resolveClassificationGate } = require("./classification-gate");
 const {
   StaleHeadError, StalePolicyError, applyLabels, escapeMarkdown, markerBody, writeState,
 } = require("./write-state");
@@ -119,19 +120,47 @@ test("automatic review requires exact-head CI and only reruns after a later push
   assert.match(workflowJob(workflow, "review-pipeline"), /review-gate\.outputs\.eligible == 'true'/);
 });
 
-test("cached and reclassified retries use exclusive dispatch paths", () => {
-  const workflow = readWorkflow();
-  const requestReview = workflowJob(workflow, "request-review");
-  const resolveClassification = workflowJob(workflow, "resolve-classification-state");
-  const writer = workflowJob(workflow, "write-state");
+test("classification gate reuses completed state but forces oversized retries", async () => {
+  let reads = 0;
+  const machineState = {
+    protocolRelated: false, risk: "low", specialistReviewers: [],
+    automaticReviewEligible: true,
+  };
+  const github = { rest: { checks: { listForRef: async () => {
+    reads += 1;
+    return { data: { check_runs: [{
+      external_id: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
+      conclusion: "success",
+      app: { slug: "github-actions" },
+      output: {
+        title: "Classification complete",
+        summary: `Validated classification.\n\n${encodeCheckState(machineState)}`,
+      },
+    }] } };
+  } } } };
+  const args = { github, owner: "Devolutions", repo: "IronRDP", expectedSha: SHA };
 
-  assert.match(requestReview, /needs\.resolve-pr\.outputs\.review-requested == 'true'/);
-  assert.match(requestReview, /needs\.classification-gate\.outputs\.required == 'false'/);
-  assert.match(requestReview, /dispatchClassificationComplete/);
-  assert.match(resolveClassification, /needs\.classification-gate\.outputs\.required == 'true'/);
-  assert.match(writer,
-    /REVIEW_REQUESTED: \$\{\{ needs\.resolve-pr\.outputs\.review-requested \}\}/);
-  assert.match(writer, /reviewRequested: process\.env\.REVIEW_REQUESTED === "true"/);
+  const cached = await resolveClassificationGate(args);
+  assert.equal(cached.available, true);
+  assert.equal(cached.required, false);
+  assert.equal(reads, 1);
+
+  const retry = await resolveClassificationGate({ ...args, retryWithLargerEvidence: true });
+  assert.deepEqual(retry, {
+    available: true, required: true, reason: "", largerEvidence: true,
+  });
+  assert.equal(reads, 1);
+
+  const unavailable = await resolveClassificationGate({
+    ...args,
+    github: { rest: { checks: { listForRef: async () => { throw new Error("unavailable"); } } } },
+  });
+  assert.deepEqual(unavailable, {
+    available: false,
+    required: false,
+    reason: "GitHub checks API unavailable",
+    error: "unavailable",
+  });
 });
 
 test("review skills own methodology while stage prompts own pipeline contracts", () => {

--- a/.github/pr-automation/classification-gate.js
+++ b/.github/pr-automation/classification-gate.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const { SCHEMA_VERSION, parseCheckState } = require("./validate-classifier");
+
+async function resolveClassificationGate({
+  github, owner, repo, expectedSha, force = false, retryWithLargerEvidence = false,
+}) {
+  if (force) {
+    return { available: true, required: true, reason: "", force: true };
+  }
+  if (retryWithLargerEvidence) {
+    return { available: true, required: true, reason: "", largerEvidence: true };
+  }
+  try {
+    const { data } = await github.rest.checks.listForRef({
+      owner, repo, ref: expectedSha, check_name: "AI classification", per_page: 100,
+    });
+    const externalId = `${SCHEMA_VERSION}:${expectedSha}`;
+    const completed = data.check_runs.some((run) => {
+      const state = parseCheckState(run.output?.summary);
+      return run.external_id === externalId && run.conclusion === "success" &&
+        run.app?.slug === "github-actions" && state?.automaticReviewEligible === true &&
+        run.output?.title === "Classification complete";
+    });
+    return { available: true, required: !completed, reason: "", externalId, completed };
+  } catch (error) {
+    return {
+      available: false,
+      required: false,
+      reason: "GitHub checks API unavailable",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+module.exports = { resolveClassificationGate };

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -269,8 +269,10 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
       await deleteMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, marker);
     }
     if (state.check) {
-      const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      if (created && state.check.title === "Classification complete" && state.dispatchReview !== false) {
+      await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
+      // Check persistence remains idempotent.
+      // Each explicit classification attempt must wake review even when the same head produces unchanged state.
+      if (state.check.title === "Classification complete" && state.dispatchReview === true) {
         await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
       }
     }

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -234,7 +234,7 @@ async function applyLabels(github, owner, repo, prNumber, state, currentLabels) 
   return true;
 }
 
-async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
+async function writeState({ github, owner, repo, prNumber, state, botLogin, reviewRequested = false }) {
   if (!state?.ok || !["classification", "review"].includes(state.mode) ||
       typeof state.expectedSha !== "string" || !Number.isSafeInteger(prNumber) || prNumber <= 0) {
     throw new Error("invalid normalized state");
@@ -269,10 +269,10 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
       await deleteMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, marker);
     }
     if (state.check) {
-      await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      // Check persistence remains idempotent.
-      // Each explicit classification attempt must wake review even when the same head produces unchanged state.
-      if (state.check.title === "Classification complete" && state.dispatchReview === true) {
+      const changed = await ensureClassificationCheck(
+        github, owner, repo, prNumber, state.expectedSha, state.check);
+      if ((changed || reviewRequested) && state.check.title === "Classification complete" &&
+          state.dispatchReview !== false) {
         await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
       }
     }

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -83,8 +83,7 @@ Adding that label must retry classification.
 Evidence above the applicable limit fails closed without partial model input.
 
 Normal classification-to-review dispatch is edge-triggered and occurs only when the persisted SHA-bound classification check changes.
-Adding `ai-review/allow-oversized` is an explicit maintainer retry and may dispatch on the same SHA when classification state is unchanged.
-Cached classifications use the dedicated `request-review` job, while actual reclassification uses the writer’s explicit-retry exception.
+Adding `ai-review/allow-oversized` forces reclassification and may dispatch on the same SHA when the resulting classification state is unchanged.
 Unrelated label events and repeated non-explicit unchanged classifications must not dispatch.
 
 Force mode bypasses policy gates but not evidence, validation, filesystem, citation, publication, or stale-head safeguards.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -82,4 +82,9 @@ Use a 1 MiB evidence diff limit by default and a 4 MiB limit when `ai-review/all
 Adding that label must retry classification.
 Evidence above the applicable limit fails closed without partial model input.
 
+Normal classification-to-review dispatch is edge-triggered and occurs only when the persisted SHA-bound classification check changes.
+Adding `ai-review/allow-oversized` is an explicit maintainer retry and may dispatch on the same SHA when classification state is unchanged.
+Cached classifications use the dedicated `request-review` job, while actual reclassification uses the writer’s explicit-retry exception.
+Unrelated label events and repeated non-explicit unchanged classifications must not dispatch.
+
 Force mode bypasses policy gates but not evidence, validation, filesystem, citation, publication, or stale-head safeguards.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -814,6 +814,7 @@ jobs:
       - uses: actions/github-script@v8
         env:
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          REVIEW_REQUESTED: ${{ needs.resolve-pr.outputs.review-requested }}
           CLASSIFICATION_STATE: ${{ needs.resolve-classification-state.outputs.state }}
           REVIEW_STATE: ${{ needs.resolve-review-state.outputs.state }}
           UPSTREAM_RESULTS: >-
@@ -840,6 +841,7 @@ jobs:
               github, owner: context.repo.owner, repo: context.repo.repo,
               prNumber: Number(process.env.PULL_REQUEST_NUMBER), state,
               botLogin: "github-actions[bot]",
+              reviewRequested: process.env.REVIEW_REQUESTED === "true",
             });
             core.info(JSON.stringify({
               event: "pr-automation.write-state-complete",

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -126,92 +126,23 @@ jobs:
           RETRY_WITH_LARGER_EVIDENCE: ${{ needs.resolve-pr.outputs.review-requested }}
         with:
           script: |
-            const { SCHEMA_VERSION, parseCheckState } = require("./.github/pr-automation/validate-classifier");
-            const force = process.env.FORCE === "true";
-            if (force) {
-              core.setOutput("required", true);
-              core.setOutput("available", true);
-              core.setOutput("reason", "");
-              core.info(JSON.stringify({
-                event: "pr-automation.classification-gate",
-                decision: { available: true, required: true, force: true },
-              }));
-              return;
-            }
-            if (process.env.RETRY_WITH_LARGER_EVIDENCE === "true") {
-              core.setOutput("required", true);
-              core.setOutput("available", true);
-              core.setOutput("reason", "");
-              core.info(JSON.stringify({
-                event: "pr-automation.classification-gate",
-                decision: { available: true, required: true, largerEvidence: true },
-              }));
-              return;
-            }
-            try {
-              const { data } = await github.rest.checks.listForRef({
-                owner: context.repo.owner, repo: context.repo.repo, ref: process.env.HEAD_SHA,
-                check_name: "AI classification", per_page: 100,
-              });
-              const externalId = `${SCHEMA_VERSION}:${process.env.HEAD_SHA}`;
-              // A check without the current machine-readable state cannot satisfy the review gate,
-              // so it must not suppress reclassification either.
-              const completed = data.check_runs.some((run) => {
-                const state = parseCheckState(run.output?.summary);
-                return run.external_id === externalId && run.conclusion === "success" &&
-                  run.app?.slug === "github-actions" && state?.automaticReviewEligible === true &&
-                  run.output?.title === "Classification complete";
-              });
-              core.setOutput("required", !completed);
-              core.setOutput("available", true);
-              core.setOutput("reason", "");
-              core.info(JSON.stringify({
-                event: "pr-automation.classification-gate",
-                decision: { available: true, required: !completed, externalId, completed },
-              }));
-            } catch (error) {
-              core.warning(`Classification gate unavailable: ${error.message}`);
-              core.setOutput("required", false);
-              core.setOutput("available", false);
-              core.setOutput("reason", "GitHub checks API unavailable");
-              core.info(JSON.stringify({
-                event: "pr-automation.classification-gate",
-                decision: { available: false, required: false, reason: error.message },
-              }));
-            }
-
-  request-review:
-    name: Request automated review
-    needs: [resolve-pr, classification-gate]
-    if: >-
-      needs.resolve-pr.outputs.ok == 'true' &&
-      needs.resolve-pr.outputs.review-requested == 'true' &&
-      needs.classification-gate.outputs.available == 'true' &&
-      needs.classification-gate.outputs.required == 'false'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: master
-          persist-credentials: false
-
-      - uses: actions/github-script@v8
-        env:
-          PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
-          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
-        with:
-          script: |
-            const { dispatchClassificationComplete } = require("./.github/pr-automation/write-state");
-            await dispatchClassificationComplete(
+            const { resolveClassificationGate } = require("./.github/pr-automation/classification-gate");
+            const decision = await resolveClassificationGate({
               github,
-              context.repo.owner,
-              context.repo.repo,
-              Number(process.env.PULL_REQUEST_NUMBER),
-              process.env.HEAD_SHA,
-            );
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              expectedSha: process.env.HEAD_SHA,
+              force: process.env.FORCE === "true",
+              retryWithLargerEvidence: process.env.RETRY_WITH_LARGER_EVIDENCE === "true",
+            });
+            core.setOutput("required", decision.required);
+            core.setOutput("available", decision.available);
+            core.setOutput("reason", decision.reason);
+            if (decision.error) core.warning(`Classification gate unavailable: ${decision.error}`);
+            core.info(JSON.stringify({
+              event: "pr-automation.classification-gate",
+              decision,
+            }));
 
   deterministic-analysis:
     name: Calculate deterministic labels


### PR DESCRIPTION
Preserve edge-triggered review dispatch for new or changed SHA-bound classification checks. Treat `ai-review/allow-oversized` as an explicit retry that forces actual reclassification and may redispatch unchanged state on the same head. Remove the unreachable cached-dispatch job so repeated unchanged classifications and unrelated label events remain inert.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>