### PR TITLE
feat(displaycontrol): let a server handler override its capabilities

### DIFF
--- a/crates/ironrdp-displaycontrol/src/server.rs
+++ b/crates/ironrdp-displaycontrol/src/server.rs
@@ -10,6 +10,17 @@ pub trait DisplayControlHandler: Send {
     fn monitor_layout(&self, layout: DisplayControlMonitorLayout) {
         debug!(?layout);
     }
+
+    /// Capabilities advertised to the client when the channel starts.
+    ///
+    /// Defaults to today's single-monitor values (`max_num_monitors = 1`,
+    /// factors `3840`/`2400`, i.e. one 4K-area monitor), so any existing
+    /// handler that doesn't override this keeps its current behavior.
+    /// A handler serving more than one monitor should override this to
+    /// return `DisplayControlCapabilities::new(monitor_count, 3840, 2400)`.
+    fn capabilities(&self) -> DisplayControlCapabilities {
+        DisplayControlCapabilities::new(1, 3840, 2400).expect("(1, 3840, 2400) are always within the valid range")
+    }
 }
 
 /// A server for the Display Control Virtual Channel.
@@ -32,9 +43,7 @@ impl DvcProcessor for DisplayControlServer {
     }
 
     fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
-        let pdu: DisplayControlPdu = DisplayControlCapabilities::new(1, 3840, 2400)
-            .map_err(|e| decode_err!(e))?
-            .into();
+        let pdu: DisplayControlPdu = self.handler.capabilities().into();
 
         Ok(vec![Box::new(pdu)])
     }

--- a/crates/ironrdp-displaycontrol/src/server.rs
+++ b/crates/ironrdp-displaycontrol/src/server.rs
@@ -17,9 +17,14 @@ pub trait DisplayControlHandler: Send {
     /// `3840`/`2400`, i.e. one 4K-area monitor), so any handler that doesn't
     /// override this keeps that behavior.
     /// A handler serving more than one monitor should override this, e.g.
-    /// `DisplayControlCapabilities::new(monitor_count, 3840, 2400).expect("valid range")`.
-    fn capabilities(&self) -> DisplayControlCapabilities {
-        DisplayControlCapabilities::new(1, 3840, 2400).expect("(1, 3840, 2400) are always within the valid range")
+    /// `DisplayControlCapabilities::new(monitor_count, 3840, 2400)`. Fallible
+    /// because [`DisplayControlCapabilities::new`] validates its arguments
+    /// (MS-RDPEDISP does not bound them, but the wire encoding does); an
+    /// overrider deriving values from runtime display state should propagate
+    /// that error rather than `expect` it, since this is called from
+    /// [`DvcProcessor::start`] and a panic there aborts the connection.
+    fn capabilities(&self) -> PduResult<DisplayControlCapabilities> {
+        DisplayControlCapabilities::new(1, 3840, 2400).map_err(|e| decode_err!(e))
     }
 }
 
@@ -43,7 +48,7 @@ impl DvcProcessor for DisplayControlServer {
     }
 
     fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
-        let pdu: DisplayControlPdu = self.handler.capabilities().into();
+        let pdu: DisplayControlPdu = self.handler.capabilities()?.into();
 
         Ok(vec![Box::new(pdu)])
     }

--- a/crates/ironrdp-displaycontrol/src/server.rs
+++ b/crates/ironrdp-displaycontrol/src/server.rs
@@ -13,11 +13,11 @@ pub trait DisplayControlHandler: Send {
 
     /// Capabilities advertised to the client when the channel starts.
     ///
-    /// Defaults to today's single-monitor values (`max_num_monitors = 1`,
-    /// factors `3840`/`2400`, i.e. one 4K-area monitor), so any existing
-    /// handler that doesn't override this keeps its current behavior.
-    /// A handler serving more than one monitor should override this to
-    /// return `DisplayControlCapabilities::new(monitor_count, 3840, 2400)`.
+    /// Defaults to a single-monitor value (`max_num_monitors = 1`, factors
+    /// `3840`/`2400`, i.e. one 4K-area monitor), so any handler that doesn't
+    /// override this keeps that behavior.
+    /// A handler serving more than one monitor should override this, e.g.
+    /// `DisplayControlCapabilities::new(monitor_count, 3840, 2400).expect("valid range")`.
     fn capabilities(&self) -> DisplayControlCapabilities {
         DisplayControlCapabilities::new(1, 3840, 2400).expect("(1, 3840, 2400) are always within the valid range")
     }

--- a/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Mutex};
 use ironrdp_core::decode;
 use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_displaycontrol::pdu;
+use ironrdp_displaycontrol::server::{DisplayControlHandler, DisplayControlServer};
 use ironrdp_dvc::DvcProcessor as _;
+use ironrdp_pdu::{PduResult, decode_err};
 use ironrdp_testsuite_core::encode_decode_test;
 
 encode_decode_test! {
@@ -216,4 +218,23 @@ fn client_process_rejects_trailing_bytes_after_caps() {
         "bytes left over after decoding the caps body should be rejected"
     );
     assert!(!client.ready());
+}
+
+struct OutOfRangeCapsHandler;
+
+impl DisplayControlHandler for OutOfRangeCapsHandler {
+    fn capabilities(&self) -> PduResult<pdu::DisplayControlCapabilities> {
+        // More than 1024 monitors is rejected by DisplayControlCapabilities::new, per
+        // invalid_caps above.
+        pdu::DisplayControlCapabilities::new(2000, 100, 100).map_err(|e| decode_err!(e))
+    }
+}
+
+#[test]
+fn server_start_propagates_an_invalid_capabilities_override_as_an_error() {
+    // A handler deriving capabilities from real runtime state can hit the wire-encoding bound
+    // DisplayControlCapabilities::new enforces; start() must surface that as a PduResult::Err
+    // rather than let a handler's own expect()/panic tear down the connection.
+    let mut server = DisplayControlServer::new(Box::new(OutOfRangeCapsHandler));
+    assert!(server.start(0).is_err());
 }


### PR DESCRIPTION
## Summary

- `DisplayControlServer::start()` sends `DisplayControlCapabilities::new(1, 3840, 2400)` unconditionally, so every server using this crate is capped at one monitor with no way to advertise more.
- Added a default trait method on `DisplayControlHandler`, `capabilities()`, that `start()` now calls instead of the hardcoded literal.
- The default returns the same `(1, 3840, 2400)` values, so any existing implementation that does not override it keeps its current behavior unchanged.
- A handler serving more than one monitor can override `capabilities()` to report the real count.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass.

## Notes

- Additive only: one new trait method with a default body, one call-site change in `start()`. No existing implementor is affected unless it opts in.
