### PR TITLE
ci(pr-automation): simplify review findings

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -28,7 +28,7 @@ Medium- and high-risk changes always require the skeptical specialist.
 Model output cannot select parallelism.
 
 Specialists use one bounded candidate schema.
-Each candidate binds to the expected head SHA, a configured reviewer ID, a changed path, an optional added-line range, and a unique finding ID.
+Each candidate binds to the expected head SHA, a configured reviewer ID, a changed path, an optional added-line range, a severity, a question flag, and a unique finding ID.
 Protocol candidates also carry structured protocol references.
 One specialist never receives another specialist's output.
 
@@ -36,7 +36,19 @@ The general reviewer independently inspects the pull request, attempts to falsif
 It can merge overlapping candidates and add findings that no specialist reported.
 Only the validated general-review result can be published.
 
-## Visible finding sources
+## Visible finding format and sources
+
+Published findings use severity as the only ranking signal:
+
+| Severity | Indicator |
+| --- | --- |
+| `critical` | `:purple_circle:` |
+| `high` | `:red_circle:` |
+| `medium` | `:orange_circle:` |
+| `low` | `:yellow_circle:` |
+
+Questions append `:question:` after the severity indicator.
+A successful review with no findings shows `:green_circle:` in its main comment.
 
 Workflow code derives a visible prefix from validated source references.
 The model cannot provide or override the prefix.

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -9,8 +9,7 @@ const { SIZE_LABELS, addedLinesByPath, analyzeFiles, parseLabelerRules } = requi
 const { SCHEMA_VERSION: CLASSIFIER_SCHEMA_VERSION, validateClassifier } = require("./validate-classifier");
 const { validateCandidateReview } = require("./validate-candidate-review");
 const {
-  SCHEMA_VERSION: FINAL_REVIEW_SCHEMA_VERSION, provenancePrefix,
-  validateFinalReview, validateNormalizedFinalReview,
+  provenancePrefix, validateFinalReview, validateNormalizedFinalReview,
 } = require("./validate-final-review");
 const { buildSpecialistAggregate, validateSpecialistRun } = require("./review-pipeline");
 const { resolveReviewerRoute, validateReviewerRoute } = require("./routing");
@@ -36,7 +35,7 @@ const {
 const SHA = "a".repeat(40);
 const OTHER_SHA = "b".repeat(40);
 const classifier = (changes = {}) => ({
-  schema_version: "1", head_sha: SHA, risk: "low", technical_debt: false, documentation_only: false,
+  head_sha: SHA, risk: "low", technical_debt: false, documentation_only: false,
   cross_cutting: false,
   duplicate: { detected: false, similar_pr_number: null, similar_pr_url: null, confidence: 0, rationale: "" },
   likely_non_legitimate: false, non_legitimate_confidence: 0, non_legitimate_reason: "",
@@ -46,22 +45,22 @@ const classifier = (changes = {}) => ({
 });
 
 const finding = (changes = {}) => ({
-  classification: "blocking", severity: "high", path: "src/lib.rs", start_line: 4, end_line: 4,
+  question: false, severity: "high", path: "src/lib.rs", start_line: 4, end_line: 4,
   title: "Incorrect boundary", rationale: "incorrect boundary", confidence: 0.9,
   sources: [],
   ...changes,
 });
 const review = (changes = {}) => ({
-  head_sha: SHA, summary: "finding", findings: [finding()], has_findings: true,
+  head_sha: SHA, summary: "finding", findings: [finding()],
   ...changes,
 });
 const candidateFinding = (changes = {}) => ({
-  id: "finding-1", classification: "blocking", severity: "high", path: "src/lib.rs",
+  id: "finding-1", question: false, severity: "high", path: "src/lib.rs",
   start_line: 4, end_line: 4, title: "Incorrect boundary", rationale: "incorrect boundary",
   confidence: 0.9, references: [], ...changes,
 });
 const candidateReview = (reviewer = "skeptical", changes = {}) => ({
-  schema_version: "1", head_sha: SHA, reviewer, summary: "candidate review",
+  head_sha: SHA, reviewer, summary: "candidate review",
   findings: [candidateFinding()], ...changes,
 });
 
@@ -515,6 +514,9 @@ test("candidate reviews require configured identity, changed paths, and paired l
   assert.equal(validateCandidateReview(candidateReview(), context).ok, true);
   assert.equal(validateCandidateReview(candidateReview("protocol"), context).ok, false);
   assert.equal(validateCandidateReview(candidateReview("skeptical", {
+    findings: [candidateFinding({ question: "yes" })],
+  }), context).ok, false);
+  assert.equal(validateCandidateReview(candidateReview("skeptical", {
     findings: [candidateFinding({ path: "unchanged.rs" })],
   }), context).ok, false);
   assert.equal(validateCandidateReview(candidateReview("skeptical", {
@@ -707,7 +709,7 @@ test("general reviewer accounts for every candidate and derives validated proven
       disposition: "refined", rationale: "the narrower claim is supported",
     }],
     findings: [{
-      classification: "blocking", severity: "high", path: "src/lib.rs",
+      question: false, severity: "high", path: "src/lib.rs",
       start_line: 4, end_line: 4, title: "[protocol] hostile title",
       rationale: "verified defect", confidence: 0.95,
       sources: [{ reviewer: "skeptical", finding_id: "finding-1" }],
@@ -723,7 +725,12 @@ test("general reviewer accounts for every candidate and derives validated proven
   assert.equal(result.ok, true);
   assert.equal(provenancePrefix(result.value.findings[0].sources), "[skeptical]");
   assert.equal(validateNormalizedFinalReview(result.value, SHA).ok, true);
+  assert.equal(validateNormalizedFinalReview({ ...result.value, has_findings: true }, SHA).ok, false);
   assert.equal(validateFinalReview({ ...raw, candidate_dispositions: [] }, context).ok, false);
+  assert.equal(validateFinalReview({
+    ...raw,
+    findings: [{ ...raw.findings[0], question: "yes" }],
+  }, context).ok, false);
   assert.equal(validateFinalReview({
     ...raw,
     candidate_dispositions: [{
@@ -1040,7 +1047,7 @@ test("all classified changes are reviewable unless a legitimacy or count gate bl
 });
 
 test("review publication applies the same policy the workflow spent its call on", () => {
-  const reviewer = review({ has_findings: false, summary: "none", findings: [] });
+  const reviewer = review({ summary: "none", findings: [] });
   const args = {
     expectedSha: SHA, reviewer, contributor: { status: "eligible" },
   };
@@ -1238,7 +1245,7 @@ test("forced classification bypasses policy, quota, and cache but still validate
 });
 
 test("forced review bypasses eligibility while retaining publication gates", () => {
-  const reviewer = review({ has_findings: false, summary: "none", findings: [] });
+  const reviewer = review({ summary: "none", findings: [] });
   const args = {
     expectedSha: SHA,
     labels: ["ai-reviewed/2", "duplicate", "size/XXL", "risk/low"],
@@ -1278,7 +1285,7 @@ test("forced review bypasses eligibility while retaining publication gates", () 
 });
 
 test("review transition is terminal-safe and preserves human triage on no findings", () => {
-  const reviewer = review({ has_findings: false, summary: "none", findings: [] });
+  const reviewer = review({ summary: "none", findings: [] });
   const state = resolveReviewState({
     expectedSha: SHA, labels: ["risk/high"], reviewer,
     gate: {
@@ -1288,6 +1295,8 @@ test("review transition is terminal-safe and preserves human triage on no findin
   });
   assert.deepEqual(state.labelSets[0].desired, ["ai-reviewed/1"]);
   assert.deepEqual(state.addLabels, ["maintainer-required"]);
+  assert.equal(state.comments.length, 1);
+  assert.deepEqual(state.comments[0].review, reviewer);
   assert.equal(resolveReviewState({
     expectedSha: SHA, labels: ["ai-reviewed/2"], reviewer,
     gate: {
@@ -1341,7 +1350,7 @@ test("review blockers distinguish gate and contributor history failures", () => 
 });
 
 test("an unavailable mandatory protocol specialist blocks the review count", () => {
-  const reviewer = review({ has_findings: false, summary: "none", findings: [] });
+  const reviewer = review({ summary: "none", findings: [] });
   const args = {
     expectedSha: SHA, labels: ["risk/high"], reviewer,
     gate: {
@@ -1531,7 +1540,7 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   const github = {
     paginate: { iterator: async function* () {
       yield { data: [{
-        id: 7, external_id: `${FINAL_REVIEW_SCHEMA_VERSION}:${SHA}`, conclusion: "neutral",
+        id: 7, external_id: SHA, conclusion: "neutral",
         output: { title: "Automated review unavailable", summary: "Model timed out." },
       }] };
     } },
@@ -1550,7 +1559,7 @@ test("writer upgrades a neutral automated review check instead of creating a dup
     state: {
       ok: true, mode: "review", expectedSha: SHA, labelSets: [], addLabels: [], comments: [],
       expectedReviewCount: null, forced: false, protocolRelated: true,
-      check: { name: "AI automated review", externalId: `${FINAL_REVIEW_SCHEMA_VERSION}:${SHA}` },
+      check: { name: "AI automated review", externalId: SHA },
     },
   });
   assert.equal(created, 0);
@@ -1765,7 +1774,7 @@ test("failed review check persistence does not consume review count", async () =
       expectedReviewCount: null, forced: false, protocolRelated: false,
       labelSets: [{ owned: ["ai-reviewed/1", "ai-reviewed/2"], desired: ["ai-reviewed/1"] }],
       addLabels: [], comments: [],
-      check: { name: "AI automated review", externalId: `${FINAL_REVIEW_SCHEMA_VERSION}:${SHA}` },
+      check: { name: "AI automated review", externalId: SHA },
     },
   }), /check failed/);
   assert.equal(labelWrites, 0);
@@ -1797,13 +1806,24 @@ test("writer publishes each finding either inline or in the review body", async 
           findings: [
             finding({
               start_line: 3,
+              severity: "critical",
+              question: true,
               title: "[protocol] untrusted title",
               rationale: "inline-only rationale",
               sources: [{ reviewer: "protocol", finding_id: "protocol-1" }],
             }),
             finding({
               path: "src/other.rs", start_line: null, end_line: null,
+              severity: "high",
               rationale: "body-only rationale",
+            }),
+            finding({
+              path: "src/medium.rs", start_line: null, end_line: null,
+              severity: "medium", rationale: "medium rationale",
+            }),
+            finding({
+              path: "src/low.rs", start_line: null, end_line: null,
+              severity: "low", rationale: "low rationale",
             }),
           ],
         }),
@@ -1818,10 +1838,46 @@ test("writer publishes each finding either inline or in the review body", async 
   assert.doesNotMatch(published.comments[0].body, /body-only rationale/);
   assert.match(published.comments[0].body, /^\*\*\[protocol\]/);
   assert.match(published.comments[0].body, /\\\[protocol\\\] untrusted title/);
+  assert.match(published.comments[0].body, /critical :purple_circle: :question:/);
+  assert.doesNotMatch(published.comments[0].body, /red_circle|orange_circle|yellow_circle/);
   assert.match(published.body, /review summary/);
   assert.match(published.body, /\[general\]/);
   assert.match(published.body, /body-only rationale/);
+  assert.match(published.body, /high :red_circle:/);
+  assert.match(published.body, /medium :orange_circle:/);
+  assert.match(published.body, /low :yellow_circle:/);
+  assert.doesNotMatch(published.body, /purple_circle|:question:|blocking|non_blocking/);
   assert.doesNotMatch(published.body, /inline-only rationale/);
+});
+
+test("writer publishes a green main comment when no findings remain", async () => {
+  let published;
+  const github = {
+    paginate: { iterator: async function* () { yield { data: [] }; } },
+    rest: {
+      pulls: {
+        listReviews: () => {},
+        get: async () => ({ data: { state: "open", head: { sha: SHA } } }),
+        createReview: async (payload) => { published = payload; },
+      },
+      issues: { get: async () => ({ data: { labels: [] } }) },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "review", expectedSha: SHA, labelSets: [], addLabels: [],
+      expectedReviewCount: null, forced: false, protocolRelated: false,
+      comments: [{
+        kind: "review",
+        marker: `<!-- ironrdp-pr-automation:review:${SHA} -->`,
+        review: review({ summary: "No findings identified.", findings: [] }),
+      }],
+    },
+  });
+
+  assert.deepEqual(published.comments, []);
+  assert.match(published.body, /:green_circle: No findings identified\./);
 });
 
 function paginated(pages) {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -112,6 +112,8 @@ test("automatic review requires exact-head CI and only reruns after a later push
   assert.match(reviewGate, /head_sha: headSha/);
   assert.match(reviewGate,
     /workflowRuns\.some\(\(run\) => run\?\.name === "CI" && run\?\.conclusion === "success"\)/);
+  assert.match(reviewGate,
+    /run\.conclusion === "success" && run\.app\?\.slug === "github-actions"/);
   assert.match(reviewGate, /const secondReviewEligible = !labels\.includes\("ai-reviewed\/1"\) \|\| !reviewAtHead/);
   assert.match(reviewGate,
     /ok: classificationCheck && ciGreen && secondReviewEligible && policyEligible/);

--- a/.github/pr-automation/prompts/code-compressor.md
+++ b/.github/pr-automation/prompts/code-compressor.md
@@ -8,7 +8,8 @@ Read `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff` first, 
 Read `pr-evidence/pull-request-context.json` before judging necessity or scope.
 Do not read or use output from any other specialist.
 
-Return only candidate-review JSON for the context head SHA with `schema_version` set to `"1"` and `reviewer` set to `"code-compressor"`.
+Return only candidate-review JSON for the context head SHA with `reviewer` set to `"code-compressor"`.
 Use unique stable kebab-case finding IDs and report only changed paths.
 Use line ranges only when every line is added by the diff; otherwise use null for both lines.
 Set every `references` array to empty.
+Rate severity by concrete impact, and set `question` to true only when missing context prevents a conclusion.

--- a/.github/pr-automation/prompts/general-reviewer.md
+++ b/.github/pr-automation/prompts/general-reviewer.md
@@ -17,5 +17,5 @@ Use an empty `sources` array only for findings discovered by this independent re
 Report only paths listed in `pr-evidence/changed-files.txt`.
 Include a line range only when every line was added by the pull request; otherwise use null for both line fields.
 Use concise titles and rationales.
-Map correctness, safety, architectural, API, protocol, and material maintainability defects to `blocking`.
-Use `non_blocking` for concrete improvements that do not justify rejection and `question` only when missing context prevents a conclusion.
+Rate severity by the concrete correctness, safety, architectural, API, protocol, or maintainability impact.
+Set `question` to true only when missing context prevents a conclusion.

--- a/.github/pr-automation/prompts/protocol-reviewer.md
+++ b/.github/pr-automation/prompts/protocol-reviewer.md
@@ -13,7 +13,7 @@ Return only JSON matching the supplied candidate-review schema for the context h
 Report only concrete protocol defects.
 Always provide a concise, nonempty review summary.
 Use unique stable IDs in the form `protocol-N`.
-Use `blocking`, `non_blocking`, or `question` for classification and `critical`, `high`, `medium`, or `low` for severity.
+Use `critical`, `high`, `medium`, or `low` for severity, and set `question` to true only when missing context prevents a conclusion.
 Restrict paths to files in `pr-evidence/changed-files.txt`.
 Set both line fields to changed lines on the new side, or set both to `null` when no safe inline location exists.
 Every finding requires at least one exact corpus reference with protocol ID, section number, and heading.

--- a/.github/pr-automation/prompts/skeptical.md
+++ b/.github/pr-automation/prompts/skeptical.md
@@ -8,9 +8,9 @@ Read `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff` first, 
 Read `pr-evidence/pull-request-context.json` before judging necessity or scope.
 Do not read or use output from any other specialist.
 
-Return only candidate-review JSON for the context head SHA with `schema_version` set to `"1"` and `reviewer` set to `"skeptical"`.
+Return only candidate-review JSON for the context head SHA with `reviewer` set to `"skeptical"`.
 Use unique stable kebab-case finding IDs and report only changed paths.
 Use line ranges only when every line is added by the diff; otherwise use null for both lines.
 Set every `references` array to empty.
 Omit formatting, naming, stylistic, speculative, and preference-only findings.
-Use `blocking` only for material defects, `non_blocking` for concrete quality improvements, and `question` only when missing context prevents a supported conclusion.
+Rate severity by concrete impact, and set `question` to true only when missing context prevents a supported conclusion.

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -1,10 +1,7 @@
 "use strict";
 
-const { SCHEMA_VERSION: CLASSIFIER_SCHEMA_VERSION } = require("./validate-classifier");
-const {
-  SCHEMA_VERSION: REVIEWER_SCHEMA_VERSION, validateNormalizedFinalReview,
-} = require("./validate-final-review");
-const { validateClassifier } = require("./validate-classifier");
+const { SCHEMA_VERSION: CLASSIFIER_SCHEMA_VERSION, validateClassifier } = require("./validate-classifier");
+const { validateNormalizedFinalReview } = require("./validate-final-review");
 const { resolveReviewerRoute, reviewPolicyEligible, validateReviewerRoute } = require("./routing");
 
 const RISK = ["risk/low", "risk/medium", "risk/high", "risk/unknown"];
@@ -273,7 +270,7 @@ function resolveReviewState({
         ...(comments.some((comment) => comment.kind === "global-quota") ? [] : [GLOBAL_QUOTA_MARKER]),
       ],
       ...(report ? { check: {
-        name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}`,
+        name: "AI automated review", externalId: expectedSha,
         title: "Automated review unavailable",
         summary: `Automated review was unavailable: ${reason}. Maintainer review is required.`,
         conclusion: "neutral",
@@ -330,19 +327,18 @@ function resolveReviewState({
   const expectedReviewCount = existing.has("ai-reviewed/2") ? "ai-reviewed/2"
     : existing.has("ai-reviewed/1") ? "ai-reviewed/1"
     : null;
-  const hasFindings = reviewerResult.value.has_findings;
+  const hasFindings = reviewerResult.value.findings.length > 0;
   const reviewMarker = `<!-- ironrdp-pr-automation:review:${expectedSha}` +
     `${forced ? `:force:${reviewMarkerId}` : ""} -->`;
   return {
     ok: true, mode: "review", expectedSha, labelSets: [{ owned: AI_COUNTS, desired: [nextCount] }],
     addLabels: nextCount === "ai-reviewed/2" || !hasFindings ? ["maintainer-required"] : [],
     removeLabels: nextCount === "ai-reviewed/1" && hasFindings ? ["maintainer-required"] : [],
-    comments: hasFindings ? [{ kind: "review", marker: reviewMarker,
-      review: reviewerResult.value }] : [],
+    comments: [{ kind: "review", marker: reviewMarker, review: reviewerResult.value }],
     removeCommentMarkers: [
       EVIDENCE_LIMIT_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER,
     ],
-    check: { name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}` },
+    check: { name: "AI automated review", externalId: expectedSha },
     expectedReviewCount,
     forced,
     protocolRelated: gate.protocolRelated === true,

--- a/.github/pr-automation/schemas/candidate-review.json
+++ b/.github/pr-automation/schemas/candidate-review.json
@@ -1,10 +1,8 @@
 {
-  "$id": "https://github.com/Devolutions/IronRDP/pr-automation/candidate-review-v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "head_sha", "reviewer", "summary", "findings"],
+  "required": ["head_sha", "reviewer", "summary", "findings"],
   "properties": {
-    "schema_version": { "const": "1" },
     "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "reviewer": { "enum": ["protocol", "skeptical", "code-compressor"] },
     "summary": { "type": "string", "minLength": 1, "maxLength": 1000 },
@@ -16,7 +14,7 @@
         "additionalProperties": false,
         "required": [
           "id",
-          "classification",
+          "question",
           "severity",
           "path",
           "start_line",
@@ -28,7 +26,7 @@
         ],
         "properties": {
           "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
-          "classification": { "enum": ["blocking", "non_blocking", "question"] },
+          "question": { "type": "boolean" },
           "severity": { "enum": ["critical", "high", "medium", "low"] },
           "path": {
             "type": "string",

--- a/.github/pr-automation/schemas/classifier.json
+++ b/.github/pr-automation/schemas/classifier.json
@@ -1,10 +1,8 @@
 {
-  "$id": "https://github.com/Devolutions/IronRDP/pr-automation/classifier-v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "head_sha", "risk", "technical_debt", "documentation_only", "cross_cutting", "duplicate", "likely_non_legitimate", "non_legitimate_confidence", "non_legitimate_reason", "breaking_change_suspected", "breaking_change_rationale", "breaking_change_surface", "protocol_related", "summary"],
+  "required": ["head_sha", "risk", "technical_debt", "documentation_only", "cross_cutting", "duplicate", "likely_non_legitimate", "non_legitimate_confidence", "non_legitimate_reason", "breaking_change_suspected", "breaking_change_rationale", "breaking_change_surface", "protocol_related", "summary"],
   "properties": {
-    "schema_version": { "const": "1" },
     "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "risk": { "enum": ["low", "medium", "high"] },
     "technical_debt": { "type": "boolean" },

--- a/.github/pr-automation/schemas/final-review.json
+++ b/.github/pr-automation/schemas/final-review.json
@@ -1,5 +1,4 @@
 {
-  "$id": "https://github.com/Devolutions/IronRDP/pr-automation/final-review-v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["head_sha", "summary", "candidate_dispositions", "findings"],
@@ -27,9 +26,9 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["classification", "severity", "path", "start_line", "end_line", "title", "rationale", "confidence", "sources"],
+        "required": ["question", "severity", "path", "start_line", "end_line", "title", "rationale", "confidence", "sources"],
         "properties": {
-          "classification": { "enum": ["blocking", "non_blocking", "question"] },
+          "question": { "type": "boolean" },
           "severity": { "enum": ["critical", "high", "medium", "low"] },
           "path": { "type": "string", "minLength": 1, "maxLength": 300, "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$)).+$" },
           "start_line": { "type": ["integer", "null"], "minimum": 1 },

--- a/.github/pr-automation/validate-candidate-review.js
+++ b/.github/pr-automation/validate-candidate-review.js
@@ -5,14 +5,12 @@ const {
 } = require("./validation");
 const { REVIEWER_ORDER: REVIEWERS } = require("./routing");
 
-const SCHEMA_VERSION = "candidate-review-v1";
-const CLASSIFICATIONS = new Set(["blocking", "non_blocking", "question"]);
 const SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const FINDING_ID = /^[a-z][a-z0-9-]{0,63}$/;
 const PROTOCOL_ID = /^(?:MS|MC)-[A-Z0-9]+$/;
 const SECTION = /^[0-9]+(?:\.[0-9]+)*$/;
 const FINDING_KEYS = [
-  "id", "classification", "severity", "path", "start_line", "end_line", "title", "rationale",
+  "id", "question", "severity", "path", "start_line", "end_line", "title", "rationale",
   "confidence", "references",
 ];
 const REFERENCE_KEYS = ["protocol_id", "section", "heading"];
@@ -32,8 +30,8 @@ function normalizeCandidateReview(raw, {
   expectedSha, expectedReviewer, changedPaths = [], changedLines = {},
 } = {}) {
   const value = parseJson(raw, 32768);
-  if (!exactKeys(value, ["schema_version", "head_sha", "reviewer", "summary", "findings"]) ||
-      value.schema_version !== "1" || !SHA.test(value.head_sha) || value.head_sha !== expectedSha ||
+  if (!exactKeys(value, ["head_sha", "reviewer", "summary", "findings"]) ||
+      !SHA.test(value.head_sha) || value.head_sha !== expectedSha ||
       !REVIEWERS.includes(value.reviewer) || value.reviewer !== expectedReviewer ||
       !Array.isArray(value.findings) || value.findings.length > 20) {
     return invalid("invalid candidate review object");
@@ -53,7 +51,7 @@ function normalizeCandidateReview(raw, {
     const title = normalizeText(finding.title, 200);
     const rationale = normalizeText(finding.rationale, 1200);
     if (!id || !FINDING_ID.test(id) || ids.has(id) ||
-        !CLASSIFICATIONS.has(finding.classification) || !SEVERITIES.has(finding.severity) ||
+        typeof finding.question !== "boolean" || !SEVERITIES.has(finding.severity) ||
         path === null || Buffer.byteLength(path, "utf8") > 300 || path.includes("\\") ||
         !REPO_PATH.test(path) || !paths.has(path) || !title || !rationale ||
         !Number.isFinite(finding.confidence) || finding.confidence < 0 || finding.confidence > 1 ||
@@ -79,7 +77,7 @@ function normalizeCandidateReview(raw, {
     ids.add(id);
     findings.push({
       id,
-      classification: finding.classification,
+      question: finding.question,
       severity: finding.severity,
       path,
       start_line: locationIsValidated ? finding.start_line : null,
@@ -92,7 +90,6 @@ function normalizeCandidateReview(raw, {
   }
 
   const normalized = {
-    schema_version: "1",
     head_sha: value.head_sha,
     reviewer: value.reviewer,
     summary,
@@ -101,10 +98,9 @@ function normalizeCandidateReview(raw, {
   if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > 32768) {
     return invalid("candidate review output too large");
   }
-  return { ok: true, status: "valid", schemaVersion: SCHEMA_VERSION, value: normalized };
+  return { ok: true, status: "valid", value: normalized };
 }
 
 module.exports = {
-  SCHEMA_VERSION, normalizeCandidateReview,
-  validateCandidateReview: normalizeCandidateReview,
+  normalizeCandidateReview, validateCandidateReview: normalizeCandidateReview,
 };

--- a/.github/pr-automation/validate-classifier.js
+++ b/.github/pr-automation/validate-classifier.js
@@ -27,15 +27,13 @@ function validateClassifier(raw, {
   }
   const value = parseJson(raw, 4096);
   const required = [
-    "schema_version", "head_sha", "risk", "technical_debt", "documentation_only", "cross_cutting", "duplicate",
+    "head_sha", "risk", "technical_debt", "documentation_only", "cross_cutting", "duplicate",
     "likely_non_legitimate", "non_legitimate_confidence", "non_legitimate_reason",
     "breaking_change_suspected", "breaking_change_rationale", "breaking_change_surface",
     "protocol_related", "summary",
   ];
   if (!exactKeys(value, required)) return invalid("invalid classifier object");
-  if (value.schema_version !== "1" || !SHA.test(value.head_sha) || value.head_sha !== expectedSha) {
-    return invalid("classifier schema version or SHA mismatch");
-  }
+  if (!SHA.test(value.head_sha) || value.head_sha !== expectedSha) return invalid("classifier SHA mismatch");
   if (!["low", "medium", "high"].includes(value.risk) ||
       typeof value.technical_debt !== "boolean" || typeof value.documentation_only !== "boolean" ||
       typeof value.cross_cutting !== "boolean" ||
@@ -97,7 +95,7 @@ function validateClassifier(raw, {
     return invalid("documentation-only conflicts with technical debt");
   }
   const normalized = {
-    schema_version: value.schema_version, head_sha: value.head_sha, risk: value.risk, technical_debt: value.technical_debt,
+    head_sha: value.head_sha, risk: value.risk, technical_debt: value.technical_debt,
     documentation_only: value.documentation_only, cross_cutting: value.cross_cutting, duplicate: {
       detected: duplicate.detected, similar_pr_number: duplicate.similar_pr_number,
       similar_pr_url: duplicate.similar_pr_url, confidence: duplicate.confidence, rationale,
@@ -110,7 +108,7 @@ function validateClassifier(raw, {
     protocol_related: value.protocol_related, summary,
   };
   if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > 4096) return invalid("classifier output too large");
-  return { ok: true, status: "valid", schemaVersion: SCHEMA_VERSION, value: normalized };
+  return { ok: true, status: "valid", value: normalized };
 }
 
 function encodeCheckState({

--- a/.github/pr-automation/validate-final-review.js
+++ b/.github/pr-automation/validate-final-review.js
@@ -5,10 +5,10 @@ const {
 } = require("./validation");
 const { REVIEWER_ORDER: REVIEWERS } = require("./routing");
 
-const SCHEMA_VERSION = "final-review-v1";
 const MAXIMUM_BYTES = 65536;
 const MAXIMUM_CANDIDATES = 60;
 const MAXIMUM_FINDINGS = 20;
+const SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const FINDING_ID = /^[a-z][a-z0-9-]{0,63}$/;
 const REVIEWER_ORDER = new Map(REVIEWERS.map((reviewer, index) => [reviewer, index]));
 
@@ -45,7 +45,7 @@ function aggregateCandidates(specialistAggregate, expectedSha) {
   const candidates = new Map();
   let previousReviewer = -1;
   const candidateKeys = [
-    "id", "classification", "severity", "path", "start_line", "end_line", "title", "rationale",
+    "id", "question", "severity", "path", "start_line", "end_line", "title", "rationale",
     "confidence", "references",
   ];
   for (const review of aggregate.reviewers) {
@@ -63,8 +63,8 @@ function aggregateCandidates(specialistAggregate, expectedSha) {
         !isBoundedArray(review.findings, MAXIMUM_FINDINGS)) return null;
     for (const candidate of review.findings) {
       if (!exactKeys(candidate, candidateKeys) ||
-          !["blocking", "non_blocking", "question"].includes(candidate.classification) ||
-          !["critical", "high", "medium", "low"].includes(candidate.severity) ||
+          typeof candidate.question !== "boolean" ||
+          !SEVERITIES.has(candidate.severity) ||
           !Array.isArray(candidate.references)) return null;
       const reference = normalizeReference({
         reviewer: review.reviewer,
@@ -100,12 +100,12 @@ function normalizeDispositions(entries, candidates) {
 
 function normalizeFinding(finding, changedPaths, changedLines, dispositions, referencedCandidates) {
   const keys = [
-    "classification", "severity", "path", "start_line", "end_line", "title", "rationale",
+    "question", "severity", "path", "start_line", "end_line", "title", "rationale",
     "confidence", "sources",
   ];
   if (!exactKeys(finding, keys) ||
-      !["blocking", "non_blocking", "question"].includes(finding.classification) ||
-      !["critical", "high", "medium", "low"].includes(finding.severity) ||
+      typeof finding.question !== "boolean" ||
+      !SEVERITIES.has(finding.severity) ||
       typeof finding.path !== "string" || Buffer.byteLength(finding.path, "utf8") > 300 ||
       finding.path.includes("\\") || !REPO_PATH.test(finding.path) || !changedPaths.has(finding.path) ||
       !Number.isFinite(finding.confidence) || finding.confidence < 0 || finding.confidence > 1 ||
@@ -140,7 +140,7 @@ function normalizeFinding(finding, changedPaths, changedLines, dispositions, ref
   const locationIsValidated = linesAreNull ||
     linesAreValidated(finding.path, finding.start_line, finding.end_line, changedLines);
   return {
-    classification: finding.classification,
+    question: finding.question,
     severity: finding.severity,
     path: finding.path,
     start_line: locationIsValidated ? finding.start_line : null,
@@ -192,37 +192,34 @@ function validateFinalReview(raw, {
     head_sha: value.head_sha,
     summary,
     findings,
-    has_findings: findings.length > 0,
   };
   if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > MAXIMUM_BYTES) {
     return invalid("final review output too large");
   }
-  return { ok: true, status: "valid", schemaVersion: SCHEMA_VERSION, value: normalized };
+  return { ok: true, status: "valid", value: normalized };
 }
 
 function validateNormalizedFinalReview(value, expectedSha) {
   if (!exactKeys(value, [
-    "head_sha", "summary", "findings", "has_findings",
+    "head_sha", "summary", "findings",
   ]) || value.head_sha !== expectedSha || !SHA.test(value.head_sha) ||
-      typeof value.has_findings !== "boolean" ||
-      value.has_findings !== (Array.isArray(value.findings) && value.findings.length > 0) ||
       !isBoundedArray(value.findings, MAXIMUM_FINDINGS)) return invalid("invalid validated final review");
   for (const finding of value.findings) {
     if (!exactKeys(finding, [
-      "classification", "severity", "path", "start_line", "end_line", "title", "rationale",
+      "question", "severity", "path", "start_line", "end_line", "title", "rationale",
       "confidence", "sources",
-    ])) return invalid("invalid validated final review finding");
+    ]) || typeof finding.question !== "boolean" ||
+        !SEVERITIES.has(finding.severity)) return invalid("invalid validated final review finding");
     try {
       provenancePrefix(finding.sources);
     } catch {
       return invalid("invalid validated final review source");
     }
   }
-  return { ok: true, status: "valid", schemaVersion: SCHEMA_VERSION, value };
+  return { ok: true, status: "valid", value };
 }
 
 module.exports = {
-  MAXIMUM_CANDIDATES, MAXIMUM_FINDINGS, REVIEWERS, SCHEMA_VERSION,
-  provenancePrefix, sourceCategories, validateFinalReview,
+  MAXIMUM_CANDIDATES, MAXIMUM_FINDINGS, REVIEWERS, provenancePrefix, sourceCategories, validateFinalReview,
   validateNormalizedFinalReview,
 };

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -4,6 +4,13 @@ const { encodeCheckState } = require("./validate-classifier");
 const { provenancePrefix } = require("./validate-final-review");
 const { reviewPolicyEligible } = require("./routing");
 
+const SEVERITY_EMOJI = {
+  critical: ":purple_circle:",
+  high: ":red_circle:",
+  medium: ":orange_circle:",
+  low: ":yellow_circle:",
+};
+
 class StaleHeadError extends Error {
   constructor() { super("pull request head is no longer current"); this.name = "StaleHeadError"; }
 }
@@ -22,6 +29,11 @@ function escapeMarkdown(value) {
     .replace(/"/g, "&quot;").replace(/'/g, "&#39;").replace(/`/g, "&#96;")
     .replace(/@(?=[\w-])/g, "`@`").replace(/(?<!&)#(?=\d)/g, "`#`")
     .replace(/[[\]()!*_~|]/g, "\\$&");
+}
+
+function findingIndicator(finding) {
+  return `${finding.severity} ${SEVERITY_EMOJI[finding.severity]}` +
+    `${finding.question ? " :question:" : ""}`;
 }
 
 async function assertCurrentHead(github, owner, repo, prNumber, expectedSha) {
@@ -90,10 +102,11 @@ async function deleteMarkedComment(github, owner, repo, prNumber, expectedSha, b
 function reviewBody(marker, review) {
   const findings = review.findings.filter((finding) => finding.start_line === null).map((finding, index) => {
     return `${index + 1}. **${provenancePrefix(finding.sources)} ${escapeMarkdown(finding.title)}** — ` +
-      `${finding.classification} / ${finding.severity} — ${escapeMarkdown(finding.path)}\n` +
+      `${findingIndicator(finding)} — ${escapeMarkdown(finding.path)}\n` +
       `   ${escapeMarkdown(finding.rationale)}`;
   }).join("\n");
-  return `${marker}\n\n${escapeMarkdown(review.summary)}${findings ? `\n\n${findings}` : ""}`;
+  const clean = review.findings.length === 0 ? ":green_circle: " : "";
+  return `${marker}\n\n${clean}${escapeMarkdown(review.summary)}${findings ? `\n\n${findings}` : ""}`;
 }
 
 async function reviews(github, owner, repo, prNumber) {
@@ -125,7 +138,7 @@ async function publishReview(github, owner, repo, prNumber, state, botLogin, com
     const comment = {
       path: finding.path, line: finding.end_line, side: "RIGHT",
       body: `**${provenancePrefix(finding.sources)} ${escapeMarkdown(finding.title)}** — ` +
-        `${finding.classification} / ${finding.severity}: ${escapeMarkdown(finding.rationale)}`,
+        `${findingIndicator(finding)} — ${escapeMarkdown(finding.rationale)}`,
     };
     if (finding.start_line !== finding.end_line) {
       comment.start_line = finding.start_line;

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -50,7 +50,7 @@ The general reviewer independently inspects the pull request, attempts to falsif
 It can merge overlapping candidates and add findings that no specialist reported.
 Only the validated general-review result can be published.
 The published comments include the name of the specialist that found the finding.
-Reviewer findings use severity and a question boolean without classification.
+Reviewer findings use severity and a question boolean.
 Render severity as `critical :purple_circle:`, `high :red_circle:`, `medium :orange_circle:`, or `low :yellow_circle:`.
 Append `:question:` for questions, and show `:green_circle:` in the main comment when no findings are found.
 

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -9,6 +9,7 @@ To use the 5 parallel requests as efficiently as possible:
 - Run at most one reviewer pipeline with at most 3 specialist reviews in parallel.
 
 That totals at most 5 parallel requests at any time.
+All model-output schemas are internal and unversioned.
 
 For simplicity, derive static concurrency lanes from the pull request number instead of using an external semaphore service.
 
@@ -49,10 +50,13 @@ The general reviewer independently inspects the pull request, attempts to falsif
 It can merge overlapping candidates and add findings that no specialist reported.
 Only the validated general-review result can be published.
 The published comments include the name of the specialist that found the finding.
+Reviewer findings use severity and a question boolean without classification.
+Render severity as `critical :purple_circle:`, `high :red_circle:`, `medium :orange_circle:`, or `low :yellow_circle:`.
+Append `:question:` for questions, and show `:green_circle:` in the main comment when no findings are found.
 
 ### Specialist reviewers
 
-Currently we define three specialist reviewers:
+Use three specialist reviewers:
 
 - protocol
 - skeptical

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -600,7 +600,8 @@ jobs:
                 owner: context.repo.owner, repo: context.repo.repo, ref: headSha,
                 check_name: "AI automated review", per_page: 100,
               });
-              const reviewAtHead = completed(reviewRuns, headSha)?.conclusion === "success";
+              const reviewAtHead = reviewRuns.data.check_runs.some((run) =>
+                run.conclusion === "success" && run.app?.slug === "github-actions");
               const workflowRuns = process.env.ROUTE === "ci" ? [context.payload.workflow_run] :
                 (await github.rest.actions.listWorkflowRunsForRepo({
                   owner: context.repo.owner, repo: context.repo.repo, head_sha: headSha, per_page: 100,

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -537,7 +537,6 @@ jobs:
         with:
           script: |
             const { SCHEMA_VERSION, parseCheckState } = require("./.github/pr-automation/validate-classifier");
-            const { SCHEMA_VERSION: REVIEWER_SCHEMA_VERSION } = require("./.github/pr-automation/validate-final-review");
             const { contributorEligibility, reviewPolicyEligible } = require("./.github/pr-automation/resolve-state");
             const { resolveReviewerRoute } = require("./.github/pr-automation/routing");
             const prNumber = Number(process.env.PULL_REQUEST_NUMBER);
@@ -601,7 +600,7 @@ jobs:
                 owner: context.repo.owner, repo: context.repo.repo, ref: headSha,
                 check_name: "AI automated review", per_page: 100,
               });
-              const reviewAtHead = completed(reviewRuns, `${REVIEWER_SCHEMA_VERSION}:${headSha}`)?.conclusion === "success";
+              const reviewAtHead = completed(reviewRuns, headSha)?.conclusion === "success";
               const workflowRuns = process.env.ROUTE === "ci" ? [context.payload.workflow_run] :
                 (await github.rest.actions.listWorkflowRunsForRepo({
                   owner: context.repo.owner, repo: context.repo.repo, head_sha: headSha, per_page: 100,


### PR DESCRIPTION
Report severity as the actionable review signal and leave blocking decisions to pull request authors.

Remove redundant classification and model-schema version fields, retain questions as a boolean marker, and publish a green review when no findings remain.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>