### PR TITLE
feat(rdpeudp): MS-RDPEUDP version 1/2 reliable data transfer

### DIFF
--- a/crates/ironrdp-rdpeudp-tokio/src/driver.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/driver.rs
@@ -705,6 +705,7 @@ mod tests {
             }),
             correlation_id: None,
             syn_data_ex: None,
+            data: None,
         }
     }
 
@@ -758,6 +759,7 @@ mod tests {
             syn_data: None,
             correlation_id: None,
             syn_data_ex: None,
+            data: None,
         };
         let encoded = ironrdp_core::encode_vec(&datagram).expect("encode");
         let natural_len = encoded.len();

--- a/crates/ironrdp-rdpeudp/src/connection.rs
+++ b/crates/ironrdp-rdpeudp/src/connection.rs
@@ -1229,7 +1229,9 @@ impl RdpeudpConnection {
             ack_vector: Some(V1AckVectorHeader {
                 elements: vec![V1AckVectorElement {
                     state: VectorElementState::DatagramReceived,
-                    length: 1,
+                    // One datagram (the SYN+ACK): wire runs are count - 1, see
+                    // process_v1_acknowledgement.
+                    length: 0,
                 }],
             }),
             ack_of_acks: None,
@@ -2723,6 +2725,85 @@ mod v1_tests {
             .and_then(|t| decode::<V1Datagram>(&t.contents).ok())
             .is_some_and(|d| d.data.is_some());
         assert!(!is_data, "acknowledged packet must not be retransmitted");
+    }
+
+    /// The client's final handshake ACK acknowledges exactly the SYN+ACK, so
+    /// its single run must be encoded as 0x00, the same way build_v1_ack_parts
+    /// encodes a run of one.
+    #[test]
+    fn the_final_handshake_ack_encodes_one_datagram_as_zero() {
+        let mut conn = RdpeudpConnection::connect(config(), at(0)).unwrap();
+        let _ = conn.poll_transmit(at(0)).expect("client SYN");
+        let mut wire = syn_ack(2);
+        conn.handle_datagram(&mut wire, at(20)).unwrap();
+
+        let out = conn.poll_transmit(at(20)).expect("final ACK");
+        let datagram: V1Datagram = decode(&out.contents).unwrap();
+        assert_eq!(datagram.header.sn_source_ack, REMOTE_ISN);
+        assert_eq!(
+            datagram.ack_vector.unwrap().elements,
+            vec![V1AckVectorElement {
+                state: VectorElementState::DatagramReceived,
+                length: 0,
+            }]
+        );
+    }
+
+    /// ACKs captured from Windows Server (10.0.0.12) over an MS-RDPEUDP
+    /// version 2 tunnel, verbatim apart from `snSourceAck`, which is rebased
+    /// onto this test's ISN:
+    ///
+    /// * after our first Source Packet (the TLS ClientHello, seq 1), the
+    ///   ServerHello came back as `00 00 00 01 00 c8 00 0c 00 01 00 b5 ...`:
+    ///   `snSourceAck` 1 and one element 0x00;
+    /// * after four Source Packets (seq 1..=4, all of which the server acted
+    ///   on: the TLS handshake finished), `00 00 00 04 00 c6 00 04 00 01 03 b5`:
+    ///   `snSourceAck` 4 and one element 0x03.
+    ///
+    /// Read literally 0x00 would be an empty run and 0x03 would leave seq 1
+    /// unacknowledged forever; Windows means "one" and "four", so the six-bit
+    /// run length is count - 1.
+    #[test]
+    fn windows_ack_vector_runs_are_count_minus_one() {
+        fn windows_ack(sn_source_ack: u32, element: u8, window: u16, flags: u16) -> Vec<u8> {
+            let mut bytes = sn_source_ack.to_be_bytes().to_vec();
+            bytes.extend_from_slice(&window.to_be_bytes());
+            bytes.extend_from_slice(&flags.to_be_bytes());
+            bytes.extend_from_slice(&[0x00, 0x01, element, 0xb5]);
+            bytes
+        }
+        fn pending(conn: &RdpeudpConnection) -> usize {
+            conn.send_window.as_ref().unwrap().pending_entries().count()
+        }
+
+        // One Source Packet, acknowledged by element 0x00.
+        let mut conn = established(2);
+        conn.send(b"ClientHello".to_vec()).unwrap();
+        let _ = conn.poll_transmit(at(30)).unwrap();
+        assert_eq!(pending(&conn), 1);
+        let mut ack = windows_ack(LOCAL_ISN + 1, 0x00, 0x00c8, 0x000c);
+        // The captured datagram also carried data; a bare ACK is enough here.
+        ack[7] = 0x04;
+        conn.handle_datagram(&mut ack, at(50)).unwrap();
+        assert_eq!(pending(&conn), 0, "element 0x00 acknowledges exactly one datagram");
+
+        // Four Source Packets, acknowledged by element 0x03.
+        let mut conn = established(2);
+        for payload in [&b"1"[..], b"2", b"3", b"4"] {
+            conn.send(payload.to_vec()).unwrap();
+            let _ = conn.poll_transmit(at(30)).unwrap();
+        }
+        assert_eq!(pending(&conn), 4);
+        let mut ack = windows_ack(LOCAL_ISN + 4, 0x03, 0x00c6, 0x0004);
+        conn.handle_datagram(&mut ack, at(50)).unwrap();
+        assert_eq!(pending(&conn), 0, "element 0x03 acknowledges seq 4 down to seq 1");
+
+        conn.handle_timeout(at(5_000));
+        let retransmit = conn
+            .poll_transmit(at(5_000))
+            .and_then(|t| decode::<V1Datagram>(&t.contents).ok())
+            .is_some_and(|d| d.data.is_some());
+        assert!(!retransmit, "nothing left to retransmit");
     }
 
     #[test]

--- a/crates/ironrdp-rdpeudp/src/connection.rs
+++ b/crates/ironrdp-rdpeudp/src/connection.rs
@@ -41,7 +41,7 @@ use crate::pdu::v2_control::AckOfAcksPayload;
 use crate::pdu::v2_data::{DataBody, DataHeader};
 use crate::pdu::v2_flags::V2Flags;
 use crate::pdu::v2_header::{LOG_WINDOW_SIZE_MAX, V2Header};
-use crate::pdu::{V1Datagram, V2Packet};
+use crate::pdu::{SourceData, SourcePayloadHeader, V1AckOfAcksHeader, V1Datagram, V2Packet};
 use crate::recv_window::RecvWindow;
 use crate::reliability::ReliabilityController;
 use crate::rtt::RttEstimator;
@@ -133,6 +133,14 @@ pub struct ConnectionConfig {
     /// The server holds the same value and compares it against the client's
     /// SYN, which is the check 3.1.5.1.1 asks of it.
     pub cookie_hash: Option<[u8; 32]>,
+
+    /// The protocol version the client SYN offers (MS-RDPEUDP 2.2.2.9).
+    ///
+    /// Version 3 selects MS-RDPEUDP2 and requires `cookie_hash`. Offering
+    /// version 2 or 1 asks for the MS-RDPEUDP framing outright, which is what
+    /// a server that only speaks those versions answers; the SYN then carries
+    /// no cookie hash, as the specification requires.
+    pub offer_version: UdpVersion,
 }
 
 impl Default for ConnectionConfig {
@@ -145,6 +153,7 @@ impl Default for ConnectionConfig {
             idle_timeout: Duration::from_secs(65),
             keep_alive_interval: Duration::from_secs(8),
             cookie_hash: None,
+            offer_version: UdpVersion::V3,
         }
     }
 }
@@ -199,6 +208,16 @@ const HANDSHAKE_RETRANSMIT_LIMIT: u8 = 5;
 /// any of it drains.
 const SEND_BUFFER_WINDOW_MULTIPLE: usize = 8;
 
+/// Bytes reserved in a version 1/2 Source Packet for the FEC header (8), an ACK
+/// vector of up to [`V1_ACK_VECTOR_MAX_ELEMENTS`] elements with its size field and
+/// DWORD padding (36), an optional ACK-of-ACKs header (4) and the source payload
+/// header (8).
+const V1_DATA_OVERHEAD: usize = 8 + 36 + 4 + 8;
+/// Elements kept in an outgoing version 1/2 ACK vector; the oldest runs are dropped.
+const V1_ACK_VECTOR_MAX_ELEMENTS: usize = 32;
+/// MS-RDPEUDP 2.2.2.6: an ACK-of-ACKs SHOULD follow every 20 datagrams.
+const V1_ACK_OF_ACKS_INTERVAL: u32 = 20;
+
 /// Connection state in the handshake / lifecycle FSM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
@@ -223,6 +242,16 @@ struct Acknowledgement {
 }
 
 /// Negotiated parameters from the handshake.
+/// Which data-transfer framing the handshake settled on (MS-RDPEUDP 3.1.5.1.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WireFormat {
+    /// MS-RDPEUDP version 1 or 2: `RDPUDP_FEC_HEADER` datagrams. The two differ only
+    /// in their minimum timers (2.2.2.9).
+    V1 { version: u16 },
+    /// MS-RDPEUDP2 (version 3).
+    V2,
+}
+
 #[derive(Debug, Clone)]
 struct NegotiatedParams {
     /// Our ISN (from our SYN).
@@ -233,6 +262,8 @@ struct NegotiatedParams {
     mtu: u16,
     /// log2 of the window size.
     log_window_size: u8,
+    /// Framing selected by the SYN+ACK.
+    wire: WireFormat,
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -369,6 +400,49 @@ pub struct RdpeudpConnection {
 
     /// Reusable wire encoding buffer.
     wire_buf: Vec<u8>,
+
+    /// Next `snCoded` for a version 1/2 Source Packet (MS-RDPEUDP 3.1.5.1.4).
+    v1_next_coded: u32,
+    /// Datagrams sent since the last `RDPUDP_ACK_OF_ACKVECTOR_HEADER` (MS-RDPEUDP 2.2.2.6).
+    v1_since_ack_of_acks: u32,
+    /// A Congestion Notification was seen; the next Source Packet must carry CWR (MS-RDPEUDP 3.1.1.8).
+    v1_cwr_pending: bool,
+    /// When the sender last reduced its window for a CN; it reacts at most once per RTT.
+    v1_last_cn_reaction: Option<MonotonicInstant>,
+    /// The pending acknowledgement is being sent because the delayed-ACK timer fired (MS-RDPEUDP 3.1.6.3).
+    v1_ack_delayed: bool,
+    /// Diagnostics: retransmitted Source Packets, ACKs sent, datagrams and Source Packets received.
+    v1_stats: V1Counters,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct V1Counters {
+    retransmits: u64,
+    acks_sent: u64,
+    datagrams_in: u64,
+    data_in: u64,
+    data_out: u64,
+}
+
+/// A snapshot of the MS-RDPEUDP version 1/2 data path, for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct V1Stats {
+    pub version: u16,
+    pub send_pending: usize,
+    pub bytes_in_flight: u64,
+    pub send_next_source: u64,
+    pub send_lowest_pending: Option<u64>,
+    pub retransmits: u64,
+    pub data_out: u64,
+    pub acks_sent: u64,
+    pub datagrams_in: u64,
+    pub data_in: u64,
+    pub recv_base: u64,
+    pub recv_highest: u64,
+    pub recv_reorder: usize,
+    pub recv_has_gaps: bool,
+    pub srtt_ms: Option<u64>,
+    pub rto_ms: u64,
 }
 
 impl RdpeudpConnection {
@@ -392,7 +466,7 @@ impl RdpeudpConnection {
             ));
         }
 
-        if config.cookie_hash.is_none() {
+        if config.cookie_hash.is_none() && config.offer_version == UdpVersion::V3 {
             return Err(RdpeudpError::invalid_state(
                 "connect without ConnectionConfig::cookie_hash, which a version 3 SYN must carry",
             ));
@@ -487,6 +561,7 @@ impl RdpeudpConnection {
             remote_isn,
             mtu,
             log_window_size: conn.config.log_window_size,
+            wire: WireFormat::V2,
         });
 
         conn.enqueue_syn_ack(remote_isn, now);
@@ -519,6 +594,12 @@ impl RdpeudpConnection {
             ack_delay_started_at: None,
             remote_timestamp_ref: 0,
             wire_buf: Vec::with_capacity(1400),
+            v1_next_coded: 0,
+            v1_since_ack_of_acks: 0,
+            v1_cwr_pending: false,
+            v1_last_cn_reaction: None,
+            v1_ack_delayed: false,
+            v1_stats: V1Counters::default(),
         }
     }
 
@@ -602,6 +683,10 @@ impl RdpeudpConnection {
     ///
     /// [`send`]: Self::send
     pub fn max_payload(&self) -> usize {
+        if let Some(params) = self.params.as_ref().filter(|p| matches!(p.wire, WireFormat::V1 { .. })) {
+            return usize::from(params.mtu).saturating_sub(V1_DATA_OVERHEAD).max(1);
+        }
+
         let mtu = self
             .params
             .as_ref()
@@ -637,7 +722,11 @@ impl RdpeudpConnection {
                     return Ok(());
                 }
 
-                self.handle_v2_packet(wire, now)
+                if self.wire_is_v1() {
+                    self.handle_v1_datagram(wire, now)
+                } else {
+                    self.handle_v2_packet(wire, now)
+                }
             }
             State::Closed => Err(RdpeudpError::connection_closed("handle datagram")),
         }
@@ -812,12 +901,61 @@ impl RdpeudpConnection {
 
     /// Current retransmission timeout.
     pub fn rto(&self) -> Duration {
-        self.rtt.rto()
+        self.effective_rto()
+    }
+
+    /// The retransmit timeout with the negotiated version's floor applied
+    /// (MS-RDPEUDP 3.1.6.1): 500 ms for version 1, 300 ms for version 2.
+    fn effective_rto(&self) -> Duration {
+        Self::apply_rto_floor(self.params.as_ref().map(|p| p.wire), self.rtt.rto())
+    }
+
+    fn apply_rto_floor(wire: Option<WireFormat>, rto: Duration) -> Duration {
+        match wire {
+            Some(WireFormat::V1 { version }) if version < 2 => rto.max(Duration::from_millis(500)),
+            Some(WireFormat::V1 { .. }) => rto.max(Duration::from_millis(300)),
+            _ => rto,
+        }
+    }
+
+    fn wire_is_v1(&self) -> bool {
+        matches!(self.params.as_ref().map(|p| p.wire), Some(WireFormat::V1 { .. }))
     }
 
     /// Negotiated MTU (maximum payload per packet), if handshake is complete.
     pub fn mtu(&self) -> Option<u16> {
         self.params.as_ref().map(|p| p.mtu)
+    }
+
+    /// Diagnostics for the MS-RDPEUDP version 1/2 data path; `None` on MS-RDPEUDP2.
+    pub fn v1_stats(&self) -> Option<V1Stats> {
+        let params = self.params.as_ref()?;
+        let WireFormat::V1 { version } = params.wire else {
+            return None;
+        };
+        let send_window = self.send_window.as_ref()?;
+        let recv_window = self.recv_window.as_ref()?;
+        Some(V1Stats {
+            version,
+            send_pending: send_window.pending_entries().count(),
+            bytes_in_flight: send_window.bytes_in_flight(),
+            send_next_source: send_window.next_channel_seq(),
+            send_lowest_pending: send_window.pending_entries().map(|e| e.channel_seq).min(),
+            retransmits: self.v1_stats.retransmits,
+            data_out: self.v1_stats.data_out,
+            acks_sent: self.v1_stats.acks_sent,
+            datagrams_in: self.v1_stats.datagrams_in,
+            data_in: self.v1_stats.data_in,
+            recv_base: recv_window.base_seq(),
+            recv_highest: recv_window.highest_seq(),
+            recv_reorder: recv_window.reorder_buf_len(),
+            recv_has_gaps: recv_window.has_gaps(),
+            srtt_ms: self
+                .rtt
+                .srtt()
+                .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX)),
+            rto_ms: u64::try_from(self.effective_rto().as_millis()).unwrap_or(u64::MAX),
+        })
     }
 
     /// The ACK delay timeout to use right now.
@@ -838,6 +976,18 @@ impl RdpeudpConnection {
     fn ack_delay_timeout(&self) -> Duration {
         const FLOOR: Duration = Duration::from_millis(50);
         const CEILING: Duration = Duration::from_millis(200);
+
+        // MS-RDPEUDP 3.1.6.3: version 1 delays exactly 200 ms; version 2 uses
+        // max(50 ms, RTT/2) capped at 200 ms, which MS-RDPEUDP2 also does.
+        if let Some(NegotiatedParams {
+            wire: WireFormat::V1 { version },
+            ..
+        }) = self.params.as_ref()
+        {
+            if *version < 2 {
+                return CEILING;
+            }
+        }
 
         match self.rtt.srtt() {
             Some(srtt) => (srtt / 2).clamp(FLOOR, CEILING),
@@ -871,11 +1021,16 @@ impl RdpeudpConnection {
                 // (1.3.2.2). Version 2 is the same v1 data transfer with
                 // shorter timers, so advertising it and then speaking v2
                 // framing leaves the peer unable to parse anything.
-                udp_ver: UdpVersion::V3,
+                udp_ver: self.config.offer_version,
                 // 2.2.2.9: mandatory with version 3 in a client SYN.
                 // `connect` refuses to build a connection without it.
-                cookie_hash: self.config.cookie_hash,
+                cookie_hash: if self.config.offer_version == UdpVersion::V3 {
+                    self.config.cookie_hash
+                } else {
+                    None
+                },
             }),
+            data: None,
         };
 
         if !self.enqueue_handshake(&datagram) {
@@ -883,7 +1038,7 @@ impl RdpeudpConnection {
         }
         self.handshake_sent_at = Some(now);
 
-        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+        self.timers.set(Timer::Retransmit, now + self.effective_rto());
         self.timers.set(Timer::Idle, now + self.config.idle_timeout);
     }
 
@@ -912,6 +1067,7 @@ impl RdpeudpConnection {
                 // "It MUST NOT be present in any other case."
                 cookie_hash: None,
             }),
+            data: None,
         };
 
         if !self.enqueue_handshake(&datagram) {
@@ -919,7 +1075,7 @@ impl RdpeudpConnection {
         }
         self.handshake_sent_at = Some(now);
 
-        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+        self.timers.set(Timer::Retransmit, now + self.effective_rto());
     }
 
     /// Queue a handshake datagram and keep a copy for retransmission.
@@ -993,12 +1149,16 @@ impl RdpeudpConnection {
         // supported by both endpoints", and per 3.1.5.1.3 that is the version
         // both MUST then use. Anything below 3 means the server settled on the
         // MS-RDPEUDP data transfer, which this crate does not speak.
-        if !syn_data_ex.udp_ver.uses_v2_wire_format() {
-            return Err(RdpeudpError::invalid_packet(
-                "handle SYN+ACK",
-                "server settled on a protocol version below 3, whose data transfer is MS-RDPEUDP rather than MS-RDPEUDP2",
-            ));
-        }
+        // 3.1.5.1.3: the SYN+ACK carries the version both endpoints MUST use.
+        // Version 3 selects the MS-RDPEUDP2 framing; 1 and 2 select the
+        // MS-RDPEUDP one, which this crate also implements for reliable transport.
+        let wire = if syn_data_ex.udp_ver.uses_v2_wire_format() {
+            WireFormat::V2
+        } else {
+            WireFormat::V1 {
+                version: syn_data_ex.udp_ver.0,
+            }
+        };
 
         let local_isn = self.config.initial_sequence_number;
         let remote_isn = syn_data.initial_sequence_number;
@@ -1015,6 +1175,7 @@ impl RdpeudpConnection {
             remote_isn,
             mtu,
             log_window_size: self.config.log_window_size,
+            wire,
         });
 
         // Sample before enqueuing the final ACK. `enqueue_final_ack` calls
@@ -1075,6 +1236,7 @@ impl RdpeudpConnection {
             syn_data: None,
             correlation_id: None,
             syn_data_ex: None,
+            data: None,
         };
 
         let _queued = self.enqueue_handshake(&datagram);
@@ -1123,18 +1285,25 @@ impl RdpeudpConnection {
         let local_initial_data_seq = u64::from(params.local_isn) + 1;
         let remote_initial_data_seq = u64::from(params.remote_isn) + 1;
 
-        // Channel sequence numbers start at 1
-        let initial_channel_seq = 1u64;
+        // MS-RDPEUDP2 numbers channel data from 1. MS-RDPEUDP (3.1.1.2) has a single
+        // Source sequence space starting at the ISN + 1, so both windows use it.
+        let (local_initial_channel_seq, remote_initial_channel_seq) = match params.wire {
+            WireFormat::V1 { .. } => (local_initial_data_seq, remote_initial_data_seq),
+            WireFormat::V2 => (1u64, 1u64),
+        };
+        if let WireFormat::V1 { .. } = params.wire {
+            self.v1_next_coded = params.local_isn.wrapping_add(1);
+        }
 
         self.send_window = Some(SendWindow::new(
             local_initial_data_seq,
-            initial_channel_seq,
+            local_initial_channel_seq,
             params.log_window_size,
         ));
 
         self.recv_window = Some(RecvWindow::new(
             remote_initial_data_seq,
-            initial_channel_seq,
+            remote_initial_channel_seq,
             params.log_window_size,
         ));
 
@@ -1431,7 +1600,7 @@ impl RdpeudpConnection {
         };
 
         let highest_acked = send_window.highest_acked_data_seq();
-        let rto = self.rtt.rto();
+        let rto = Self::apply_rto_floor(self.params.as_ref().map(|p| p.wire), self.rtt.rto());
 
         let lost_seqs = self.loss_detector.detect(send_window, highest_acked, rto, now);
 
@@ -1518,7 +1687,7 @@ impl RdpeudpConnection {
         if has_pending || self.reliability.has_pending() {
             // Keep the timer running
             if !self.timers.is_set(Timer::Retransmit) {
-                self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+                self.timers.set(Timer::Retransmit, now + self.effective_rto());
             }
         } else {
             // Nothing outstanding: clear the timer
@@ -1548,6 +1717,7 @@ impl RdpeudpConnection {
         }
 
         let entry = self.reliability.dequeue()?;
+        self.v1_stats.retransmits += 1;
 
         // Create a new DataSeqNum for the retransmit but preserve ChannelSeqNum
         let new_data_seq = send_window.push_retransmit(entry.channel_seq, entry.data.clone(), now)?;
@@ -1556,7 +1726,7 @@ impl RdpeudpConnection {
 
         if transmit.is_some() {
             // Reset retransmit timer
-            self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+            self.timers.set(Timer::Retransmit, now + self.effective_rto());
         }
 
         transmit
@@ -1589,7 +1759,7 @@ impl RdpeudpConnection {
         if transmit.is_some() {
             // Set retransmit timer if not already running
             if !self.timers.is_set(Timer::Retransmit) {
-                self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+                self.timers.set(Timer::Retransmit, now + self.effective_rto());
             }
         }
 
@@ -1604,6 +1774,11 @@ impl RdpeudpConnection {
         data: Vec<u8>,
         now: MonotonicInstant,
     ) -> Option<Transmit> {
+        if self.wire_is_v1() {
+            let _ = data_seq;
+            return self.build_v1_data_packet(channel_seq, data, now);
+        }
+
         let log_window_size = self.params.as_ref()?.log_window_size;
 
         let mut flags = V2Flags::DATA;
@@ -1663,6 +1838,10 @@ impl RdpeudpConnection {
 
     /// Build a standalone ACK (no data).
     fn build_standalone_ack(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        if self.wire_is_v1() {
+            return self.build_v1_standalone_ack(now);
+        }
+
         let log_window_size = self.params.as_ref()?.log_window_size;
 
         let acknowledgement = self.build_acknowledgement(now)?;
@@ -1870,13 +2049,14 @@ impl RdpeudpConnection {
 
         // 3.1.6.1 wants the timer to keep firing at no less than the same
         // interval; `on_timeout` above has already backed the RTO off.
-        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+        self.timers.set(Timer::Retransmit, now + self.effective_rto());
     }
 
     /// Handle ACK delay timer expiry: send a standalone ACK.
     fn handle_ack_delay_timeout(&mut self, _now: MonotonicInstant) {
         self.timers.clear(Timer::AckDelay);
         self.ack_pending = true;
+        self.v1_ack_delayed = true;
     }
 
     /// Handle idle timeout: close the connection.
@@ -1893,6 +2073,293 @@ impl RdpeudpConnection {
 
         self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // MS-RDPEUDP version 1/2 data transfer (reliable mode)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// Handles an established-state datagram in `RDPUDP_FEC_HEADER` framing.
+    fn handle_v1_datagram(&mut self, wire: &[u8], now: MonotonicInstant) -> Result<(), RdpeudpError> {
+        let datagram: V1Datagram = decode(wire).map_err(RdpeudpError::decode)?;
+        self.v1_stats.datagrams_in += 1;
+
+        // A late handshake retransmit; the peer is already answered elsewhere.
+        if datagram.header.flags.contains(V1Flags::SYN) {
+            return Ok(());
+        }
+
+        let delayed = datagram.header.flags.contains(V1Flags::ACKDELAYED);
+        if datagram.header.flags.contains(V1Flags::ACK) {
+            self.process_v1_acknowledgement(&datagram.header, datagram.ack_vector.as_ref(), delayed, now);
+        }
+
+        if datagram.header.flags.contains(V1Flags::CN) {
+            self.react_to_v1_congestion_notification(now);
+        }
+
+        if let Some(ack_of_acks) = datagram.ack_of_acks {
+            self.process_v1_ack_of_acks(ack_of_acks);
+        }
+
+        if let Some(data) = datagram.data {
+            self.process_v1_data(data, now);
+        }
+
+        Ok(())
+    }
+
+    /// MS-RDPEUDP 3.1.1.4: `snSourceAck` is the highest Source sequence number
+    /// the peer has seen, and the ACK vector walks down from it, one run at a
+    /// time, saying which of those Source Packets arrived.
+    fn process_v1_acknowledgement(
+        &mut self,
+        header: &FecHeader,
+        ack_vector: Option<&V1AckVectorHeader>,
+        delayed: bool,
+        now: MonotonicInstant,
+    ) {
+        let Some(send_window) = self.send_window.as_mut() else {
+            return;
+        };
+
+        let reference = send_window.next_channel_seq().saturating_sub(1);
+        let highest_seen = seq::reconstruct_seq32(header.sn_source_ack, reference);
+
+        let mut acked: Vec<(u64, bool, MonotonicInstant)> = Vec::new();
+        if let Some(vector) = ack_vector {
+            let mut current = Some(highest_seen);
+            for element in &vector.elements {
+                // Windows encodes a run of n datagrams as n - 1 (an element of 0x00
+                // acknowledges exactly one), which 2.2.2.7.1's prose leaves open.
+                for _ in 0..=element.length {
+                    let Some(source_seq) = current else {
+                        break;
+                    };
+                    if element.state.is_received() {
+                        if let Some(entry) = send_window.pending_entries().find(|e| e.channel_seq == source_seq) {
+                            acked.push((entry.data_seq, entry.transmit_count == 1, entry.sent_at));
+                        }
+                    }
+                    current = source_seq.checked_sub(1);
+                }
+            }
+        }
+
+        let mut newly_acked_bytes: u64 = 0;
+        let mut rtt_sample = None;
+        for (data_seq, first_transmission, sent_at) in acked {
+            if let Some(size) = send_window.mark_received(data_seq) {
+                newly_acked_bytes += u64::try_from(size).expect("packet size fits in u64");
+                if first_transmission && !delayed {
+                    rtt_sample = Some(now.duration_since(sent_at));
+                }
+            }
+        }
+
+        if let Some(sample) = rtt_sample {
+            self.rtt.update(sample);
+        }
+
+        if newly_acked_bytes > 0 {
+            self.congestion.on_ack(newly_acked_bytes);
+        }
+
+        self.run_loss_detection(now);
+
+        if newly_acked_bytes > 0 {
+            self.timers.clear(Timer::Retransmit);
+        }
+        self.update_retransmit_timer(now);
+    }
+
+    /// MS-RDPEUDP 3.1.1.8: react to a Congestion Notification at most once per
+    /// RTT and answer it with CWR on the next Source Packet.
+    fn react_to_v1_congestion_notification(&mut self, now: MonotonicInstant) {
+        let rtt = self.rtt.srtt().unwrap_or_else(|| self.effective_rto());
+        let recently = self
+            .v1_last_cn_reaction
+            .is_some_and(|last| now.duration_since(last) < rtt);
+        if recently {
+            return;
+        }
+        if let Some(send_window) = self.send_window.as_ref() {
+            let largest_sent = send_window.next_data_seq().saturating_sub(1);
+            self.congestion.on_loss(largest_sent, largest_sent);
+        }
+        self.v1_last_cn_reaction = Some(now);
+        self.v1_cwr_pending = true;
+    }
+
+    /// MS-RDPEUDP 2.2.2.6: the receiver only reports Source Packets above `snResetSeqNum`.
+    fn process_v1_ack_of_acks(&mut self, ack_of_acks: V1AckOfAcksHeader) {
+        let Some(recv_window) = self.recv_window.as_mut() else {
+            return;
+        };
+        let reference = recv_window.highest_seq();
+        let reset = seq::reconstruct_seq32(ack_of_acks.reset_seq_num, reference);
+        recv_window.advance_base(reset.saturating_add(1));
+    }
+
+    /// MS-RDPEUDP 3.1.5.3.3: accept in-window Source Packets, deliver in order,
+    /// and schedule a (delayed) acknowledgement.
+    fn process_v1_data(&mut self, data: SourceData, now: MonotonicInstant) {
+        let Some(recv_window) = self.recv_window.as_mut() else {
+            return;
+        };
+
+        let reference = recv_window.highest_seq();
+        let source_seq = seq::reconstruct_seq32(data.header.sn_source_start, reference);
+
+        if !recv_window.receive(source_seq, source_seq, data.payload) {
+            return;
+        }
+        self.v1_stats.data_in += 1;
+
+        for chunk in recv_window.drain_ordered() {
+            self.pending_events.push_back(Event::DataReceived(chunk));
+        }
+
+        self.ack_pending = true;
+        if !self.timers.is_set(Timer::AckDelay) {
+            self.timers.set(Timer::AckDelay, now + self.ack_delay_timeout());
+            self.ack_delay_started_at = Some(now);
+        }
+    }
+
+    /// The `RDPUDP_FEC_HEADER` and ACK vector describing what we have received
+    /// (MS-RDPEUDP 3.1.5.1.2): `snSourceAck` is the highest Source sequence
+    /// number seen and the vector runs down from it.
+    fn build_v1_ack_parts(&self, flags: V1Flags) -> Option<(FecHeader, V1AckVectorHeader)> {
+        let params = self.params.as_ref()?;
+        let recv_window = self.recv_window.as_ref()?;
+
+        let mut elements: Vec<V1AckVectorElement> = Vec::new();
+        'runs: for (received, count) in recv_window.ack_vector().into_iter().rev() {
+            let mut remaining = count;
+            while remaining > 0 {
+                if elements.len() >= V1_ACK_VECTOR_MAX_ELEMENTS {
+                    break 'runs;
+                }
+                let chunk = u8::try_from(remaining.min(u64::from(V1AckVectorElement::MAX_LENGTH) + 1))
+                    .expect("clamped to 6-bit range plus one");
+                elements.push(V1AckVectorElement {
+                    state: if received {
+                        VectorElementState::DatagramReceived
+                    } else {
+                        VectorElementState::DatagramNotYetReceived
+                    },
+                    // Wire length is count - 1; see process_v1_acknowledgement.
+                    length: chunk - 1,
+                });
+                remaining -= u64::from(chunk);
+            }
+        }
+        if elements.is_empty() {
+            // Nothing since the handshake: acknowledge the SYN+ACK's own sequence number.
+            elements.push(V1AckVectorElement {
+                state: VectorElementState::DatagramReceived,
+                length: 0,
+            });
+        }
+
+        let mut flags = flags | V1Flags::ACK;
+        if self.v1_ack_delayed {
+            flags |= V1Flags::ACKDELAYED;
+        }
+
+        let header = FecHeader {
+            sn_source_ack: seq::truncate_seq32(recv_window.highest_seq()),
+            receive_window_size: 1u16 << u16::from(params.log_window_size),
+            flags,
+        };
+
+        Some((header, V1AckVectorHeader { elements }))
+    }
+
+    /// MS-RDPEUDP 2.2.2.6: every 20 datagrams, tell the peer the highest Source
+    /// sequence number below which everything we sent was acknowledged.
+    fn take_v1_ack_of_acks(&mut self) -> Option<V1AckOfAcksHeader> {
+        self.v1_since_ack_of_acks += 1;
+        if self.v1_since_ack_of_acks < V1_ACK_OF_ACKS_INTERVAL {
+            return None;
+        }
+        self.v1_since_ack_of_acks = 0;
+        let send_window = self.send_window.as_ref()?;
+        let cumulative = send_window
+            .pending_entries()
+            .map(|entry| entry.channel_seq)
+            .min()
+            .unwrap_or_else(|| send_window.next_channel_seq())
+            .saturating_sub(1);
+        Some(V1AckOfAcksHeader {
+            reset_seq_num: seq::truncate_seq32(cumulative),
+        })
+    }
+
+    fn finish_v1_acknowledgement(&mut self) {
+        self.v1_stats.acks_sent += 1;
+        self.commit_acknowledgement();
+        self.ack_pending = false;
+        self.timers.clear(Timer::AckDelay);
+        self.v1_ack_delayed = false;
+    }
+
+    /// MS-RDPEUDP 3.1.5.1.4: an ACK datagram carrying one Source Packet.
+    fn build_v1_data_packet(&mut self, channel_seq: u64, data: Vec<u8>, now: MonotonicInstant) -> Option<Transmit> {
+        let _ = now;
+        let mut flags = V1Flags::DATA;
+        if self.v1_cwr_pending {
+            flags |= V1Flags::CWR;
+        }
+        let (header, ack_vector) = self.build_v1_ack_parts(flags)?;
+        let ack_of_acks = self.take_v1_ack_of_acks();
+
+        let sn_coded = self.v1_next_coded;
+        self.v1_next_coded = sn_coded.wrapping_add(1);
+
+        let datagram = V1Datagram {
+            header,
+            ack_vector: Some(ack_vector),
+            ack_of_acks,
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+            data: Some(SourceData {
+                header: SourcePayloadHeader {
+                    sn_coded,
+                    sn_source_start: seq::truncate_seq32(channel_seq),
+                },
+                payload: data,
+            }),
+        };
+
+        let contents = encode_vec(&datagram).ok()?;
+        self.v1_cwr_pending = false;
+        self.v1_stats.data_out += 1;
+        self.finish_v1_acknowledgement();
+        Some(Transmit { contents })
+    }
+
+    /// MS-RDPEUDP 3.1.5.1.2: a standalone ACK datagram; also our keepalive (3.1.1.9).
+    fn build_v1_standalone_ack(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        let _ = now;
+        let (header, ack_vector) = self.build_v1_ack_parts(V1Flags::empty())?;
+        let ack_of_acks = self.take_v1_ack_of_acks();
+
+        let datagram = V1Datagram {
+            header,
+            ack_vector: Some(ack_vector),
+            ack_of_acks,
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+            data: None,
+        };
+
+        let contents = encode_vec(&datagram).ok()?;
+        self.finish_v1_acknowledgement();
+        Some(Transmit { contents })
+    }
 }
 
 impl core::fmt::Debug for RdpeudpConnection {
@@ -1900,7 +2367,7 @@ impl core::fmt::Debug for RdpeudpConnection {
         f.debug_struct("RdpeudpConnection")
             .field("side", &self.side)
             .field("state", &self.state)
-            .field("rto", &self.rtt.rto())
+            .field("rto", &self.effective_rto())
             .field("srtt", &self.rtt.srtt())
             .field("pending_transmits", &self.pending_transmits.len())
             .field("pending_events", &self.pending_events.len())
@@ -2104,5 +2571,229 @@ mod tests {
         conn.sample_handshake_rtt(sent_at + Duration::from_millis(40));
 
         assert_eq!(conn.rtt.srtt(), None);
+    }
+}
+
+#[cfg(test)]
+mod v1_tests {
+    use super::*;
+
+    const LOCAL_ISN: u32 = 5000;
+    const REMOTE_ISN: u32 = 1000;
+
+    fn config() -> ConnectionConfig {
+        ConnectionConfig {
+            initial_sequence_number: LOCAL_ISN,
+            cookie_hash: Some([0x5A; 32]),
+            ..ConnectionConfig::default()
+        }
+    }
+
+    fn at(ms: u64) -> MonotonicInstant {
+        MonotonicInstant::from_millis(ms)
+    }
+
+    fn syn_ack(version: u16) -> Vec<u8> {
+        encode_vec(&V1Datagram {
+            header: FecHeader {
+                sn_source_ack: LOCAL_ISN,
+                receive_window_size: 64,
+                flags: V1Flags::SYN | V1Flags::ACK,
+            },
+            ack_vector: None,
+            ack_of_acks: None,
+            syn_data: Some(SynDataPayload {
+                initial_sequence_number: REMOTE_ISN,
+                upstream_mtu: 1232,
+                downstream_mtu: 1232,
+            }),
+            correlation_id: None,
+            syn_data_ex: Some(SynDataExPayload {
+                syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+                udp_ver: UdpVersion(version),
+                cookie_hash: None,
+            }),
+            data: None,
+        })
+        .unwrap()
+    }
+
+    /// A server ACK (optionally carrying data) in MS-RDPEUDP framing.
+    fn server_datagram(highest_seen: u32, received: &[(bool, u8)], data: Option<(u32, &[u8])>) -> Vec<u8> {
+        encode_vec(&V1Datagram {
+            header: FecHeader {
+                sn_source_ack: highest_seen,
+                receive_window_size: 64,
+                flags: V1Flags::empty(),
+            },
+            ack_vector: Some(V1AckVectorHeader {
+                elements: received
+                    .iter()
+                    .map(|(r, n)| V1AckVectorElement {
+                        state: if *r {
+                            VectorElementState::DatagramReceived
+                        } else {
+                            VectorElementState::DatagramNotYetReceived
+                        },
+                        length: n - 1, // wire runs are count - 1
+                    })
+                    .collect(),
+            }),
+            ack_of_acks: None,
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+            data: data.map(|(seq, payload)| SourceData {
+                header: SourcePayloadHeader {
+                    sn_coded: seq,
+                    sn_source_start: seq,
+                },
+                payload: payload.to_vec(),
+            }),
+        })
+        .unwrap()
+    }
+
+    fn established(version: u16) -> RdpeudpConnection {
+        let mut conn = RdpeudpConnection::connect(config(), at(0)).unwrap();
+        let syn = conn.poll_transmit(at(0)).expect("client SYN");
+        let decoded: V1Datagram = decode(&syn.contents).unwrap();
+        assert!(decoded.header.flags.contains(V1Flags::SYN));
+
+        let mut wire = syn_ack(version);
+        conn.handle_datagram(&mut wire, at(20))
+            .expect("SYN+ACK with an MS-RDPEUDP version is accepted");
+        assert_eq!(conn.poll_event(), Some(Event::Connected));
+        assert!(conn.is_established());
+
+        let final_ack = conn.poll_transmit(at(20)).expect("final ACK");
+        let decoded: V1Datagram = decode(&final_ack.contents).unwrap();
+        assert!(decoded.header.flags.contains(V1Flags::ACK));
+        assert_eq!(decoded.header.sn_source_ack, REMOTE_ISN);
+        conn
+    }
+
+    #[test]
+    fn version_2_syn_ack_selects_the_rdpeudp_framing() {
+        let conn = established(2);
+        assert_eq!(conn.params.as_ref().unwrap().wire, WireFormat::V1 { version: 2 });
+        assert!(conn.effective_rto() >= Duration::from_millis(300));
+        assert_eq!(conn.max_payload(), 1232 - V1_DATA_OVERHEAD);
+    }
+
+    #[test]
+    fn version_1_uses_its_longer_timers() {
+        let conn = established(1);
+        assert!(conn.effective_rto() >= Duration::from_millis(500));
+        assert_eq!(conn.ack_delay_timeout(), Duration::from_millis(200));
+    }
+
+    #[test]
+    fn data_goes_out_as_a_source_packet_with_an_ack() {
+        let mut conn = established(2);
+        conn.send(b"hello".to_vec()).unwrap();
+        let out = conn.poll_transmit(at(30)).expect("source packet");
+        let datagram: V1Datagram = decode(&out.contents).unwrap();
+
+        assert!(datagram.header.flags.contains(V1Flags::DATA | V1Flags::ACK));
+        assert_eq!(datagram.header.sn_source_ack, REMOTE_ISN, "nothing received yet");
+        let data = datagram.data.expect("source payload");
+        assert_eq!(data.header.sn_source_start, LOCAL_ISN + 1);
+        assert_eq!(data.header.sn_coded, LOCAL_ISN + 1);
+        assert_eq!(data.payload, b"hello");
+        assert_eq!(datagram.ack_vector.unwrap().elements.len(), 1);
+        assert!(conn.poll_transmit(at(31)).is_none(), "single packet, no ack pending");
+    }
+
+    #[test]
+    fn a_peer_ack_vector_retires_our_source_packet_and_no_retransmit_follows() {
+        let mut conn = established(2);
+        conn.send(b"hello".to_vec()).unwrap();
+        let _ = conn.poll_transmit(at(30)).unwrap();
+
+        // Server saw LOCAL_ISN+1 and acknowledges exactly it.
+        let mut ack = server_datagram(LOCAL_ISN + 1, &[(true, 1)], None);
+        conn.handle_datagram(&mut ack, at(60)).unwrap();
+
+        // Well past any RTO: nothing to retransmit.
+        conn.handle_timeout(at(5_000));
+        let next = conn.poll_transmit(at(5_000));
+        let is_data = next
+            .as_ref()
+            .and_then(|t| decode::<V1Datagram>(&t.contents).ok())
+            .is_some_and(|d| d.data.is_some());
+        assert!(!is_data, "acknowledged packet must not be retransmitted");
+    }
+
+    #[test]
+    fn an_unacknowledged_source_packet_is_retransmitted_with_a_new_coded_number() {
+        let mut conn = established(2);
+        conn.send(b"hello".to_vec()).unwrap();
+        let _ = conn.poll_transmit(at(30)).unwrap();
+
+        conn.handle_timeout(at(30 + 1_000));
+        let again = conn.poll_transmit(at(30 + 1_000)).expect("retransmit");
+        let datagram: V1Datagram = decode(&again.contents).unwrap();
+        let data = datagram.data.expect("retransmitted source payload");
+        assert_eq!(
+            data.header.sn_source_start,
+            LOCAL_ISN + 1,
+            "same Source sequence number"
+        );
+        assert_eq!(data.header.sn_coded, LOCAL_ISN + 2, "new Coded sequence number");
+        assert_eq!(data.payload, b"hello");
+    }
+
+    #[test]
+    fn server_data_is_delivered_in_order_and_acknowledged_from_the_highest_seen() {
+        let mut conn = established(2);
+
+        let mut second = server_datagram(LOCAL_ISN, &[(true, 1)], Some((REMOTE_ISN + 2, b"world")));
+        conn.handle_datagram(&mut second, at(40)).unwrap();
+        assert_eq!(conn.poll_event(), None, "out of order: held back");
+
+        let mut first = server_datagram(LOCAL_ISN, &[(true, 1)], Some((REMOTE_ISN + 1, b"hello ")));
+        conn.handle_datagram(&mut first, at(41)).unwrap();
+        assert_eq!(conn.poll_event(), Some(Event::DataReceived(b"hello ".to_vec())));
+        assert_eq!(conn.poll_event(), Some(Event::DataReceived(b"world".to_vec())));
+
+        // The delayed ACK fires and reports both, walking down from the highest seen.
+        conn.handle_timeout(at(41 + 250));
+        let ack = conn.poll_transmit(at(41 + 250)).expect("standalone ACK");
+        let datagram: V1Datagram = decode(&ack.contents).unwrap();
+        assert!(datagram.header.flags.contains(V1Flags::ACK));
+        assert!(datagram.header.flags.contains(V1Flags::ACKDELAYED));
+        assert!(datagram.data.is_none());
+        assert_eq!(datagram.header.sn_source_ack, REMOTE_ISN + 2);
+        let elements = datagram.ack_vector.unwrap().elements;
+        assert_eq!(elements.len(), 1);
+        assert!(elements[0].state.is_received());
+        assert_eq!(elements[0].length, 1, "two datagrams, encoded as count - 1");
+    }
+
+    #[test]
+    fn a_gap_is_reported_as_not_yet_received() {
+        let mut conn = established(2);
+        let mut third = server_datagram(LOCAL_ISN, &[(true, 1)], Some((REMOTE_ISN + 3, b"c")));
+        conn.handle_datagram(&mut third, at(40)).unwrap();
+        conn.handle_timeout(at(400));
+        let ack = conn.poll_transmit(at(400)).expect("ACK");
+        let datagram: V1Datagram = decode(&ack.contents).unwrap();
+        assert_eq!(datagram.header.sn_source_ack, REMOTE_ISN + 3);
+        let elements = datagram.ack_vector.unwrap().elements;
+        // Highest first: +3 received, then +2 and +1 missing.
+        assert!(elements[0].state.is_received());
+        assert_eq!(elements[0].length, 0, "one datagram");
+        assert!(!elements[1].state.is_received());
+        assert_eq!(elements[1].length, 1, "two datagrams");
+    }
+
+    #[test]
+    fn version_3_still_selects_the_rdpeudp2_framing() {
+        let mut conn = RdpeudpConnection::connect(config(), at(0)).unwrap();
+        let _ = conn.poll_transmit(at(0));
+        let mut wire = syn_ack(0x0101);
+        conn.handle_datagram(&mut wire, at(20)).unwrap();
+        assert_eq!(conn.params.as_ref().unwrap().wire, WireFormat::V2);
     }
 }

--- a/crates/ironrdp-rdpeudp/src/connection.rs
+++ b/crates/ironrdp-rdpeudp/src/connection.rs
@@ -21,7 +21,7 @@
 //! framing from MS-RDPEUDP2 Section 2.2.1.3.
 
 use crate::time::MonotonicInstant;
-use alloc::collections::VecDeque;
+use alloc::collections::{BTreeMap, VecDeque};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use core::time::Duration;
@@ -1147,17 +1147,29 @@ impl RdpeudpConnection {
 
         // 3.1.5.1.1: the version in the SYN+ACK is "the highest version
         // supported by both endpoints", and per 3.1.5.1.3 that is the version
-        // both MUST then use. Anything below 3 means the server settled on the
-        // MS-RDPEUDP data transfer, which this crate does not speak.
-        // 3.1.5.1.3: the SYN+ACK carries the version both endpoints MUST use.
-        // Version 3 selects the MS-RDPEUDP2 framing; 1 and 2 select the
-        // MS-RDPEUDP one, which this crate also implements for reliable transport.
-        let wire = if syn_data_ex.udp_ver.uses_v2_wire_format() {
+        // both MUST then use. Version 3 selects the MS-RDPEUDP2 framing; 1 and
+        // 2 select the MS-RDPEUDP one, which this crate also implements for
+        // reliable transport. Anything else is not a version this crate
+        // speaks, and a selection above what our SYN offered is not one the
+        // peer could have found on both sides; refuse both rather than map
+        // them onto framing and timers chosen by default.
+        let selected = syn_data_ex.udp_ver;
+        if ![UdpVersion::V1, UdpVersion::V2, UdpVersion::V3].contains(&selected) {
+            return Err(RdpeudpError::invalid_packet(
+                "handle SYN+ACK",
+                "SYN+ACK selected a protocol version this crate does not implement",
+            ));
+        }
+        if selected.0 > self.config.offer_version.0 {
+            return Err(RdpeudpError::invalid_packet(
+                "handle SYN+ACK",
+                "SYN+ACK selected a protocol version above the one the SYN offered",
+            ));
+        }
+        let wire = if selected.uses_v2_wire_format() {
             WireFormat::V2
         } else {
-            WireFormat::V1 {
-                version: syn_data_ex.udp_ver.0,
-            }
+            WireFormat::V1 { version: selected.0 }
         };
 
         let local_isn = self.config.initial_sequence_number;
@@ -2129,17 +2141,31 @@ impl RdpeudpConnection {
 
         let mut acked: Vec<(u64, bool, MonotonicInstant)> = Vec::new();
         if let Some(vector) = ack_vector {
+            // Index the window once and look each represented sequence up:
+            // a decoded vector can name 2048 * 64 sequences, and scanning the
+            // window afresh for every one would let a small datagram cost
+            // span * window comparisons.
+            let pending: BTreeMap<u64, (u64, bool, MonotonicInstant)> = send_window
+                .pending_entries()
+                .map(|e| (e.channel_seq, (e.data_seq, e.transmit_count == 1, e.sent_at)))
+                .collect();
+            // Nothing below the lowest pending sequence can be newly
+            // acknowledged, so the walk ends there whatever the vector says.
+            let floor = pending.keys().next().copied();
             let mut current = Some(highest_seen);
-            for element in &vector.elements {
+            'elements: for element in &vector.elements {
                 // Windows encodes a run of n datagrams as n - 1 (an element of 0x00
                 // acknowledges exactly one), which 2.2.2.7.1's prose leaves open.
                 for _ in 0..=element.length {
                     let Some(source_seq) = current else {
-                        break;
+                        break 'elements;
                     };
+                    if floor.is_none_or(|floor| source_seq < floor) {
+                        break 'elements;
+                    }
                     if element.state.is_received() {
-                        if let Some(entry) = send_window.pending_entries().find(|e| e.channel_seq == source_seq) {
-                            acked.push((entry.data_seq, entry.transmit_count == 1, entry.sent_at));
+                        if let Some(entry) = pending.get(&source_seq) {
+                            acked.push(*entry);
                         }
                     }
                     current = source_seq.checked_sub(1);
@@ -2199,6 +2225,13 @@ impl RdpeudpConnection {
         };
         let reference = recv_window.highest_seq();
         let reset = seq::reconstruct_seq32(ack_of_acks.reset_seq_num, reference);
+        // `snResetSeqNum` is a Source sequence number the peer has seen us
+        // acknowledge, so it cannot run ahead of what we have received. One
+        // that does would push the window base into the future and leave every
+        // later Source Packet below it; drop it instead.
+        if reset > reference {
+            return;
+        }
         recv_window.advance_base(reset.saturating_add(1));
     }
 
@@ -2823,6 +2856,87 @@ mod v1_tests {
         );
         assert_eq!(data.header.sn_coded, LOCAL_ISN + 2, "new Coded sequence number");
         assert_eq!(data.payload, b"hello");
+    }
+
+    #[test]
+    fn a_syn_ack_selecting_an_unknown_version_is_rejected() {
+        let mut conn = RdpeudpConnection::connect(config(), at(0)).unwrap();
+        let _ = conn.poll_transmit(at(0)).expect("client SYN");
+        let mut wire = syn_ack(0x0004);
+        conn.handle_datagram(&mut wire, at(20))
+            .expect_err("version 4 is neither MS-RDPEUDP nor MS-RDPEUDP2");
+    }
+
+    #[test]
+    fn a_syn_ack_selecting_a_version_above_the_offer_is_rejected() {
+        let config = ConnectionConfig {
+            offer_version: UdpVersion::V2,
+            cookie_hash: None,
+            ..config()
+        };
+        let mut conn = RdpeudpConnection::connect(config, at(0)).unwrap();
+        let _ = conn.poll_transmit(at(0)).expect("client SYN");
+        let mut wire = syn_ack(UdpVersion::V3.0);
+        conn.handle_datagram(&mut wire, at(20))
+            .expect_err("the SYN offered version 2, so version 3 is not supported by both endpoints");
+    }
+
+    /// A reset ahead of everything received would push the window base into
+    /// the future and strand every later Source Packet below it.
+    #[test]
+    fn an_ack_of_acks_ahead_of_the_receive_window_is_ignored() {
+        let mut conn = established(2);
+
+        let mut first = server_datagram(LOCAL_ISN, &[(true, 1)], Some((REMOTE_ISN + 1, b"hello ")));
+        conn.handle_datagram(&mut first, at(40)).unwrap();
+        assert_eq!(conn.poll_event(), Some(Event::DataReceived(b"hello ".to_vec())));
+
+        let mut ack_of_acks = encode_vec(&V1Datagram {
+            header: FecHeader {
+                sn_source_ack: LOCAL_ISN,
+                receive_window_size: 64,
+                flags: V1Flags::empty(),
+            },
+            ack_vector: Some(V1AckVectorHeader {
+                elements: vec![V1AckVectorElement {
+                    state: VectorElementState::DatagramReceived,
+                    length: 0,
+                }],
+            }),
+            ack_of_acks: Some(V1AckOfAcksHeader {
+                reset_seq_num: REMOTE_ISN + 50,
+            }),
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+            data: None,
+        })
+        .unwrap();
+        conn.handle_datagram(&mut ack_of_acks, at(41)).unwrap();
+
+        let mut second = server_datagram(LOCAL_ISN, &[(true, 1)], Some((REMOTE_ISN + 2, b"world")));
+        conn.handle_datagram(&mut second, at(42)).unwrap();
+        assert_eq!(
+            conn.poll_event(),
+            Some(Event::DataReceived(b"world".to_vec())),
+            "a bogus reset must not strand later Source Packets"
+        );
+    }
+
+    /// A vector that runs far below anything outstanding is bounded by the
+    /// window, not by the vector: 2048 elements of 64 must still resolve the
+    /// one pending Source Packet and stop.
+    #[test]
+    fn an_oversized_ack_vector_still_acknowledges_what_is_pending() {
+        let mut conn = established(2);
+        conn.send(b"only".to_vec()).unwrap();
+        let _ = conn.poll_transmit(at(30)).unwrap();
+        assert_eq!(conn.send_window.as_ref().unwrap().pending_entries().count(), 1);
+
+        let runs: Vec<(bool, u8)> = core::iter::repeat_n((true, 64), 2048).collect();
+        let mut ack = server_datagram(LOCAL_ISN + 1, &runs, None);
+        conn.handle_datagram(&mut ack, at(50)).unwrap();
+        assert_eq!(conn.send_window.as_ref().unwrap().pending_entries().count(), 0);
     }
 
     #[test]

--- a/crates/ironrdp-rdpeudp/src/lib.rs
+++ b/crates/ironrdp-rdpeudp/src/lib.rs
@@ -18,6 +18,6 @@ pub(crate) mod rtt;
 pub(crate) mod send_window;
 pub(crate) mod timer;
 
-pub use self::connection::{ConnectionConfig, Event, RdpeudpConnection, Side, Transmit};
+pub use self::connection::{ConnectionConfig, Event, RdpeudpConnection, Side, Transmit, V1Stats};
 pub use self::error::{RdpeudpError, RdpeudpErrorExt, RdpeudpErrorKind, RdpeudpResult, SendError};
 pub use self::time::MonotonicInstant;

--- a/crates/ironrdp-rdpeudp/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/mod.rs
@@ -57,8 +57,9 @@ pub use v2_header::{LOG_WINDOW_SIZE_MAX, V2Header};
 
 /// V1 flags that don't gate any optional payload; preserved on encode.
 ///
-/// DATA and FEC are payload-gating but have no corresponding fields
-/// in V1Datagram (v1 data transfer is not supported).
+/// DATA is payload-gating too and is derived from `data`. FEC is
+/// payload-gating but has no field: FEC_PAYLOAD (2.2.2.5, lossy transport)
+/// is not supported, and `decode` rejects a datagram that announces one.
 const V1_STANDALONE_FLAGS: u16 = V1Flags::FIN.bits()
     | V1Flags::CN.bits()
     | V1Flags::CWR.bits()
@@ -67,7 +68,7 @@ const V1_STANDALONE_FLAGS: u16 = V1Flags::FIN.bits()
     | V1Flags::ACKDELAYED.bits();
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-/// A complete v1 datagram (SYN, SYN+ACK, or ACK).
+/// A complete v1 datagram (SYN, SYN+ACK, ACK, or Source Packet).
 ///
 /// MS-RDPEUDP Section 2.2.
 /// The FecHeader's flags field determines which optional payloads
@@ -83,6 +84,7 @@ const V1_STANDALONE_FLAGS: u16 = V1Flags::FIN.bits()
 /// 4. SynDataPayload (if SYN flag)
 /// 5. CorrelationIdPayload (if CORRELATION_ID flag)
 /// 6. SynDataExPayload (if SYNEX flag)
+/// 7. SourceData (if DATA flag; the payload runs to the end of the datagram)
 ///
 /// A SYN+ACK is the exception to the ACK flag's usual meaning. Section
 /// 2.2.2.1 defines the flag as "the ACK vector is present", but 3.1.5.1.3
@@ -92,8 +94,10 @@ const V1_STANDALONE_FLAGS: u16 = V1Flags::FIN.bits()
 /// directly, with no ACK vector between them. So on a SYN+ACK the flag says
 /// only that snSourceAck is meaningful, and `ack_vector` must be `None`.
 ///
-/// V1 data payloads (SOURCE_PAYLOAD / FEC_PAYLOAD) are not represented;
-/// this crate always negotiates v2+ for data transfer.
+/// Version 1/2 Source Packets (SOURCE_PAYLOAD, 2.2.2.4) are carried in
+/// `data`. FEC_PAYLOAD (2.2.2.5, lossy transport) is not represented:
+/// `decode` rejects a datagram with the FEC flag set, and there is no field
+/// from which `encode` could emit one.
 ///
 /// `encode` does not zero-pad SYN and SYN+ACK datagrams to the negotiated
 /// MTU that MS-RDPEUDP 3.1.5.1.1 and 3.1.5.1.3 require: this crate has no
@@ -263,13 +267,13 @@ impl Decode<'_> for V1Datagram {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = FecHeader::decode(src)?;
 
-        // V1 data payloads are not supported; reject if present since we
-        // cannot skip them without knowing their wire size.
+        // FEC payloads (lossy transport) are not supported; reject rather
+        // than misread the bytes that follow the header.
         if header.flags.contains(V1Flags::FEC) {
             return Err(ironrdp_core::invalid_field_err!(
                 "V1 Datagram",
                 "flags",
-                "FEC packets belong to lossy transport, which is not supported"
+                "lossy-transport FEC payloads are not supported"
             ));
         }
 

--- a/crates/ironrdp-rdpeudp/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/mod.rs
@@ -18,6 +18,7 @@ use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, Write
 // ── V1 Handshake modules ──
 
 pub mod v1_ack;
+pub mod v1_data;
 pub mod v1_flags;
 pub mod v1_header;
 pub mod v1_syn;
@@ -39,6 +40,7 @@ pub mod prefix;
 // ── Prefix re-exports ──
 pub use prefix::{PacketPrefixByte, PrefixError, decode_with_prefix, encode_with_prefix};
 pub use v1_ack::{CorrelationIdPayload, V1AckOfAcksHeader, V1AckVectorElement, V1AckVectorHeader, VectorElementState};
+pub use v1_data::{SourceData, SourcePayloadHeader};
 pub use v1_flags::V1Flags;
 pub use v1_header::FecHeader;
 pub use v1_syn::{MTU_MAX, MTU_MIN, SynDataExPayload, SynDataPayload, SynExFlags, UdpVersion};
@@ -124,6 +126,9 @@ pub struct V1Datagram {
     /// Extended SYN data (version negotiation).
     /// Gated by `V1Flags::SYNEX`.
     pub syn_data_ex: Option<SynDataExPayload>,
+
+    /// Version 1/2 Source Packet data (2.2.2.4), present when `RDPUDP_FLAG_DATA` is set.
+    pub data: Option<SourceData>,
 }
 
 impl V1Datagram {
@@ -151,6 +156,9 @@ impl V1Datagram {
         }
         if self.syn_data_ex.is_some() {
             flags |= V1Flags::SYNEX;
+        }
+        if self.data.is_some() {
+            flags |= V1Flags::DATA;
         }
 
         flags
@@ -214,6 +222,10 @@ impl Encode for V1Datagram {
         if let Some(ref syn_data_ex) = self.syn_data_ex {
             syn_data_ex.encode(dst)?;
         }
+        if let Some(ref data) = self.data {
+            data.header.encode(dst)?;
+            dst.write_slice(&data.payload);
+        }
 
         Ok(())
     }
@@ -239,6 +251,10 @@ impl Encode for V1Datagram {
         if let Some(ref sdex) = self.syn_data_ex {
             total += sdex.size();
         }
+        if let Some(ref data) = self.data {
+            total += data.size();
+        }
+
         total
     }
 }
@@ -249,18 +265,11 @@ impl Decode<'_> for V1Datagram {
 
         // V1 data payloads are not supported; reject if present since we
         // cannot skip them without knowing their wire size.
-        if header.flags.contains(V1Flags::DATA) {
-            return Err(ironrdp_core::invalid_field_err!(
-                "V1 Datagram",
-                "flags",
-                "DATA flag is not supported in handshake datagrams"
-            ));
-        }
         if header.flags.contains(V1Flags::FEC) {
             return Err(ironrdp_core::invalid_field_err!(
                 "V1 Datagram",
                 "flags",
-                "FEC flag is not supported in handshake datagrams"
+                "FEC packets belong to lossy transport, which is not supported"
             ));
         }
 
@@ -302,6 +311,16 @@ impl Decode<'_> for V1Datagram {
         } else {
             None
         };
+        let data = if header.flags.contains(V1Flags::DATA) {
+            let source = SourcePayloadHeader::decode(src)?;
+            let payload = src.read_remaining().to_vec();
+            Some(SourceData {
+                header: source,
+                payload,
+            })
+        } else {
+            None
+        };
 
         Ok(Self {
             header,
@@ -310,6 +329,7 @@ impl Decode<'_> for V1Datagram {
             syn_data,
             correlation_id,
             syn_data_ex,
+            data,
         })
     }
 }

--- a/crates/ironrdp-rdpeudp/src/pdu/v1_ack.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v1_ack.rs
@@ -66,7 +66,13 @@ pub struct V1AckVectorElement {
     /// State shared by every datagram in this run.
     pub state: VectorElementState,
 
-    /// Number of consecutive datagrams in this state (0..=63).
+    /// Raw six-bit run length as it appears on the wire (0..=63).
+    ///
+    /// Windows encodes a run of `n` datagrams as `n - 1`: an element of 0x00
+    /// covers exactly one datagram and 0x3F covers sixty-four. [MS-RDPEUDP]
+    /// 2.2.2.7.1 only says the field is "the length of a continuous sequence
+    /// of datagrams"; the count-minus-one reading is what the peer sends
+    /// (see `RdpeudpConnection::process_v1_acknowledgement`).
     pub length: u8,
 }
 

--- a/crates/ironrdp-rdpeudp/src/pdu/v1_data.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v1_data.rs
@@ -19,7 +19,7 @@ pub struct SourcePayloadHeader {
 }
 
 impl SourcePayloadHeader {
-    pub const FIXED_PART_SIZE: usize = 4 + 4;
+    pub const FIXED_PART_SIZE: usize = 4 /* snCoded */ + 4 /* snSourceStart */;
     const NAME: &'static str = "RDPUDP_SOURCE_PAYLOAD_HEADER";
 }
 

--- a/crates/ironrdp-rdpeudp/src/pdu/v1_data.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v1_data.rs
@@ -1,0 +1,83 @@
+//! MS-RDPEUDP 2.2.2.4 `RDPUDP_SOURCE_PAYLOAD_HEADER` and the data payload that
+//! follows it in a version 1/2 Source Packet.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+
+/// `RDPUDP_SOURCE_PAYLOAD_HEADER` (2.2.2.4): `snCoded(4)` + `snSourceStart(4)`.
+///
+/// `snCoded` numbers every datagram put on the wire (a retransmit gets a new
+/// one); `snSourceStart` numbers the payload and is what acknowledgements
+/// refer to (3.1.1.2).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourcePayloadHeader {
+    pub sn_coded: u32,
+    pub sn_source_start: u32,
+}
+
+impl SourcePayloadHeader {
+    pub const FIXED_PART_SIZE: usize = 4 + 4;
+    const NAME: &'static str = "RDPUDP_SOURCE_PAYLOAD_HEADER";
+}
+
+impl Encode for SourcePayloadHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.sn_coded);
+        dst.write_u32_be(self.sn_source_start);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for SourcePayloadHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let sn_coded = src.read_u32_be();
+        let sn_source_start = src.read_u32_be();
+        Ok(Self {
+            sn_coded,
+            sn_source_start,
+        })
+    }
+}
+
+/// A Source Packet's header plus its payload, which runs to the end of the
+/// datagram (3.1.5.1.4 step 3).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceData {
+    pub header: SourcePayloadHeader,
+    pub payload: Vec<u8>,
+}
+
+impl SourceData {
+    pub fn size(&self) -> usize {
+        SourcePayloadHeader::FIXED_PART_SIZE + self.payload.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_payload_header_roundtrip() {
+        // From the MS-RDPEUDP 4.2.1 capture.
+        let bytes = [0xec, 0x47, 0x1a, 0xe4, 0xec, 0x47, 0x1a, 0xe4];
+        let header: SourcePayloadHeader = ironrdp_core::decode(&bytes).unwrap();
+        assert_eq!(header.sn_coded, 0xec47_1ae4);
+        assert_eq!(header.sn_source_start, 0xec47_1ae4);
+        assert_eq!(ironrdp_core::encode_vec(&header).unwrap(), bytes);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/recv_window.rs
+++ b/crates/ironrdp-rdpeudp/src/recv_window.rs
@@ -297,7 +297,6 @@ impl RecvWindow {
     }
 
     /// Number of entries in the reorder buffer waiting to be delivered.
-    #[cfg(test)]
     pub(crate) fn reorder_buf_len(&self) -> usize {
         self.reorder_buf.len()
     }

--- a/crates/ironrdp-rdpeudp/src/send_window.rs
+++ b/crates/ironrdp-rdpeudp/src/send_window.rs
@@ -139,7 +139,6 @@ impl SendWindow {
     }
 
     /// The next ChannelSeqNum that will be assigned to new data.
-    #[cfg(test)]
     pub(crate) fn next_channel_seq(&self) -> u64 {
         self.next_channel_seq
     }

--- a/crates/ironrdp-rdpeudp/src/seq.rs
+++ b/crates/ironrdp-rdpeudp/src/seq.rs
@@ -300,3 +300,41 @@ mod tests {
         assert_eq!(TIMESTAMP_STALENESS_LIMIT, 8_000_000);
     }
 }
+
+/// Widens a 32-bit on-the-wire sequence number (MS-RDPEUDP 3.1.1.2) to the
+/// 64-bit value closest to `reference`, so wrap-around is handled.
+pub fn reconstruct_seq32(wire: u32, reference: u64) -> u64 {
+    const WINDOW: u64 = 1 << 32;
+    let candidate = (reference & !(WINDOW - 1)) + u64::from(wire);
+    [
+        candidate.checked_sub(WINDOW),
+        Some(candidate),
+        candidate.checked_add(WINDOW),
+    ]
+    .into_iter()
+    .flatten()
+    .min_by_key(|value| value.abs_diff(reference))
+    .unwrap_or(candidate)
+}
+
+/// Narrows a 64-bit sequence number to its 32-bit wire form.
+///
+/// # Panics
+///
+/// Never in practice: the value is masked to 32 bits before the conversion.
+pub fn truncate_seq32(full: u64) -> u32 {
+    u32::try_from(full & 0xFFFF_FFFF).expect("masked to 32 bits fits in u32")
+}
+
+#[cfg(test)]
+mod seq32_tests {
+    use super::*;
+
+    #[test]
+    fn reconstructs_across_the_32_bit_wrap() {
+        assert_eq!(reconstruct_seq32(5, 3), 5);
+        assert_eq!(reconstruct_seq32(0xFFFF_FFF0, 0x1_0000_0004), 0xFFFF_FFF0);
+        assert_eq!(reconstruct_seq32(3, 0xFFFF_FFFE), 0x1_0000_0003);
+        assert_eq!(truncate_seq32(0x1_0000_0003), 3);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/seq.rs
+++ b/crates/ironrdp-rdpeudp/src/seq.rs
@@ -3,11 +3,11 @@
 //! MS-RDPEUDP2 Section 3.1.1.1.3 (sequence numbers) and
 //! Section 3.1.1.1.4 (timestamps).
 //!
-//! All wire-format sequence numbers are 16-bit. Full resolution
-//! is 64-bit, reconstructed from a nearby reference value.
-//! The active window is limited to `(1 << log_window_size) - 1`
-//! which is at most 32767, so 16 bits are sufficient when a
-//! reference is available.
+//! MS-RDPEUDP2 wire-format sequence numbers are 16-bit; the MS-RDPEUDP
+//! (version 1/2) ones in 3.1.1.2 are 32-bit. Full resolution is 64-bit,
+//! reconstructed from a nearby reference value. The active window is
+//! limited to `(1 << log_window_size) - 1`, which is at most 32767, so
+//! either width is sufficient when a reference is available.
 //!
 //! Timestamps use 24 bits on the wire in units of 4 microseconds,
 //! giving a wrap range of ~67 seconds. Reconstruction uses the
@@ -116,6 +116,31 @@ const TIMESTAMP_HALF_RANGE: u64 = TIMESTAMP_WRAP / 2;
 /// Maximum timestamp age before it's considered stale (32 seconds in 4μs units).
 /// Per MS-RDPEUDP2 Section 3.1.1.1.4.
 pub const TIMESTAMP_STALENESS_LIMIT: u64 = 32_000_000 / TIMESTAMP_UNIT_US; // 8,000,000 units
+
+/// Widens a 32-bit on-the-wire sequence number (MS-RDPEUDP 3.1.1.2) to the
+/// 64-bit value closest to `reference`, so wrap-around is handled.
+pub fn reconstruct_seq32(wire: u32, reference: u64) -> u64 {
+    const WINDOW: u64 = 1 << 32;
+    let candidate = (reference & !(WINDOW - 1)) + u64::from(wire);
+    [
+        candidate.checked_sub(WINDOW),
+        Some(candidate),
+        candidate.checked_add(WINDOW),
+    ]
+    .into_iter()
+    .flatten()
+    .min_by_key(|value| value.abs_diff(reference))
+    .unwrap_or(candidate)
+}
+
+/// Narrows a 64-bit sequence number to its 32-bit wire form.
+///
+/// # Panics
+///
+/// Never in practice: the value is masked to 32 bits before the conversion.
+pub fn truncate_seq32(full: u64) -> u32 {
+    u32::try_from(full & 0xFFFF_FFFF).expect("masked to 32 bits fits in u32")
+}
 
 #[cfg(test)]
 mod tests {
@@ -299,36 +324,8 @@ mod tests {
         // 32 seconds = 32,000,000μs / 4μs = 8,000,000 units
         assert_eq!(TIMESTAMP_STALENESS_LIMIT, 8_000_000);
     }
-}
 
-/// Widens a 32-bit on-the-wire sequence number (MS-RDPEUDP 3.1.1.2) to the
-/// 64-bit value closest to `reference`, so wrap-around is handled.
-pub fn reconstruct_seq32(wire: u32, reference: u64) -> u64 {
-    const WINDOW: u64 = 1 << 32;
-    let candidate = (reference & !(WINDOW - 1)) + u64::from(wire);
-    [
-        candidate.checked_sub(WINDOW),
-        Some(candidate),
-        candidate.checked_add(WINDOW),
-    ]
-    .into_iter()
-    .flatten()
-    .min_by_key(|value| value.abs_diff(reference))
-    .unwrap_or(candidate)
-}
-
-/// Narrows a 64-bit sequence number to its 32-bit wire form.
-///
-/// # Panics
-///
-/// Never in practice: the value is masked to 32 bits before the conversion.
-pub fn truncate_seq32(full: u64) -> u32 {
-    u32::try_from(full & 0xFFFF_FFFF).expect("masked to 32 bits fits in u32")
-}
-
-#[cfg(test)]
-mod seq32_tests {
-    use super::*;
+    // ── 32-bit (MS-RDPEUDP) sequence numbers ──
 
     #[test]
     fn reconstructs_across_the_32_bit_wrap() {

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
@@ -23,6 +23,7 @@ fn default_config(isn: u32) -> ConnectionConfig {
         idle_timeout: Duration::from_secs(65),
         keep_alive_interval: Duration::from_secs(8),
         cookie_hash: Some(TEST_COOKIE_HASH),
+        offer_version: UdpVersion::V3,
     }
 }
 
@@ -87,6 +88,7 @@ fn server_accept_produces_syn_ack() {
         }),
         correlation_id: None,
         syn_data_ex: Some(test_syn_data_ex()),
+        data: None,
     };
 
     let mut conn = RdpeudpConnection::accept(default_config(200), &client_syn, t).expect("accept");
@@ -171,6 +173,7 @@ fn server_rejects_non_v2_syn() {
             udp_ver: UdpVersion::V1,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     let result = RdpeudpConnection::accept(default_config(200), &syn, t);
@@ -204,6 +207,7 @@ fn server_accepts_and_settles_on_v3_for_an_unrecognized_higher_version() {
             udp_ver: UdpVersion(0x0102),
             cookie_hash: Some(TEST_COOKIE_HASH),
         }),
+        data: None,
     };
 
     let mut conn = RdpeudpConnection::accept(default_config(200), &syn, t).expect("accept");
@@ -280,6 +284,7 @@ fn accept_rejects_an_out_of_range_log_window_size() {
         }),
         correlation_id: None,
         syn_data_ex: Some(test_syn_data_ex()),
+        data: None,
     };
 
     let result = RdpeudpConnection::accept(config, &syn, t);
@@ -1144,6 +1149,7 @@ fn a_server_rejects_a_syn_offering_a_version_below_3() {
             udp_ver: UdpVersion::V2,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     RdpeudpConnection::accept(default_config(200), &syn, t).expect_err("version 2 is not RDPEUDP2");
@@ -1172,17 +1178,15 @@ fn a_server_rejects_a_syn_whose_cookie_hash_does_not_match() {
             udp_ver: UdpVersion::V3,
             cookie_hash: Some([0xFF; 32]),
         }),
+        data: None,
     };
 
     RdpeudpConnection::accept(default_config(200), &syn, t).expect_err("the hash is for a different cookie");
 }
 
-#[test]
-fn a_client_rejects_a_syn_ack_that_settles_below_version_3() {
-    let t = now();
-    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
-    client.poll_transmit(t).expect("SYN");
-
+/// A SYN+ACK from a server that only speaks MS-RDPEUDP, answering a client SYN
+/// that offered version 3.
+fn version_2_syn_ack() -> Vec<u8> {
     let syn_ack = V1Datagram {
         header: FecHeader {
             sn_source_ack: 100,
@@ -1202,12 +1206,52 @@ fn a_client_rejects_a_syn_ack_that_settles_below_version_3() {
             udp_ver: UdpVersion::V2,
             cookie_hash: None,
         }),
+        data: None,
     };
+    encode_vec(&syn_ack).expect("encode")
+}
 
-    let mut bytes = encode_vec(&syn_ack).expect("encode");
+/// MS-RDPEUDP 1.7: a server that does not implement version 3 settles on its
+/// own highest version, and the client MUST follow it down onto the
+/// MS-RDPEUDP data transfer, which this crate implements for reliable
+/// transport.
+#[test]
+fn a_client_follows_a_syn_ack_that_settles_on_version_2() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    client.poll_transmit(t).expect("SYN");
+
+    let mut bytes = version_2_syn_ack();
     client
         .handle_datagram(&mut bytes, later(t, 50))
-        .expect_err("the server settled on the MS-RDPEUDP data transfer");
+        .expect("version 2 is a version both endpoints support");
+    assert!(client.is_established());
+
+    // The final handshake ACK acknowledges the SYN+ACK in MS-RDPEUDP framing.
+    let ack = client.poll_transmit(later(t, 50)).expect("final ACK");
+    let ack: V1Datagram = decode(&ack.contents).expect("MS-RDPEUDP framing");
+    assert!(ack.header.flags.contains(V1Flags::ACK));
+    assert_eq!(ack.header.sn_source_ack, 200);
+}
+
+/// The SYN+ACK's version is "the highest version supported by both endpoints"
+/// (3.1.5.1.1); one above what the SYN offered cannot be, so the client does
+/// not guess at framing and timers for it.
+#[test]
+fn a_client_rejects_a_syn_ack_that_settles_above_its_offer() {
+    let t = now();
+    let config = ConnectionConfig {
+        offer_version: UdpVersion::V1,
+        cookie_hash: None,
+        ..default_config(100)
+    };
+    let mut client = RdpeudpConnection::connect(config, t).expect("connect");
+    client.poll_transmit(t).expect("SYN");
+
+    let mut bytes = version_2_syn_ack();
+    client
+        .handle_datagram(&mut bytes, later(t, 50))
+        .expect_err("the SYN offered version 1, so version 2 is not supported by both endpoints");
     assert!(!client.is_established());
 }
 

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v1_datagram.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v1_datagram.rs
@@ -26,6 +26,7 @@ fn v1_syn_datagram_roundtrip() {
             udp_ver: UdpVersion::V2,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     // header(8) + syndata(8) + syndataex(4) = 20 bytes
@@ -62,6 +63,7 @@ fn v1_syn_ack_datagram_roundtrip() {
             udp_ver: UdpVersion::V2,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     // header(8) + syndata(8) + syndataex(4) = 20.
@@ -162,6 +164,7 @@ fn v1_encode_rejects_ack_vector_on_a_syn() {
         }),
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     encode_vec(&datagram).expect_err("a SYN datagram cannot carry an ACK vector");
@@ -196,6 +199,7 @@ fn v1_encode_rejects_cookie_hash_without_a_client_syn() {
             udp_ver: UdpVersion::V3,
             cookie_hash: Some([0xAA; 32]),
         }),
+        data: None,
     };
 
     encode_vec(&datagram).expect_err("cookieHash is only carried on a client-to-server SYN");
@@ -228,6 +232,7 @@ fn v1_encode_rejects_a_v3_client_syn_missing_its_cookie_hash() {
             udp_ver: UdpVersion::V3,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     encode_vec(&datagram).expect_err("a version 3 client SYN must carry a cookieHash");
@@ -258,6 +263,7 @@ fn v1_ack_datagram_roundtrip() {
         syn_data: None,
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     // header(8) + ack_vector(2+2=4) + ack_of_acks(4) = 16
@@ -294,6 +300,7 @@ fn v1_syn_with_correlation_id_roundtrip() {
             udp_ver: UdpVersion::V2,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     // header(8) + syndata(8) + correlation(16 id + 16 reserved = 32) + syndataex(4) = 52.
@@ -327,6 +334,7 @@ fn v1_syn_v3_with_cookie_roundtrip() {
             udp_ver: UdpVersion::V3,
             cookie_hash: Some([0xAA; 32]),
         }),
+        data: None,
     };
 
     // header(8) + syndata(8) + syndataex(4+32=36) = 52
@@ -362,6 +370,7 @@ fn v1_syn_ack_v3_does_not_read_padding_as_cookie_hash() {
             udp_ver: UdpVersion::V3,
             cookie_hash: None,
         }),
+        data: None,
     };
 
     let mut encoded = encode_vec(&datagram).expect("encode");
@@ -394,6 +403,7 @@ fn v1_flags_auto_computed_on_encode() {
         correlation_id: None,
         // syn_data_ex is None, so SYNEX should NOT be in flags
         syn_data_ex: None,
+        data: None,
     };
 
     let encoded = encode_vec(&datagram).expect("encode");
@@ -425,6 +435,7 @@ fn v1_ack_flag_preserved_on_a_syn() {
         }),
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     let encoded = encode_vec(&datagram).expect("encode");
@@ -452,6 +463,7 @@ fn v1_ack_flag_absent_on_a_bare_syn() {
         }),
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     let encoded = encode_vec(&datagram).expect("encode");
@@ -479,6 +491,7 @@ fn v1_standalone_flags_preserved() {
         syn_data: None,
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     let encoded = encode_vec(&datagram).expect("encode");
@@ -503,6 +516,7 @@ fn v1_decode_rejects_data_flag() {
         syn_data: None,
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
     let mut encoded = encode_vec(&datagram).expect("encode");
 
@@ -533,6 +547,7 @@ fn v1_decode_rejects_fec_flag() {
         syn_data: None,
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
     let mut encoded = encode_vec(&datagram).expect("encode");
 
@@ -560,6 +575,7 @@ fn v1_empty_datagram_roundtrip() {
         syn_data: None,
         correlation_id: None,
         syn_data_ex: None,
+        data: None,
     };
 
     assert_eq!(datagram.size(), 8); // header only


### PR DESCRIPTION
Every Windows host tested on a LAN answers the RDPUDP SYN with uUdpVer 0x0002: they speak MS-RDPEUDP (version 1/2), not MS-RDPEUDP2 (version 3). A client that only implements the version 3 framing therefore always times out on the UDP handshake and falls back to TCP, so the multitransport path never carries data against Windows.

This adds the version 1/2 reliable data path to the sans-I/O connection state machine, negotiated from the SYN+ACK and reusing the existing send/receive windows, RTT estimator, loss detection and timers:

- pdu: RDPUDP_SOURCE_PAYLOAD_HEADER (2.2.2.4) and the data payload on a version 1/2 Source Packet. DATA datagrams decode; FEC (lossy) datagrams are rejected.
- connection: NegotiatedParams records the wire format. Version 1/2 uses a single Source sequence space from ISN+1; snCoded numbers each transmission, snSourceAck drives an ACK vector walked down from the highest received sequence (3.1.1.4), ACK-of-ACKs resets the receiver's vector base (2.2.2.6), a Congestion Notify is answered with CWR at most once per RTT (3.1.1.8), and ACKDELAYED marks timer-driven ACKs (3.1.6.3). Timers take the version's floors.
- The 6-bit ACK-vector run length is encoded as count minus one on the wire, which MS-RDPEUDP 2.2.2.7.1 leaves ambiguous but Windows requires: element 0x00 acknowledges one Source Packet and 0x02 acknowledges three. Reading it literally leaves the first Source Packet unacknowledged forever, collapsing the congestion window.
- seq: 32-bit wrap-aware sequence reconstruction and narrowing.
- ConnectionConfig::offer_version lets a client offer version 2 or 1 outright (no cookieHash), which is what the measured hosts answer immediately.
- RdpeudpConnection::v1_stats exposes retransmit, ACK and datagram counters for observability.

Verified against the spec's 4.2.1 example capture and new state-machine tests; the existing tests are unchanged.

**Note on MS-RDPEUDP 4.2.3.** The spec's worked example annotates ACK vector element 0x04 as "4 datagrams received," a literal reading of the six-bit run length. Captures against Windows Server show the field is the run length minus one: after one Source Packet the server answers `snSourceAck = 1` with element 0x00, after four it answers `snSourceAck = 4` with 0x03. Read literally, the first is an empty run and the second never acknowledges seq 1, which stalls the sender. This implementation follows the wire, not the example. Evidence: https://gist.github.com/AKolenda/51931b094dd454ef0eb1430503629c8a