### PR TITLE
fix(web): restore default remote cursor rendering

### DIFF
--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1503,7 +1503,7 @@ fn build_config(
         client_dir: "C:\\Windows\\System32\\mstscax.dll".to_owned(),
         platform: ironrdp::pdu::rdp::capability_sets::MajorPlatformType::UNSPECIFIED,
         compression_type: None,
-        enable_server_pointer: false,
+        enable_server_pointer: true,
         autologon: false,
         enable_audio_playback: false,
         enable_audio_capture: false,


### PR DESCRIPTION
`build_config()` has hardcoded `enable_server_pointer: false` since the
`no_server_pointer` to `enable_server_pointer` rename (218fed03) inverted
the flag's polarity without updating this literal. The CLI call site in
the same commit correctly negated the old value (`!args.no_server_pointer`);
this bare literal in `ironrdp-web` was missed.

The native client already defaults to `true`
(`ClientBuilder::enable_server_pointer.unwrap_or(true)`), so this restores
parity. Today, remote cursor shapes silently never render in the web
client: `ironrdp-session::fast_path::process_pointer_update` returns on
its first line when the flag is `false`, with no error at any log level,
so the regression is invisible until someone reads the source.

Fixes #1900, which independently rebuilt the wasm package with this exact
one-line change and verified all remote cursor shapes work correctly
against a real Windows Server host.

Not bundled here: the issue also suggests exposing this setting on
`SessionBuilder` so embedders can turn it off deliberately, since nothing
in the current public API reaches it. Leaving that as a separate,
smaller follow-up rather than widening this fix's scope.

`cargo xtask check fmt/lints/tests/typos/locks` and `cargo xtask wasm check` all pass.