### PR TITLE
fix(pdu): keep undefined channel option bits instead of refusing

### DIFF
--- a/crates/ironrdp-pdu/src/gcc/network_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/network_data.rs
@@ -279,8 +279,23 @@ impl<'de> Decode<'de> for ChannelDef {
         let name = src.read_array();
         let name = ChannelName::new(name);
 
-        let options = ChannelOptions::from_bits(src.read_u32())
-            .ok_or_else(|| invalid_field_err!("options", "invalid channel options", in: src))?;
+        // Undefined bits are kept rather than rejected. [MS-RDPBCGR]
+        // 2.2.1.3.4.1 never asks a server to validate this field, and for five
+        // of the eleven flags it asks the opposite: CHANNEL_OPTION_INITIALIZED,
+        // ENCRYPT_RDP, ENCRYPT_SC and ENCRYPT_CS are each "unused and its value
+        // MUST be ignored by the server", and SHOW_PROTOCOL likewise.
+        //
+        // Rejecting is not only stricter than the protocol, it costs real
+        // sessions. rdesktop 1.9.0 writes this one field big-endian while the
+        // rest of the block is little-endian (secure.c:516 uses
+        // `out_uint32_be`), so every channel it registers arrives byte-swapped
+        // and every bit lands outside the mask -- and a server that rejects
+        // drops the connection at GCC, before any channel is joined.
+        //
+        // This is the "peer advertisements" case in STYLE.md's "Decoding
+        // unknown values": `from_bits_retain` keeps the unknown bits so that a
+        // decode -> encode round-trip reproduces the wire bytes.
+        let options = ChannelOptions::from_bits_retain(src.read_u32());
 
         Ok(Self { name, options })
     }
@@ -301,5 +316,61 @@ bitflags! {
         const COMPRESS = 0x0040_0000;
         const SHOW_PROTOCOL = 0x0020_0000;
         const REMOTE_CONTROL_PERSISTENT = 0x0010_0000;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel_def(name: &[u8; 8], options: u32) -> Vec<u8> {
+        let mut bytes = name.to_vec();
+        bytes.extend_from_slice(&options.to_le_bytes());
+        bytes
+    }
+
+    /// [MS-RDPBCGR] 2.2.1.3.4.1 asks the server to ignore several of these
+    /// flags and never asks it to validate the field, so a bit the server does
+    /// not know is not a reason to refuse the connection. The known bits are
+    /// still readable, and the unknown ones are kept rather than dropped.
+    #[test]
+    fn undefined_option_bits_are_kept_rather_than_refused() {
+        let known = ChannelOptions::INITIALIZED | ChannelOptions::COMPRESS_RDP;
+        let bytes = channel_def(b"rdpdr\0\0\0", known.bits() | 0x0000_0044);
+
+        let decoded = ChannelDef::decode(&mut ReadCursor::new(&bytes)).expect("undefined bits are not fatal");
+
+        assert!(decoded.options.contains(known));
+        assert_eq!(decoded.options.bits(), known.bits() | 0x0000_0044);
+    }
+
+    /// The value rdesktop 1.9.0 actually puts on the wire for its clipboard
+    /// channel: its flags written big-endian in a little-endian field, so every
+    /// set bit is undefined. Refusing it drops the connection at GCC, before a
+    /// single channel is joined; keeping the bits lets the channel through.
+    #[test]
+    fn a_wholly_undefined_value_still_yields_a_channel() {
+        let raw = u32::from_le_bytes([0xc0, 0xa0, 0x00, 0x00]);
+        let bytes = channel_def(b"cliprdr\0", raw);
+
+        let decoded = ChannelDef::decode(&mut ReadCursor::new(&bytes)).expect("still a channel");
+
+        assert_eq!(decoded.name.as_str(), Some("cliprdr"));
+        assert_eq!(decoded.options.bits(), raw);
+    }
+
+    /// Retaining unknown bits keeps decode -> encode byte-for-byte, which is
+    /// the reason STYLE.md prefers `from_bits_retain` over `from_bits_truncate`
+    /// for advertisement fields: replay tooling and the round-trip fuzz oracle
+    /// depend on it.
+    #[test]
+    fn undefined_option_bits_survive_a_round_trip() {
+        let bytes = channel_def(b"rdpdr\0\0\0", 0xdead_beef);
+
+        let decoded = ChannelDef::decode(&mut ReadCursor::new(&bytes)).expect("undefined bits are not fatal");
+
+        let mut out = vec![0u8; bytes.len()];
+        decoded.encode(&mut WriteCursor::new(&mut out)).expect("re-encode");
+        assert_eq!(out, bytes);
     }
 }


### PR DESCRIPTION
`ChannelDef::decode` rejects the whole PDU when `options` carries a bit outside the eleven defined flags. [MS-RDPBCGR] 2.2.1.3.4.1 does not ask a server to validate that field, and for several of the flags it asks the opposite — `CHANNEL_OPTION_INITIALIZED`, `ENCRYPT_RDP`, `ENCRYPT_SC` and `ENCRYPT_CS` are each *"unused and its value MUST be ignored by the server"*, and `CHANNEL_OPTION_SHOW_PROTOCOL` likewise.

So the strictness is not the protocol's, and it costs sessions.

### What it costs

**rdesktop 1.9.0 cannot connect to an IronRDP server at all.** It writes this one field big-endian while the rest of `TS_UD_CS_NET` is little-endian — `secure.c:516` uses `out_uint32_be` where every neighbouring field uses `out_uint32_le` — so each channel's flags arrive byte-swapped and every set bit lands outside the mask.

Captured from the wire against an IronRDP-based server:

```
"cliprdr"  c0 a0 00 00   ->  read little-endian as 0x0000a0c0
"rdpsnd"   c0 00 00 00   ->  0x000000c0
"rdpdr"    80 80 00 00   ->  0x00008080
```

Every bit is undefined, so the connection dies at GCC, before a single channel is joined. This is a client bug, not a vendor extension — but it is a client that has shipped for years.

### The fix

This is the "peer advertisements" case in the new `STYLE.md` "Decoding unknown values" section, which uses `ChannelOptions` as its worked example: decode with `from_bits_retain`. Unknown bits are kept, never fatal, and the decode → encode round-trip reproduces the wire bytes — which is what the round-trip fuzz oracle relies on, and the reason the guide prefers `retain` over `from_bits_truncate`.

Two alternative explanations were checked against the same bytes and ruled out: the block is not misaligned (`4 + 5*12 = 64` is exactly `blockLen`) and `channelCount` is not misread.

### Tests

Three: the known bits stay readable while an unknown bit is kept; the wholly-undefined rdesktop value still yields a channel; and the raw bits survive a decode → encode round-trip. All three fail under `from_bits_truncate`.

*(Reopened after my fork was briefly deleted, which auto-closed the original #1837. Rebased onto current master and switched from `from_bits_truncate` to `from_bits_retain` to match the STYLE.md guidance added since.)*
