### PR TITLE
docs(pr-automation): define review recovery intent

### DIFF
--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -6,7 +6,7 @@
 - Output schema.
 - Read-only access rules.
 - Execution limits.
-- Optional validation feedback for output repair.
+- Optional caller-supplied validation errors for repairing a previous result.
 
 ## Outputs
 
@@ -36,9 +36,12 @@ For retryable `429` responses:
 
 Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetries`).
 
-## Validated output
+## Output validation and repair
 
 - Use provider-enforced schema output where supported, otherwise JSON mode where supported.
-- Local schema validation is the real acceptance boundary.
-- Use schema errors or caller-supplied validation errors for bounded output repair.
-- Reuse investigation context and permit only necessary read-only evidence lookup.
+- Validate JSON and schema locally before returning success.
+- Repair JSON and schema errors internally.
+- Let callers request repair of a previous result using their task-specific validation errors.
+- Preserve the original investigation context for both repair paths.
+- Permit only necessary read-only evidence lookup during repair.
+- Bound repair across follow-up requests and return failure when valid output cannot be produced within those limits.

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -36,7 +36,7 @@ Expose these diagnostics:
 
 - Retry transient provider failures with backoff.
 - Do not automatically retry invalid configuration, rejected credentials, or exhausted quota.
-- Apply the configured retry limit per request after the initial attempt, including SDK retries.
+- Apply the configured retry limit per request after the initial attempt.
 
 For retryable `429` responses:
 

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -1,3 +1,8 @@
+## Terms
+
+- **Request retry:** resend the same provider request after a transient failure, without changing the conversation.
+- **Output repair:** ask the model to correct an invalid response using validation feedback and the existing investigation context.
+
 ## Inputs
 
 - Provider connection details and credentials.
@@ -16,25 +21,26 @@ Keep diagnostic output bounded:
 
 - Phase.
 - Latency.
-- Retry and repair counts.
+- Request-retry count.
+- Output-repair count.
 - Finish reason.
 - Token usage when available.
 - Accumulated turn and tool-call counts, including on failure.
 
-## Bounded recovery
+## Request retries
 
 - Retry transient provider failures with backoff while preserving investigation state.
 - Do not automatically retry invalid configuration, rejected credentials, or exhausted quota.
-- Keep request timeouts configurable and bound total recovery time.
-- Account for SDK retries within these bounds.
+- Keep request timeouts configurable and bound total time spent on request retries and output repair.
+- Allow at most four retries per request after the initial attempt, including SDK retries.
+- Count request retries separately from output-repair attempts, including retries of repair requests.
 
 For retryable `429` responses:
 
 - Read the provider's `Retry-After` header.
 - Wait that duration, or fall back to backoff if absent.
-- Fail closed after three consecutive `429` responses.
 
-Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetries`).
+Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetries`) where it satisfies the policy above.
 
 ## Output validation and repair
 

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -27,9 +27,14 @@ Keep diagnostic output bounded:
 - Do not automatically retry invalid configuration, rejected credentials, or exhausted quota.
 - Keep request timeouts configurable and bound total recovery time.
 - Account for SDK retries within these bounds.
-- On retryable `429`, read the provider's `Retry-After` header.
+
+For retryable `429` responses:
+
+- Read the provider's `Retry-After` header.
 - Wait that duration, or fall back to backoff if absent.
 - Fail closed after three consecutive `429` responses.
+
+Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetries`).
 
 ## Validated output
 

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -1,8 +1,40 @@
-## Graceful handling of 429
+## Inputs
 
-- On `429`, read Helmcode’s `Retry-After` header.
-- Wait that duration, or fall back to another duration if absent.
+- Provider connection details and credentials.
+- Model.
+- Instructions.
+- Output schema.
+- Read-only access rules.
+- Execution limits.
+- Optional validation feedback for output repair.
+
+## Outputs
+
+- Schema-validated JSON on success, or an explicit failure reason.
+
+Keep diagnostic output bounded:
+
+- Phase.
+- Latency.
+- Retry and repair counts.
+- Finish reason.
+- Token usage when available.
+- Accumulated turn and tool-call counts, including on failure.
+
+## Bounded recovery
+
+- Retry transient provider failures with backoff while preserving investigation state.
+- Do not automatically retry invalid configuration, rejected credentials, or exhausted quota.
+- Keep request timeouts configurable and bound total recovery time.
+- Account for SDK retries within these bounds.
+- On retryable `429`, read the provider's `Retry-After` header.
+- Wait that duration, or fall back to backoff if absent.
 - Retry the same request while preserving agent state.
 - Fail closed after three consecutive `429` responses.
 
-This logic does not have to live in our code because the OpenAI SDK provides a `maxRetries` option.
+## Validated output
+
+- Use provider-enforced schema output where supported, otherwise JSON mode where supported.
+- Local schema validation is the real acceptance boundary.
+- Use schema errors or caller-supplied validation errors for bounded output repair.
+- Reuse investigation context and permit only necessary read-only evidence lookup.

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -29,7 +29,6 @@ Keep diagnostic output bounded:
 - Account for SDK retries within these bounds.
 - On retryable `429`, read the provider's `Retry-After` header.
 - Wait that duration, or fall back to backoff if absent.
-- Retry the same request while preserving agent state.
 - Fail closed after three consecutive `429` responses.
 
 ## Validated output

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -10,30 +10,33 @@
 - Instructions.
 - Output schema.
 - Read-only access rules.
-- Execution limits.
-- Optional trusted validator for task-specific checks.
+- Request timeout.
+- Maximum request retries.
+- Maximum model turns.
+- Maximum tool calls.
+- Maximum output size.
+- Maximum output-repair attempts.
+- Optional validator for task-specific checks.
 
 ## Outputs
 
 - JSON accepted by the schema and any supplied validator, or an explicit failure reason.
 
-Keep diagnostic output bounded:
+Expose these diagnostics:
 
-- Phase.
-- Latency.
+- Activity (such as investigation, final output, or repair).
+- Duration of each provider attempt.
 - Request-retry count.
 - Output-repair count.
-- Finish reason.
+- Provider-reported stop reason (such as completion or token limit).
 - Token usage when available.
 - Accumulated turn and tool-call counts, including on failure.
 
 ## Request retries
 
-- Retry transient provider failures with backoff while preserving investigation state.
+- Retry transient provider failures with backoff.
 - Do not automatically retry invalid configuration, rejected credentials, or exhausted quota.
-- Keep request timeouts configurable and bound total time spent on request retries and output repair.
-- Allow at most four retries per request after the initial attempt, including SDK retries.
-- Count request retries separately from output-repair attempts, including retries of repair requests.
+- Apply the configured retry limit per request after the initial attempt, including SDK retries.
 
 For retryable `429` responses:
 
@@ -48,6 +51,5 @@ Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetrie
 - Accept validators only from trusted caller configuration, never from untrusted evidence or model output.
 - Validate JSON and schema locally, then run the supplied validator.
 - Repair JSON, schema, and validator-reported output errors within the same invocation.
-- Preserve the original investigation context during repair.
 - Permit only necessary read-only evidence lookup during repair.
-- Bound repair attempts and return failure when valid output cannot be produced within those limits.
+- Return failure if output remains invalid after the configured repair attempts.

--- a/.github/actions/openai-agent/INTENT.md
+++ b/.github/actions/openai-agent/INTENT.md
@@ -6,11 +6,11 @@
 - Output schema.
 - Read-only access rules.
 - Execution limits.
-- Optional caller-supplied validation errors for repairing a previous result.
+- Optional trusted validator for task-specific checks.
 
 ## Outputs
 
-- Schema-validated JSON on success, or an explicit failure reason.
+- JSON accepted by the schema and any supplied validator, or an explicit failure reason.
 
 Keep diagnostic output bounded:
 
@@ -39,9 +39,9 @@ Prefer the OpenAI SDK for `Retry-After` handling and request retries (`maxRetrie
 ## Output validation and repair
 
 - Use provider-enforced schema output where supported, otherwise JSON mode where supported.
-- Validate JSON and schema locally before returning success.
-- Repair JSON and schema errors internally.
-- Let callers request repair of a previous result using their task-specific validation errors.
-- Preserve the original investigation context for both repair paths.
+- Accept validators only from trusted caller configuration, never from untrusted evidence or model output.
+- Validate JSON and schema locally, then run the supplied validator.
+- Repair JSON, schema, and validator-reported output errors within the same invocation.
+- Preserve the original investigation context during repair.
 - Permit only necessary read-only evidence lookup during repair.
-- Bound repair across follow-up requests and return failure when valid output cannot be produced within those limits.
+- Bound repair attempts and return failure when valid output cannot be produced within those limits.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -47,12 +47,12 @@ The published comments include the name of the specialist that found the finding
 Render severity as `critical :purple_circle:`, `high :red_circle:`, `medium :orange_circle:`, or `low :yellow_circle:`.
 Append `:question:` for questions, and show `:green_circle:` in the main comment when no findings are found.
 
-### Recovery
+### Stage recovery
 
-- Retry temporary failures automatically, with delays and limits, without waiting for another PR or CI event.
+- Schedule stage recovery for temporary failures, with delays and limits, without waiting for another PR or CI event.
 - Keep all eligibility checks, resource limits, and stale-head protections in effect.
 - Never publish the same review twice, and count only published reviews toward the two-review limit.
-- Show whether retries are pending, succeeded, or exhausted in the review check and workflow summary, with reasons for every stage failure.
+- Show whether stage recovery is pending, successful, or exhausted in the review check and workflow summary, with reasons for every stage failure.
 - Show per-stage review metrics and totals across attempts in the workflow summary, including failed runs and unavailable data.
 - Link to the summary from the `AI automated review` check; keep metrics out of review comments.
 

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -38,6 +38,10 @@ concurrency:
 `llm-reviewer-pipeline` group must lock the entire review pipeline, not each reviewer job.
 The review pipeline must therefore live in a reusable workflow, with `llm-reviewer-pipeline` concurrency on its caller job.
 
+## Classification
+
+- Configure the classifier action for at most four request retries after the initial attempt.
+
 ## Reviewer pipeline
 
 - Select specialists, identify which are required, and call `review-pipeline.yml`.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -40,30 +40,21 @@ The review pipeline must therefore live in a reusable workflow, with `llm-review
 
 ## Reviewer pipeline
 
-The reviewer pipeline is roughly defined as:
+- Select specialists, identify which are required, and call `review-pipeline.yml`.
+- Publish only after all required specialists succeed and the general review passes validation.
 
-```text
-evidence -> specialist reviewers running in parallel -> general reviewer aggregating everything
-```
-
-The general reviewer independently inspects the pull request, attempts to falsify every candidate, and records exactly one `accepted`, `refined`, or `rejected` disposition per candidate.
-It can merge overlapping candidates and add findings that no specialist reported.
-Only the validated general-review result can be published.
 The published comments include the name of the specialist that found the finding.
-Reviewer findings use severity and a question boolean.
 Render severity as `critical :purple_circle:`, `high :red_circle:`, `medium :orange_circle:`, or `low :yellow_circle:`.
 Append `:question:` for questions, and show `:green_circle:` in the main comment when no findings are found.
 
-### Specialist reviewers
+### Recovery
 
-Use three specialist reviewers:
-
-- protocol
-- skeptical
-- code compressor
-
-They should run in parallel using a multi-job matrix.
-We allow at most three specialist agents to run at once.
+- Retry temporary failures automatically, with delays and limits, without waiting for another PR or CI event.
+- Keep all eligibility checks, resource limits, and stale-head protections in effect.
+- Never publish the same review twice, and count only published reviews toward the two-review limit.
+- Show whether retries are pending, succeeded, or exhausted in the review check and workflow summary, with reasons for every stage failure.
+- Show per-stage review metrics and totals across attempts in the workflow summary, including failed runs and unavailable data.
+- Link to the summary from the `AI automated review` check; keep metrics out of review comments.
 
 ## Activation policy
 

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -1,0 +1,45 @@
+## Reviewer pipeline
+
+`review-pipeline.yml` is a reusable GitHub Actions workflow with `workflow_call` as its only trigger.
+This lets specialists run in parallel while the caller applies a global concurrency limit to the entire pipeline.
+The caller owns publication.
+
+```text
+evidence -> specialist reviewers running in parallel -> general reviewer aggregating everything
+```
+
+The general reviewer independently inspects the pull request, attempts to falsify every candidate, and records exactly one `accepted`, `refined`, or `rejected` disposition per candidate.
+It can merge overlapping candidates and add findings that no specialist reported.
+Reviewer findings use severity and a question boolean.
+
+### Specialist reviewers
+
+The caller selects specialists and identifies which are required.
+Supported specialists include:
+
+- protocol
+- skeptical
+- code compressor
+
+Run selected specialists in a multi-job matrix, with at most three running at once.
+
+### Recovery
+
+- Keep validated results throughout retries so only failed or missing work is repeated.
+- Reuse only trusted workflow results for unchanged review inputs and rules, and validate them again.
+- Give invalid output a limited chance to be corrected using review-specific validation feedback.
+- Never discard findings during output repair.
+
+### Outputs
+
+- Return a validated general review only when every required specialist succeeds.
+- Return every failed stage and its reason to the caller.
+
+Return per-stage metrics, including failed attempts and marking unavailable data:
+
+- Token usage.
+- Elapsed time.
+- Retry and repair counts.
+- Whether results were reused.
+
+Do not count reused results as new token usage.

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -12,6 +12,8 @@ The general reviewer independently inspects the pull request, attempts to falsif
 It can merge overlapping candidates and add findings that no specialist reported.
 Reviewer findings use severity and a question boolean.
 
+- Configure reviewer actions for at most four request retries after the initial attempt.
+
 ### Specialist reviewers
 
 The caller selects specialists and identifies which are required.

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -27,7 +27,7 @@ Run selected specialists in a multi-job matrix, with at most three running at on
 
 - Keep validated results throughout retries so only failed or missing work is repeated.
 - Reuse only trusted workflow results for unchanged review inputs and rules, and validate them again.
-- Supply a trusted review-specific validator and let the action handle bounded output repair.
+- Supply a review-specific validator and let the action handle bounded output repair.
 - Never discard findings during output repair; fail the stage if repair cannot produce valid output.
 
 ### Outputs

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -27,7 +27,7 @@ Run selected specialists in a multi-job matrix, with at most three running at on
 
 - Keep validated results throughout retries so only failed or missing work is repeated.
 - Reuse only trusted workflow results for unchanged review inputs and rules, and validate them again.
-- Give invalid output a limited chance to be corrected using review-specific validation feedback.
+- Supply a trusted review-specific validator and let the action handle bounded output repair.
 - Never discard findings during output repair; fail the stage if repair cannot produce valid output.
 
 ### Outputs

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -23,9 +23,11 @@ Supported specialists include:
 
 Run selected specialists in a multi-job matrix, with at most three running at once.
 
-### Recovery
+### Stage recovery
 
-- Keep validated results throughout retries so only failed or missing work is repeated.
+Stage recovery repeats failed or missing stages while reusing successful results.
+
+- Keep validated results throughout stage recovery.
 - Reuse only trusted workflow results for unchanged review inputs and rules, and validate them again.
 - Supply a review-specific validator and let the action handle bounded output repair.
 - Never discard findings during output repair; fail the stage if repair cannot produce valid output.
@@ -39,7 +41,9 @@ Return per-stage metrics, including failed attempts and marking unavailable data
 
 - Token usage.
 - Elapsed time.
-- Retry and repair counts.
+- Request-retry count.
+- Output-repair count.
+- Stage-recovery count.
 - Whether results were reused.
 
 Do not count reused results as new token usage.

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -28,7 +28,7 @@ Run selected specialists in a multi-job matrix, with at most three running at on
 - Keep validated results throughout retries so only failed or missing work is repeated.
 - Reuse only trusted workflow results for unchanged review inputs and rules, and validate them again.
 - Give invalid output a limited chance to be corrected using review-specific validation feedback.
-- Never discard findings during output repair.
+- Never discard findings during output repair; fail the stage if repair cannot produce valid output.
 
 ### Outputs
 


### PR DESCRIPTION
Define recovery requirements so provider failures and invalid output do not waste completed review work.

- Keep request execution and output repair in the reusable action.
- Assign result reuse and review validation to the review pipeline.
- Keep recovery scheduling, publication, and reporting in the labeler.

This change documents intent only; runtime behavior is unchanged.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>