### PR TITLE
fix(egfx): decode AVC420 with full-range BT.709

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "ironrdp-pdu",
  "openh264",
  "tracing",
+ "yuv",
 ]
 
 [[package]]

--- a/crates/ironrdp-egfx/Cargo.toml
+++ b/crates/ironrdp-egfx/Cargo.toml
@@ -25,10 +25,11 @@ ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 openh264 = { version = "0.9", optional = true, default-features = false }
 tracing = { version = "0.1", features = ["log"] }
+yuv = { version = "0.8", default-features = false, optional = true }
 
 [features]
 arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "ironrdp-pdu/arbitrary"]
-openh264 = ["dep:openh264"]
+openh264 = ["dep:openh264", "dep:yuv"]
 openh264-bundled = ["openh264", "openh264/source"]
 openh264-libloading = ["openh264", "openh264/libloading"]
 

--- a/crates/ironrdp-egfx/src/decode.rs
+++ b/crates/ironrdp-egfx/src/decode.rs
@@ -183,6 +183,7 @@ pub trait H264Decoder: Send {
 
 #[cfg(feature = "openh264")]
 mod openh264_impl {
+    use openh264::formats::YUVSource;
     use tracing::warn;
 
     use super::{DecodedFrame, DecoderError, DecoderResult, H264Decoder};
@@ -253,7 +254,8 @@ mod openh264_impl {
                 .map_err(|e| DecoderError::new("OpenH264 decode failed", e))?
                 .ok_or_else(|| DecoderError::msg("OpenH264 returned no picture"))?;
 
-            let (width, height) = openh264::formats::YUVSource::dimensions(&yuv);
+            let (width, height) = YUVSource::dimensions(&yuv);
+            let (y_stride, u_stride, v_stride) = YUVSource::strides(&yuv);
 
             #[expect(
                 clippy::as_conversions,
@@ -261,13 +263,43 @@ mod openh264_impl {
                 reason = "H.264 frame dimensions are always within u32 range"
             )]
             let (w32, h32) = (width as u32, height as u32);
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_possible_truncation,
+                reason = "strides are bounded by frame dimensions, which fit in u32"
+            )]
+            let [y_stride, u_stride, v_stride] = [y_stride as u32, u_stride as u32, v_stride as u32];
 
+            let rgba_stride = w32
+                .checked_mul(4)
+                .ok_or_else(|| DecoderError::msg("frame dimensions too large for RGBA allocation"))?;
             let rgba_size = width
                 .checked_mul(height)
                 .and_then(|s| s.checked_mul(4))
                 .ok_or_else(|| DecoderError::msg("frame dimensions too large for RGBA allocation"))?;
             let mut rgba = vec![0u8; rgba_size];
-            yuv.write_rgba8(&mut rgba);
+
+            // MS-RDPEGFX AVC420 streams carry full-range BT.709 YUV420,
+            // but openh264's `write_rgba8` assumes limited-range BT.601,
+            // which distorts colors. Convert per [MS-RDPEGFX] 3.3.8.3.1.
+            let planar = yuv::YuvPlanarImage {
+                y_plane: yuv.y(),
+                y_stride,
+                u_plane: yuv.u(),
+                u_stride,
+                v_plane: yuv.v(),
+                v_stride,
+                width: w32,
+                height: h32,
+            };
+            yuv::yuv420_to_rgba(
+                &planar,
+                &mut rgba,
+                rgba_stride,
+                yuv::YuvRange::Full,
+                yuv::YuvStandardMatrix::Bt709,
+            )
+            .map_err(|e| DecoderError::new("failed to convert YUV420 to RGBA", e))?;
 
             Ok(DecodedFrame::new(rgba, w32, h32))
         }

--- a/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
@@ -177,3 +177,50 @@ fn test_decode_garbage_input() {
     // with a valid frame.
     assert!(result.is_err(), "garbage NAL content should not produce a valid frame");
 }
+
+// ============================================================================
+// Color Range Tests
+// ============================================================================
+
+/// Encode a YUV420p frame with the given luma/chroma planes and decode it
+/// back through `OpenH264Decoder`, returning the RGBA output.
+fn encode_and_decode_yuv(planes: ([u8; 256], [u8; 64], [u8; 64])) -> ironrdp_egfx::decode::DecodedFrame {
+    use openh264::encoder::Encoder;
+    use openh264::formats::YUVSlices;
+
+    let mut encoder = Encoder::new().expect("encoder should initialize");
+    let yuv = YUVSlices::new((&planes.0, &planes.1, &planes.2), (16, 16), (16, 8, 8));
+    let bitstream = encoder.encode(&yuv).expect("encode should succeed").to_vec();
+
+    let avc_data = annex_b_to_avc(&bitstream);
+    let mut decoder = OpenH264Decoder::new().expect("decoder should initialize");
+    decoder.decode(&avc_data).expect("decode should succeed")
+}
+
+#[test]
+fn test_decode_preserves_full_luma_range() {
+    // MS-RDPEGFX AVC420 is full range, so luma must pass through the
+    // YUV-to-RGBA conversion undistorted. A limited-range (studio swing)
+    // conversion over-expands: near-white luma is pulled past 255 and
+    // clamps there, near-black luma is pulled below 0 and clamps there.
+    // Values right at 255/0 survive either conversion after clamping, so
+    // the discriminating cases sit just inside the extremes.
+    let near_white = encode_and_decode_yuv(([245u8; 256], [128u8; 64], [128u8; 64]));
+    let data = near_white.data();
+    for px in data.chunks_exact(4) {
+        // A limited-range conversion clamps this to 255.
+        assert!(px[0] < 252, "near-white R channel saturated: {}", px[0]);
+        assert!(px[1] < 252, "near-white G channel saturated: {}", px[1]);
+        assert!(px[2] < 252, "near-white B channel saturated: {}", px[2]);
+        assert_eq!(px[3], 255);
+    }
+
+    let near_black = encode_and_decode_yuv(([10u8; 256], [128u8; 64], [128u8; 64]));
+    let data = near_black.data();
+    for px in data.chunks_exact(4) {
+        // A limited-range conversion clamps this to 0.
+        assert!(px[0] > 4, "near-black R channel crushed: {}", px[0]);
+        assert!(px[1] > 4, "near-black G channel crushed: {}", px[1]);
+        assert!(px[2] > 4, "near-black B channel crushed: {}", px[2]);
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
@@ -182,14 +182,18 @@ fn test_decode_garbage_input() {
 // Color Range Tests
 // ============================================================================
 
-/// Encode a YUV420p frame with the given luma/chroma planes and decode it
-/// back through `OpenH264Decoder`, returning the RGBA output.
-fn encode_and_decode_yuv(planes: ([u8; 256], [u8; 64], [u8; 64])) -> ironrdp_egfx::decode::DecodedFrame {
+/// Encode a YUV420p frame with the given luma/chroma planes and dimensions
+/// and decode it back through `OpenH264Decoder`, returning the RGBA output.
+fn encode_and_decode_yuv(
+    planes: (&[u8], &[u8], &[u8]),
+    dimensions: (usize, usize),
+    strides: (usize, usize, usize),
+) -> ironrdp_egfx::decode::DecodedFrame {
     use openh264::encoder::Encoder;
     use openh264::formats::YUVSlices;
 
     let mut encoder = Encoder::new().expect("encoder should initialize");
-    let yuv = YUVSlices::new((&planes.0, &planes.1, &planes.2), (16, 16), (16, 8, 8));
+    let yuv = YUVSlices::new(planes, dimensions, strides);
     let bitstream = encoder.encode(&yuv).expect("encode should succeed").to_vec();
 
     let avc_data = annex_b_to_avc(&bitstream);
@@ -205,7 +209,11 @@ fn test_decode_preserves_full_luma_range() {
     // clamps there, near-black luma is pulled below 0 and clamps there.
     // Values right at 255/0 survive either conversion after clamping, so
     // the discriminating cases sit just inside the extremes.
-    let near_white = encode_and_decode_yuv(([245u8; 256], [128u8; 64], [128u8; 64]));
+    // 16x16 with padded strides: the Y plane stride (24) exceeds its
+    // visible width, exercising the macroblock-alignment handling that
+    // prevents diagonal streaks; chroma stays at half resolution.
+    let (y, u, v) = ([245u8; 16 * 24], [128u8; 8 * 12], [128u8; 8 * 12]);
+    let near_white = encode_and_decode_yuv((&y, &u, &v), (16, 16), (24, 12, 12));
     let data = near_white.data();
     for px in data.chunks_exact(4) {
         // A limited-range conversion clamps this to 255.
@@ -215,12 +223,38 @@ fn test_decode_preserves_full_luma_range() {
         assert_eq!(px[3], 255);
     }
 
-    let near_black = encode_and_decode_yuv(([10u8; 256], [128u8; 64], [128u8; 64]));
+    let (y, u, v) = ([10u8; 16 * 24], [128u8; 8 * 12], [128u8; 8 * 12]);
+    let near_black = encode_and_decode_yuv((&y, &u, &v), (16, 16), (24, 12, 12));
     let data = near_black.data();
     for px in data.chunks_exact(4) {
         // A limited-range conversion clamps this to 0.
         assert!(px[0] > 4, "near-black R channel crushed: {}", px[0]);
         assert!(px[1] > 4, "near-black G channel crushed: {}", px[1]);
         assert!(px[2] > 4, "near-black B channel crushed: {}", px[2]);
+    }
+}
+
+#[test]
+fn test_decode_uses_bt709_chroma_matrix() {
+    // Neutral chroma cannot distinguish BT.601 from BT.709; both matrices
+    // agree on grayscale. Encode a saturated red tile (YUV planes fed
+    // directly, bypassing the encoder's own RGB conversion) and verify the
+    // decoded pixels sit near pure red under the spec's BT.709 inverse
+    // (MS-RDPEGFX 3.3.8.3.1, image14). Under a full-range BT.601 inverse
+    // the same planes decode with R at roughly 231, failing the R bound
+    // (the G bound does not discriminate there: 601's G goes negative and
+    // clamps to 0).
+    //
+    // BT.709 full-range forward on pure red: Y = (54·255) >> 8 = 53,
+    // U = (-29·255) >> 8 + 128 = 99, V = (128·255) >> 8 + 128 = 255.
+    let y = [53u8; 16 * 16];
+    let u = [99u8; 8 * 8];
+    let v = [255u8; 8 * 8];
+    let red = encode_and_decode_yuv((&y, &u, &v), (16, 16), (16, 8, 8));
+    let data = red.data();
+    for px in data.chunks_exact(4) {
+        assert!(px[0] > 245, "red R channel: {}", px[0]);
+        assert!(px[1] < 20, "red G channel leaked: {}", px[1]);
+        assert!(px[2] < 20, "red B channel leaked: {}", px[2]);
     }
 }


### PR DESCRIPTION
Replaces openh264's built-in write_rgba8 in the AVC420 decoder path with an explicit full-range BT.709 conversion from the yuv crate.

MS-RDPEGFX 3.3.8.3.1 mandates full-range BT.709 for RFX_AVC420_BITMAP_STREAM color conversion, but openh264 hardcodes a limited-range (studio swing) BT.601 matrix: near-white luma is over-expanded past 255 and clamps, near-black luma is crushed below 0, and saturated colors shift hue (BT.601 inverse renders pure red at R~232 instead of 255). Upgrading openh264 does not help; the range bias is hardcoded in every released version.

The conversion now uses yuv420_to_rgba with YuvRange::Full and YuvStandardMatrix::Bt709, matching the spec's normative inverse matrix and FreeRDP's prim_YUV.c reference. Real per-plane strides from openh264 replace the previous packed assumption, so macroblock-aligned plane padding no longer produces diagonal streaks. Conversion failures surface as DecoderError instead of a panic from openh264's internal asserts.

The optional yuv dependency is implementation-only (no public API exposure) and is wired to the openh264 feature. Cargo.lock is unchanged since yuv already exists in the dependency tree through ironrdp-graphics.

A round-trip regression test encodes near-white (Y=245) and near-black (Y=10) frames and asserts neither clamps to 255 or 0; pure black and white pass under both conversions, so the discriminating values sit just inside the extremes.

The openh264 encoder path still emits limited-range BT.601 via YUVBuffer::from_rgb_source and is now inconsistent with this conforming decoder; that fix will follow separately.

Encoder-side fix: #1925 (fixes #1924)