### PR TITLE
ci(pr-automation): explain reviewer ineligibility

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -15,8 +15,8 @@ const { buildSpecialistAggregate, validateSpecialistRun } = require("./review-pi
 const { resolveReviewerRoute, validateReviewerRoute } = require("./routing");
 const {
   resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
-  EVIDENCE_LIMIT_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX,
-  OVERSIZED_MARKER, OVERSIZED_REVIEW_LABEL, contributorEligibility,
+  CONTRIBUTOR_INELIGIBLE_MARKER, EVIDENCE_LIMIT_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL,
+  LEGITIMACY_MARKER_PREFIX, OVERSIZED_MARKER, OVERSIZED_REVIEW_LABEL, contributorEligibility,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const { resolveClassificationGate } = require("./classification-gate");
@@ -1330,6 +1330,14 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(ineligible.ok, true);
   assert.equal(ineligible.failed, true);
   assert.equal(ineligible.reason, "contributor history ineligible (merged: 0, required: 1)");
+  assert.deepEqual(ineligible.comments, [{
+    kind: "contributor-ineligible", marker: CONTRIBUTOR_INELIGIBLE_MARKER,
+  }]);
+  assert.equal(ineligible.removeCommentMarkers.includes(CONTRIBUTOR_INELIGIBLE_MARKER), false);
+  const ineligibleBody = markerBody(ineligible.comments[0], "Devolutions", "IronRDP");
+  assert.match(ineligibleBody, /Automated review will not run/);
+  assert.match(ineligibleBody, /automation policy/);
+  assert.match(ineligibleBody, /Maintainer review is required/);
 
   const unavailable = resolveReviewState({
     ...args, contributor: { status: "unavailable", reason: "GitHub API unavailable" },
@@ -1337,6 +1345,7 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(unavailable.ok, true);
   assert.equal(unavailable.failed, true);
   assert.equal(unavailable.reason, "contributor history unavailable: GitHub API unavailable");
+  assert.equal(unavailable.removeCommentMarkers.includes(CONTRIBUTOR_INELIGIBLE_MARKER), false);
 
   const secondReview = resolveReviewState({
     ...args, labels: ["ai-reviewed/1", "risk/high"],
@@ -1349,6 +1358,20 @@ test("review blockers distinguish gate and contributor history failures", () => 
     gate: { ...args.gate, policyEligible: false, protocolRelated: false },
   });
   assert.equal(policy.reason, "review is not eligible");
+});
+
+test("a later eligible review removes the contributor-ineligible comment", () => {
+  const state = resolveReviewState({
+    expectedSha: SHA, labels: ["risk/low"], reviewer: review({ findings: [] }),
+    gate: {
+      ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true,
+      risk: "low", protocolRelated: false, specialistReviewers: ["code-compressor"],
+    },
+    contributor: { status: "eligible", merged: 1 },
+  });
+
+  assert.equal(state.failed, undefined);
+  assert.equal(state.removeCommentMarkers.includes(CONTRIBUTOR_INELIGIBLE_MARKER), true);
 });
 
 test("an unavailable mandatory protocol specialist blocks the review count", () => {
@@ -1437,6 +1460,52 @@ test("writer stops before mutations when review policy or count changes", async 
     },
   }), StalePolicyError);
   assert.equal(writes, 0);
+});
+
+test("writer keeps one contributor-ineligible comment and removes it after eligibility changes", async () => {
+  const issueComments = [];
+  let nextCommentId = 1;
+  const github = {
+    paginate: { iterator: async function* () { yield { data: issueComments }; } },
+    rest: {
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: {
+        get: async () => ({ data: { labels: ["maintainer-required", "risk/low"] } }),
+        listComments: () => {},
+        createComment: async ({ body }) => {
+          issueComments.push({ id: nextCommentId++, body, user: { login: "github-actions[bot]" } });
+        },
+        deleteComment: async ({ comment_id: commentId }) => {
+          issueComments.splice(issueComments.findIndex((comment) => comment.id === commentId), 1);
+        },
+      },
+    },
+  };
+  const gate = {
+    ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true,
+    risk: "low", protocolRelated: false, specialistReviewers: ["code-compressor"],
+  };
+  const state = resolveReviewState({
+    expectedSha: SHA, labels: ["risk/low"], gate,
+    contributor: { status: "ineligible", merged: 0 },
+  });
+  const args = {
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1,
+    botLogin: "github-actions[bot]",
+  };
+
+  await writeState({ ...args, state });
+  await writeState({ ...args, state });
+  assert.equal(issueComments.length, 1);
+  assert.match(issueComments[0].body, /Automated review will not run/);
+
+  const eligibleState = resolveReviewState({
+    expectedSha: SHA, labels: ["risk/low"],
+    gate: { ...gate, classificationCheck: false },
+    contributor: { status: "eligible", merged: 1 },
+  });
+  await writeState({ ...args, state: eligibleState });
+  assert.deepEqual(issueComments, []);
 });
 
 test("writer publishes classification audit comments", async () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1338,6 +1338,7 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.match(ineligibleBody, /Automated review will not run/);
   assert.match(ineligibleBody, /automation policy/);
   assert.match(ineligibleBody, /Maintainer review is required/);
+  assert.equal(ineligibleBody.match(/LLM-assisted content \(no human feedback\)\./g)?.length, 1);
 
   const unavailable = resolveReviewState({
     ...args, contributor: { status: "unavailable", reason: "GitHub API unavailable" },

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1330,15 +1330,12 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(ineligible.ok, true);
   assert.equal(ineligible.failed, true);
   assert.equal(ineligible.reason, "contributor history ineligible (merged: 0, required: 1)");
+  assert.deepEqual(ineligible.labelSets, []);
+  assert.deepEqual(ineligible.addLabels, ["maintainer-required"]);
   assert.deepEqual(ineligible.comments, [{
     kind: "contributor-ineligible", marker: CONTRIBUTOR_INELIGIBLE_MARKER,
   }]);
   assert.equal(ineligible.removeCommentMarkers.includes(CONTRIBUTOR_INELIGIBLE_MARKER), false);
-  const ineligibleBody = markerBody(ineligible.comments[0], "Devolutions", "IronRDP");
-  assert.match(ineligibleBody, /Automated review will not run/);
-  assert.match(ineligibleBody, /automation policy/);
-  assert.match(ineligibleBody, /Maintainer review is required/);
-  assert.equal(ineligibleBody.match(/LLM-assisted content \(no human feedback\)\./g)?.length, 1);
 
   const unavailable = resolveReviewState({
     ...args, contributor: { status: "unavailable", reason: "GitHub API unavailable" },
@@ -1498,7 +1495,7 @@ test("writer keeps one contributor-ineligible comment and removes it after eligi
   await writeState({ ...args, state });
   await writeState({ ...args, state });
   assert.equal(issueComments.length, 1);
-  assert.match(issueComments[0].body, /Automated review will not run/);
+  assert.equal(issueComments[0].body.startsWith(CONTRIBUTOR_INELIGIBLE_MARKER), true);
 
   const eligibleState = resolveReviewState({
     expectedSha: SHA, labels: ["risk/low"],

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -15,6 +15,7 @@ const LEGACY_XL_MARKER = "<!-- ironrdp-pr-automation:xl -->";
 const FORK_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-quota -->";
 const GLOBAL_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-global-budget -->";
 const EVIDENCE_LIMIT_MARKER = "<!-- ironrdp-pr-automation:evidence-limit -->";
+const CONTRIBUTOR_INELIGIBLE_MARKER = "<!-- ironrdp-pr-automation:contributor-ineligible -->";
 const EVIDENCE_LIMIT_REASON = /^pull request diff exceeds the (1|4) MiB evidence limit$/;
 const ELIGIBLE_MERGED_PRS = 1;
 const ELIGIBLE_ASSOCIATIONS = new Set(["OWNER", "MEMBER"]);
@@ -256,10 +257,11 @@ function resolveReviewState({
 } = {}) {
   const existing = labelsOf(labels);
   const forced = force === true;
-  const fail = (reason, report = false) => {
+  const fail = (reason, report = false, contributorComment = null) => {
     const comments = [
       forced ? null : quotaComment(rateLimit),
       evidenceLimitComment(reason),
+      contributorComment,
     ].filter(Boolean);
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
@@ -268,6 +270,7 @@ function resolveReviewState({
         ...(comments.some((comment) => comment.kind === "evidence-limit") ? [] : [EVIDENCE_LIMIT_MARKER]),
         FORK_QUOTA_MARKER,
         ...(comments.some((comment) => comment.kind === "global-quota") ? [] : [GLOBAL_QUOTA_MARKER]),
+        ...(forced || contributor?.status === "eligible" ? [CONTRIBUTOR_INELIGIBLE_MARKER] : []),
       ],
       ...(report ? { check: {
         name: "AI automated review", externalId: expectedSha,
@@ -301,7 +304,10 @@ function resolveReviewState({
       const reason = Number.isSafeInteger(contributor.merged)
         ? `contributor history ineligible (merged: ${contributor.merged}, required: ${ELIGIBLE_MERGED_PRS})`
         : `contributor history ineligible${contributor.reason ? `: ${contributor.reason}` : ""}`;
-      return fail(reason);
+      const comment = Number.isSafeInteger(contributor.merged)
+        ? { kind: "contributor-ineligible", marker: CONTRIBUTOR_INELIGIBLE_MARKER }
+        : null;
+      return fail(reason, false, comment);
     }
     if (contributor?.status !== "eligible") {
       const reason = contributor?.reason
@@ -337,6 +343,7 @@ function resolveReviewState({
     comments: [{ kind: "review", marker: reviewMarker, review: reviewerResult.value }],
     removeCommentMarkers: [
       EVIDENCE_LIMIT_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER,
+      CONTRIBUTOR_INELIGIBLE_MARKER,
     ],
     check: { name: "AI automated review", externalId: expectedSha },
     expectedReviewCount,
@@ -346,8 +353,8 @@ function resolveReviewState({
 }
 
 module.exports = {
-  AI_COUNTS, DUPLICATE_MARKER, EVIDENCE_LIMIT_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER,
-  LEGACY_XL_MARKER, LEGITIMACY_LABEL,
+  AI_COUNTS, CONTRIBUTOR_INELIGIBLE_MARKER, DUPLICATE_MARKER, EVIDENCE_LIMIT_MARKER,
+  FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL,
   LEGITIMACY_MARKER_PREFIX, OVERSIZED_REVIEW_LABEL, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS,
   contributorEligibility, qualifyingMergedPrs, resolveClassificationState,
   resolveReviewState, reviewPolicyEligible,

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -71,7 +71,7 @@ function markerBody(comment, owner, repo) {
     return `${comment.marker}\n\nAutomated model analysis stopped because this pull request's diff exceeds the ${comment.limitMiB} MiB evidence limit. No model was invoked with partial evidence.\n\n${guidance} Maintainer review is required.`;
   }
   if (comment.kind === "contributor-ineligible") {
-    return `${comment.marker}\n\nAutomated review will not run because this contributor is not yet eligible under the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md).\n\nContributors become eligible after one qualifying IronRDP pull request is merged into \`master\`. Maintainer review is required.`;
+    return `${comment.marker}\n\nAutomated review will not run because this contributor is not yet eligible under the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md).\n\nContributors become eligible after one qualifying IronRDP pull request is merged into \`master\`. Maintainer review is required.\n\n> [!NOTE]\n> LLM-assisted content (no human feedback).`;
   }
   throw new Error("unsupported issue comment");
 }

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -70,6 +70,9 @@ function markerBody(comment, owner, repo) {
       : "The 4 MiB limit is the model runtime maximum. Please split the change into focused pull requests or reduce generated content.";
     return `${comment.marker}\n\nAutomated model analysis stopped because this pull request's diff exceeds the ${comment.limitMiB} MiB evidence limit. No model was invoked with partial evidence.\n\n${guidance} Maintainer review is required.`;
   }
+  if (comment.kind === "contributor-ineligible") {
+    return `${comment.marker}\n\nAutomated review will not run because this contributor is not yet eligible under the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md).\n\nContributors become eligible after one qualifying IronRDP pull request is merged into \`master\`. Maintainer review is required.`;
+  }
   throw new Error("unsupported issue comment");
 }
 

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -71,7 +71,7 @@ function markerBody(comment, owner, repo) {
     return `${comment.marker}\n\nAutomated model analysis stopped because this pull request's diff exceeds the ${comment.limitMiB} MiB evidence limit. No model was invoked with partial evidence.\n\n${guidance} Maintainer review is required.`;
   }
   if (comment.kind === "contributor-ineligible") {
-    return `${comment.marker}\n\nAutomated review will not run because this contributor is not yet eligible under the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md).\n\nContributors become eligible after one qualifying IronRDP pull request is merged into \`master\`. Maintainer review is required.\n\n> [!NOTE]\n> LLM-assisted content (no human feedback).`;
+    return `${comment.marker}\n\nAutomated review will not run because this contributor is not yet eligible under the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md).\n\nContributors become eligible after one qualifying IronRDP pull request is merged into \`master\`. Maintainer review is required.`;
   }
   throw new Error("unsupported issue comment");
 }


### PR DESCRIPTION
Post a bounded policy comment when contributor history blocks review.

Reuse the marker lifecycle to avoid duplicates and remove stale guidance
after eligibility changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>