### PR TITLE
fix(egfx): do not track frames a suspended client cannot acknowledge

### DIFF
--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -591,15 +591,20 @@ impl FrameTracker {
         let frame_id = self.next_frame_id;
         self.next_frame_id = self.next_frame_id.wrapping_add(1);
 
-        self.unacknowledged.insert(
-            frame_id,
-            FrameInfo {
+        // A suspended client sends no acknowledgement until it opts back in
+        // ([MS-RDPEGFX] 2.2.2.13), so nothing would take this frame back out.
+        // Backpressure is off while suspended, so the entry has no work to do.
+        if !self.ack_suspended {
+            self.unacknowledged.insert(
                 frame_id,
-                timestamp,
-                sent_at: Instant::now(),
-                size_bytes: 0,
-            },
-        );
+                FrameInfo {
+                    frame_id,
+                    timestamp,
+                    sent_at: Instant::now(),
+                    size_bytes: 0,
+                },
+            );
+        }
 
         self.total_sent += 1;
         // Edge-trigger after insert so a frame that pushes us to max_in_flight
@@ -617,7 +622,8 @@ impl FrameTracker {
 
     /// Handle frame acknowledgment from client
     pub fn acknowledge(&mut self, frame_id: u32, queue_depth: u32) -> Option<FrameInfo> {
-        if queue_depth == SUSPEND_FRAME_ACK_QUEUE_DEPTH {
+        let suspending = queue_depth == SUSPEND_FRAME_ACK_QUEUE_DEPTH;
+        if suspending {
             self.ack_suspended = true;
             self.client_queue_depth = 0;
         } else {
@@ -625,13 +631,37 @@ impl FrameTracker {
             self.client_queue_depth = queue_depth;
         }
 
+        // A suspending Frame Acknowledge still acknowledges: take the frame
+        // out before the clear below, since it carries the round-trip sample
+        // and byte count the QoE report is built from.
         let info = self.unacknowledged.remove(&frame_id);
         if info.is_some() {
             self.total_acked += 1;
         }
-        // Edge-trigger after remove so an ack that releases backpressure logs.
+        if suspending {
+            // [MS-RDPEGFX] 3.2.5.13: "the server MUST clear the Unacknowledged
+            // Frames ADM element and MUST NOT expect any further
+            // RDPGFX_FRAME_ACKNOWLEDGE_PDU messages from the client". The one
+            // frame this PDU acknowledges was already removed above, so its QoE
+            // sample survives.
+            self.unacknowledged.clear();
+        }
+
+        // Edge-trigger after the remove/clear so an ack that releases
+        // backpressure logs.
         self.emit_state_transitions();
         info
+    }
+
+    /// Whether `frame_id` was ever handed out by [`begin_frame`].
+    ///
+    /// Frame IDs are assigned sequentially, so any ID below the next one to
+    /// assign has been issued at some point. A `u32` frame counter does not
+    /// wrap within a session. Used to tell a benign acknowledgement for a
+    /// frame we no longer track (a resume after suspension cleared the map, or
+    /// a stale duplicate) from an acknowledgement for an ID never sent.
+    pub(crate) fn was_issued(&self, frame_id: u32) -> bool {
+        frame_id < self.next_frame_id
     }
 
     /// Number of frames in flight
@@ -2098,14 +2128,25 @@ impl GraphicsPipelineServer {
                 in_flight_after = self.frames.in_flight(),
                 "EGFX FrameAcknowledge received"
             );
+        } else if self.frames.was_issued(pdu.frame_id) {
+            // Issued but no longer tracked. This is the normal resume path:
+            // while acknowledgements are suspended the server stops tracking
+            // frames ([MS-RDPEGFX] 2.2.2.13), and the client opts back in by
+            // acknowledging the END_FRAME it last decoded -- which may be one
+            // of those untracked frames -- or this is a stale/duplicate ack.
+            // Either way the frame is genuinely done, not a protocol violation.
+            debug!(
+                frame_id = pdu.frame_id,
+                queue_depth, suspended, "EGFX FrameAcknowledge for an untracked issued frame (resume or stale ack)"
+            );
         } else {
             // PROTOCOL COMPLIANCE: per MS-RDPEGFX 2.2.4.3 the client MUST only
-            // acknowledge frame_ids the server has sent. An ack for an unknown
-            // frame_id indicates either client misbehavior, a server bug
-            // (frame_id reuse), or a session reset out of sync.
+            // acknowledge frame_ids the server has sent. An ack for a frame_id
+            // the server never issued indicates client misbehavior or a session
+            // out of sync.
             warn!(
                 frame_id = pdu.frame_id,
-                queue_depth, "EGFX FrameAcknowledge for UNKNOWN frame_id, protocol violation or stale ack"
+                queue_depth, "EGFX FrameAcknowledge for UNKNOWN frame_id, protocol violation"
             );
         }
 
@@ -2387,6 +2428,29 @@ mod capability_negotiation_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn was_issued_separates_stale_resume_acks_from_never_sent_ids() {
+        let ts = Timestamp {
+            milliseconds: 0,
+            seconds: 0,
+            minutes: 0,
+            hours: 0,
+        };
+        let mut frames = FrameTracker::new();
+        let a = frames.begin_frame(ts);
+        let b = frames.begin_frame(ts);
+
+        // Both were handed out, so both are "issued" even after the map is
+        // cleared -- a resume ack for either is benign, not a violation.
+        frames.clear();
+        assert!(frames.was_issued(a));
+        assert!(frames.was_issued(b));
+
+        // An id the server never assigned is a real unknown frame.
+        assert!(!frames.was_issued(b.wrapping_add(1)));
+        assert!(!frames.was_issued(u32::MAX));
+    }
 
     struct DefaultsHandler;
 

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -2,7 +2,7 @@ use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor, encode_vec};
 use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_egfx::pdu::{
     Avc420Region, Avc444BitmapStream, CapabilitiesAdvertisePdu, CapabilitiesV8Flags, CapabilitiesV10Flags,
-    CapabilitiesV81Flags, CapabilitySet, Codec1Type, Encoding, GfxPdu, PixelFormat,
+    CapabilitiesV81Flags, CapabilitySet, Codec1Type, Encoding, FrameAcknowledgePdu, GfxPdu, PixelFormat, QueueDepth,
 };
 use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer, QoeMetrics, Surface};
 use ironrdp_graphics::zgfx::Decompressor;
@@ -699,4 +699,157 @@ fn test_send_uncompressed_frame_backpressure() {
     // Second frame blocked by backpressure
     let frame2 = server.send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 16);
     assert!(frame2.is_none());
+}
+
+#[test]
+fn test_frames_sent_while_acknowledgement_is_suspended_do_not_hold_backpressure() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    server.set_max_frames_in_flight(1);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    let frame1 = server
+        .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 0)
+        .expect("first frame");
+
+    // [MS-RDPEGFX] 2.2.2.13: a queue depth of SUSPEND_FRAME_ACKNOWLEDGEMENT
+    // means the client stops sending Frame Acknowledge until it says otherwise.
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id: frame1,
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    // The pause outlasts the in-flight window by a wide margin, and none of
+    // these frames will be acknowledged.
+    let mut last_frame = frame1;
+    for index in 1..=5 {
+        last_frame = server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, index * 16)
+            .expect("a suspended client must not throttle the encoder");
+    }
+    server.drain_output();
+
+    // The client comes back and acknowledges normally.
+    let resume = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::AvailableBytes(8),
+        frame_id: last_frame,
+        total_frames_decoded: 6,
+    });
+    let _output = server.process(0, &encode_pdu(&resume)).expect("resume ack");
+
+    assert!(
+        server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 96)
+            .is_some(),
+        "frames counted during the pause hold backpressure on for good: with no \
+         frame going out there is no End Frame left for the client to acknowledge"
+    );
+}
+
+#[test]
+fn test_suspension_does_not_shrink_the_window_for_the_rest_of_the_connection() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+    server.set_max_frames_in_flight(3);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    // Fill the window, then suspend. The frames already in flight will not be
+    // acknowledged either -- the suspension covers them as much as the ones
+    // that follow.
+    let mut first = None;
+    let mut last = 0;
+    for index in 0..3 {
+        let id = server
+            .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, index * 16)
+            .expect("window not yet full");
+        first.get_or_insert(id);
+        last = id;
+    }
+
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id: first.expect("a frame went out"),
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    // The client opts back in by acknowledging a frame it actually decoded
+    // ([MS-RDPEGFX] 2.2.2.13 -- the resume ack names an END_FRAME), not a
+    // fabricated id. That frame was cleared from tracking by the suspension,
+    // so this exercises the untracked-but-issued path.
+    let resume = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::AvailableBytes(8),
+        frame_id: last,
+        total_frames_decoded: 2,
+    });
+    let _output = server.process(0, &encode_pdu(&resume)).expect("resume ack");
+    server.drain_output();
+
+    // The whole window has to be available again. Frames stranded by the
+    // suspension are never acknowledged, so leaving them tracked shrinks the
+    // window permanently -- here to one frame instead of three.
+    for index in 0..3 {
+        assert!(
+            server
+                .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 100 + index * 16)
+                .is_some(),
+            "frame {index} after resume was held back by a frame stranded in the pause"
+        );
+    }
+}
+
+#[test]
+fn test_a_suspending_acknowledgement_still_acknowledges_its_frame() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
+        flags: CapabilitiesV8Flags::SMALL_CACHE,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    let _output = server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(64, 64).unwrap();
+    server.drain_output();
+    let pixel_data = vec![0xFFu8; 64 * 64 * 4];
+
+    let frame_id = server
+        .send_uncompressed_frame(surface_id, &pixel_data, 64, 64, 0)
+        .expect("first frame");
+
+    // The PDU that suspends also acknowledges a frame, and that frame carries
+    // the round-trip sample the QoE report is built from. Dropping it because
+    // the same PDU happens to suspend loses the measurement.
+    let suspend = GfxPdu::FrameAcknowledge(FrameAcknowledgePdu {
+        queue_depth: QueueDepth::Suspend,
+        frame_id,
+        total_frames_decoded: 1,
+    });
+    let _output = server.process(0, &encode_pdu(&suspend)).expect("suspend ack");
+
+    assert!(
+        server.qoe_snapshot().is_some(),
+        "the suspending acknowledgement was not counted, so no round-trip sample exists"
+    );
 }


### PR DESCRIPTION
When a client sends a Frame Acknowledge with queue depth `SUSPEND_FRAME_ACKNOWLEDGEMENT` ([MS-RDPEGFX] 2.2.2.13) it stops acknowledging frames until it opts back in. `FrameTracker::begin_frame` keeps inserting every frame it sends into `unacknowledged` throughout the pause, and nothing takes those entries out again: the client will never acknowledge them, and per [MS-RDPEGFX] 3.2.5.13 the server *"MUST clear the Unacknowledged Frames ADM element"* on suspension anyway.

`should_backpressure` already gates on `ack_suspended`, so the encoder is not throttled *during* the pause. The cost lands on **resume**: the frames that piled up while suspended are still in the map, so `in_flight` is back over `max_in_flight` the moment the client resumes, and backpressure latches on for the rest of the connection — with no frame going out, there is no End Frame left for the client to acknowledge, so it never clears. A short pause becomes a permanently frozen surface.

### The fix

Two changes to `FrameTracker`:

- `begin_frame` does not record a frame while acknowledgement is suspended.
- A suspending `acknowledge` clears the map after taking out the frame it carries (that one still feeds the QoE report).

### Tests

Two: frames sent across a suspend/resume cycle must not hold backpressure on afterwards, and a suspension must not shrink the in-flight window for the rest of the connection. Both fail on current master.

*(Reopened after my fork was briefly deleted, which auto-closed the original #1805. Rebased onto current master; since the original PR, master added the `should_backpressure` gate that removes the steady-state throttle, so this now targets the post-resume wedge and the spec's MUST-clear specifically.)*
