### PR TITLE
feat(web): expose enable_server_pointer from the WASM module

### DIFF
--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -91,6 +91,7 @@ struct SessionBuilderInner {
 
     use_display_control: bool,
     enable_credssp: bool,
+    enable_server_pointer: bool,
     legacy_graphics: bool,
     outbound_message_size_limit: Option<usize>,
 }
@@ -134,6 +135,7 @@ impl Default for SessionBuilderInner {
 
             use_display_control: false,
             enable_credssp: true,
+            enable_server_pointer: true,
             legacy_graphics: false,
             outbound_message_size_limit: None,
         }
@@ -253,6 +255,7 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
             |kdc_proxy_url: String| { self.0.borrow_mut().kdc_proxy_url = Some(kdc_proxy_url) };
             |display_control: bool| { self.0.borrow_mut().use_display_control = display_control };
             |enable_credssp: bool| { self.0.borrow_mut().enable_credssp = enable_credssp };
+            |enable_server_pointer: bool| { self.0.borrow_mut().enable_server_pointer = enable_server_pointer };
             |legacy_graphics: bool| { self.0.borrow_mut().legacy_graphics = legacy_graphics };
             |outbound_message_size_limit: f64| {
                 let limit = if outbound_message_size_limit >= 0.0 && outbound_message_size_limit <= f64::from(u32::MAX) {
@@ -423,6 +426,9 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
 
         let enable_credssp = self.0.borrow().enable_credssp;
         config.enable_credssp = enable_credssp;
+
+        let enable_server_pointer = self.0.borrow().enable_server_pointer;
+        config.enable_server_pointer = enable_server_pointer;
 
         let (input_events_tx, input_events_rx) = mpsc::unbounded();
 

--- a/web-client/iron-remote-desktop-rdp/src/main.ts
+++ b/web-client/iron-remote-desktop-rdp/src/main.ts
@@ -57,6 +57,10 @@ export function enableCredssp(enable: boolean): Extension {
     return new Extension('enable_credssp', enable);
 }
 
+export function enableServerPointer(enable: boolean): Extension {
+    return new Extension('enable_server_pointer', enable);
+}
+
 export function legacyGraphics(enable: boolean): Extension {
     return new Extension('legacy_graphics', enable);
 }


### PR DESCRIPTION
Follow-up to #1900 / #1910: make `enable_server_pointer` reachable from JS instead of being a hardcoded constant, and default it to `true`.

### Background

`build_config` hardcodes `enable_server_pointer: false`. That value reaches `ActiveStage`, and `process_pointer_update()` in `ironrdp-session` returns on its first line, so every Pointer Update PDU is dropped **silently** — no error, no log. The visible result is that remote cursor shapes never reach the JS `set_cursor_style` callback: resize arrows, hand, I-beam all render as the plain arrow. Everything else on that path is already implemented (PNG encoding of the pointer bitmap, >32×32 scaling, the JS callbacks). Full write-up in #1900.

@glamberson filed #1910 with the one-line default flip and suggested exposing the flag on `SessionBuilder` as a follow-up. This is that follow-up.

### What this does

Follows the existing `enable_credssp` / `legacy_graphics` pattern:

- `SessionBuilderInner.enable_server_pointer`, defaulting to `true`
- an `extension_match!` arm for it
- applied to `connector::Config` in `connect()`, right next to `enable_credssp`
- `enableServerPointer(enable)` exported from `iron-remote-desktop-rdp`'s `main.ts`

One item of the `TODO(#327): expose these options from the WASM module`.

### Relationship to #1910

This deliberately **does not touch** the `enable_server_pointer: false` literal in `build_config`. `connect()` overwrites it unconditionally, so the effective default is already `true`, and leaving that line alone means **zero textual conflict with #1910**. Either can merge first.

If you would rather have the literal cleaned up here too, or would prefer to take #1910 alone and have this reduced, happy to adjust.

### Verification

- `cargo check -p ironrdp-web --target wasm32-unknown-unknown` passes.
- The extension identifier matches on both sides: `extension_match!` keys on `stringify!` of the closure parameter, so `|enable_server_pointer: bool|` pairs with `new Extension('enable_server_pointer', …)`. Checked mechanically rather than by eye — a mismatch there would fall through to the `Unknown extension` warning and the new API would be silently dead.
- The runtime effect of the flag itself was verified on real hardware in #1900, by rebuilding the wasm package from tag `npm-iron-remote-desktop-rdp-v0.7.0` with only that constant flipped: cursor shapes became correct immediately. This PR does not change that behaviour, it only makes the flag settable.

One caveat on my side: I compile-checked with Rust 1.98 rather than the pinned 1.94.1 (a local toolchain install problem, not related to this change). The diff adds no new syntax or imports, and CI will cover the pinned toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
