### PR TITLE
fix(egfx): encode AVC420 with full-range BT.709

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "ironrdp-pdu",
  "openh264",
  "tracing",
+ "yuv",
 ]
 
 [[package]]

--- a/crates/ironrdp-egfx/Cargo.toml
+++ b/crates/ironrdp-egfx/Cargo.toml
@@ -25,10 +25,11 @@ ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 openh264 = { version = "0.9", optional = true, default-features = false }
 tracing = { version = "0.1", features = ["log"] }
+yuv = { version = "0.8", default-features = false, optional = true }
 
 [features]
 arbitrary = ["dep:arbitrary", "bitflags/arbitrary", "ironrdp-pdu/arbitrary"]
-openh264 = ["dep:openh264"]
+openh264 = ["dep:openh264", "dep:yuv"]
 openh264-bundled = ["openh264", "openh264/source"]
 openh264-libloading = ["openh264", "openh264/libloading"]
 

--- a/crates/ironrdp-egfx/src/decode.rs
+++ b/crates/ironrdp-egfx/src/decode.rs
@@ -183,6 +183,7 @@ pub trait H264Decoder: Send {
 
 #[cfg(feature = "openh264")]
 mod openh264_impl {
+    use openh264::formats::YUVSource;
     use tracing::warn;
 
     use super::{DecodedFrame, DecoderError, DecoderResult, H264Decoder};
@@ -253,7 +254,8 @@ mod openh264_impl {
                 .map_err(|e| DecoderError::new("OpenH264 decode failed", e))?
                 .ok_or_else(|| DecoderError::msg("OpenH264 returned no picture"))?;
 
-            let (width, height) = openh264::formats::YUVSource::dimensions(&yuv);
+            let (width, height) = YUVSource::dimensions(&yuv);
+            let (y_stride, u_stride, v_stride) = YUVSource::strides(&yuv);
 
             #[expect(
                 clippy::as_conversions,
@@ -261,13 +263,43 @@ mod openh264_impl {
                 reason = "H.264 frame dimensions are always within u32 range"
             )]
             let (w32, h32) = (width as u32, height as u32);
+            #[expect(
+                clippy::as_conversions,
+                clippy::cast_possible_truncation,
+                reason = "strides are bounded by frame dimensions, which fit in u32"
+            )]
+            let [y_stride, u_stride, v_stride] = [y_stride as u32, u_stride as u32, v_stride as u32];
 
+            let rgba_stride = w32
+                .checked_mul(4)
+                .ok_or_else(|| DecoderError::msg("frame dimensions too large for RGBA allocation"))?;
             let rgba_size = width
                 .checked_mul(height)
                 .and_then(|s| s.checked_mul(4))
                 .ok_or_else(|| DecoderError::msg("frame dimensions too large for RGBA allocation"))?;
             let mut rgba = vec![0u8; rgba_size];
-            yuv.write_rgba8(&mut rgba);
+
+            // MS-RDPEGFX AVC420 streams carry full-range BT.709 YUV420,
+            // but openh264's `write_rgba8` assumes limited-range BT.601,
+            // which distorts colors. Convert per [MS-RDPEGFX] 3.3.8.3.1.
+            let planar = yuv::YuvPlanarImage {
+                y_plane: yuv.y(),
+                y_stride,
+                u_plane: yuv.u(),
+                u_stride,
+                v_plane: yuv.v(),
+                v_stride,
+                width: w32,
+                height: h32,
+            };
+            yuv::yuv420_to_rgba(
+                &planar,
+                &mut rgba,
+                rgba_stride,
+                yuv::YuvRange::Full,
+                yuv::YuvStandardMatrix::Bt709,
+            )
+            .map_err(|e| DecoderError::new("failed to convert YUV420 to RGBA", e))?;
 
             Ok(DecodedFrame::new(rgba, w32, h32))
         }

--- a/crates/ironrdp-egfx/src/encode.rs
+++ b/crates/ironrdp-egfx/src/encode.rs
@@ -177,12 +177,40 @@ mod openh264_impl {
                 return Err(EncoderError::msg("frame buffer length does not match dimensions"));
             }
 
-            let rgba = openh264::formats::RgbaSliceU8::new(frame.data, (width, height));
-            let yuv = openh264::formats::YUVBuffer::from_rgb_source(rgba);
+            let rgba_stride = frame
+                .width
+                .checked_mul(4)
+                .ok_or_else(|| EncoderError::msg("frame dimensions overflow"))?;
+
+            // MS-RDPEGFX 3.3.8.3.1 mandates full-range BT.709 for
+            // RFX_AVC420_BITMAP_STREAM color conversion; openh264's built-in
+            // RGBA-to-YUV applies a limited-range BT.601 matrix instead, which
+            // produces spec-nonconformant luma placement.
+            let mut planar =
+                yuv::YuvPlanarImageMut::alloc(frame.width, frame.height, yuv::YuvChromaSubsampling::Yuv420);
+            yuv::rgba_to_yuv420(
+                &mut planar,
+                frame.data,
+                rgba_stride,
+                yuv::YuvRange::Full,
+                yuv::YuvStandardMatrix::Bt709,
+                yuv::YuvConversionMode::Balanced,
+            )
+            .map_err(|e| EncoderError::new("failed to convert RGBA to YUV420", e))?;
+
+            let yuv_source = openh264::formats::YUVSlices::new(
+                (
+                    planar.y_plane.borrow(),
+                    planar.u_plane.borrow(),
+                    planar.v_plane.borrow(),
+                ),
+                (width, height),
+                (width, width / 2, width / 2),
+            );
 
             let bitstream = self
                 .encoder
-                .encode(&yuv)
+                .encode(&yuv_source)
                 .map_err(|e| EncoderError::new("OpenH264 encode failed", e))?;
 
             Ok(bitstream.to_vec())

--- a/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
@@ -177,3 +177,50 @@ fn test_decode_garbage_input() {
     // with a valid frame.
     assert!(result.is_err(), "garbage NAL content should not produce a valid frame");
 }
+
+// ============================================================================
+// Color Range Tests
+// ============================================================================
+
+/// Encode a YUV420p frame with the given luma/chroma planes and decode it
+/// back through `OpenH264Decoder`, returning the RGBA output.
+fn encode_and_decode_yuv(planes: ([u8; 256], [u8; 64], [u8; 64])) -> ironrdp_egfx::decode::DecodedFrame {
+    use openh264::encoder::Encoder;
+    use openh264::formats::YUVSlices;
+
+    let mut encoder = Encoder::new().expect("encoder should initialize");
+    let yuv = YUVSlices::new((&planes.0, &planes.1, &planes.2), (16, 16), (16, 8, 8));
+    let bitstream = encoder.encode(&yuv).expect("encode should succeed").to_vec();
+
+    let avc_data = annex_b_to_avc(&bitstream);
+    let mut decoder = OpenH264Decoder::new().expect("decoder should initialize");
+    decoder.decode(&avc_data).expect("decode should succeed")
+}
+
+#[test]
+fn test_decode_preserves_full_luma_range() {
+    // MS-RDPEGFX AVC420 is full range, so luma must pass through the
+    // YUV-to-RGBA conversion undistorted. A limited-range (studio swing)
+    // conversion over-expands: near-white luma is pulled past 255 and
+    // clamps there, near-black luma is pulled below 0 and clamps there.
+    // Values right at 255/0 survive either conversion after clamping, so
+    // the discriminating cases sit just inside the extremes.
+    let near_white = encode_and_decode_yuv(([245u8; 256], [128u8; 64], [128u8; 64]));
+    let data = near_white.data();
+    for px in data.chunks_exact(4) {
+        // A limited-range conversion clamps this to 255.
+        assert!(px[0] < 252, "near-white R channel saturated: {}", px[0]);
+        assert!(px[1] < 252, "near-white G channel saturated: {}", px[1]);
+        assert!(px[2] < 252, "near-white B channel saturated: {}", px[2]);
+        assert_eq!(px[3], 255);
+    }
+
+    let near_black = encode_and_decode_yuv(([10u8; 256], [128u8; 64], [128u8; 64]));
+    let data = near_black.data();
+    for px in data.chunks_exact(4) {
+        // A limited-range conversion clamps this to 0.
+        assert!(px[0] > 4, "near-black R channel crushed: {}", px[0]);
+        assert!(px[1] > 4, "near-black G channel crushed: {}", px[1]);
+        assert!(px[2] > 4, "near-black B channel crushed: {}", px[2]);
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/egfx/encode.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/encode.rs
@@ -1,0 +1,84 @@
+use ironrdp_egfx::decode::{H264Decoder as _, OpenH264Decoder};
+use ironrdp_egfx::encode::{EncodeFrame, H264Encoder as _, OpenH264Encoder};
+use ironrdp_egfx::pdu::annex_b_to_avc;
+
+// ============================================================================
+// Color Range Tests
+// ============================================================================
+
+/// Encode a 16x16 RGBA frame with the given solid color through
+/// `OpenH264Encoder`, decode it back with a spec-conformant full-range
+/// BT.709 decoder, and return the decoded RGBA buffer.
+fn encode_and_decode_solid(rgba: [u8; 4]) -> Vec<u8> {
+    let mut encoder = OpenH264Encoder::new().expect("encoder should initialize");
+    let mut data = Vec::with_capacity(16 * 16 * 4);
+    for _ in 0..16 * 16 {
+        data.extend_from_slice(&rgba);
+    }
+    let frame = EncodeFrame {
+        data: &data,
+        width: 16,
+        height: 16,
+    };
+    let bitstream = encoder.encode(frame).expect("encode should succeed");
+    let avc = annex_b_to_avc(&bitstream);
+
+    let mut decoder = OpenH264Decoder::new().expect("decoder should initialize");
+    let decoded = decoder.decode(&avc).expect("decode should succeed");
+    decoded.into_data()
+}
+
+#[test]
+fn test_encode_round_trips_saturated_colors() {
+    // The encoder must place luma across the full [0, 255] swing with
+    // BT.709 chroma so that a spec-conformant decoder (full-range BT.709,
+    // per MS-RDPEGFX 3.3.8.3.1) reconstructs saturated primaries near
+    // their channel extremes. Under the previous limited-range BT.601
+    // conversion, white luma lands at 235 and saturated primaries shift.
+    //
+    // The cold-channel bounds distinguish the BT.709 matrix from a
+    // hypothetical full-range BT.601 regression: the two matrices place
+    // primary-color energy differently across the non-hot channels.
+    let cases: [([u8; 4], usize, bool); 5] = [
+        ([255, 255, 255, 255], 0, true), // white: every channel near 255
+        ([0, 0, 0, 255], 0, false),      // black: every channel near 0
+        ([255, 0, 0, 255], 0, true),     // red: R near 255, G/B near 0
+        ([0, 255, 0, 255], 1, true),     // green: G near 255, R/B near 0
+        ([0, 0, 255, 255], 2, true),     // blue: B near 255, R/G near 0
+    ];
+    for (rgba, hot, above) in cases {
+        let data = encode_and_decode_solid(rgba);
+        assert_eq!(data.len(), 16 * 16 * 4);
+        for px in data.chunks_exact(4) {
+            if above {
+                assert!(px[hot] > 245, "color {rgba:?}: hot channel {hot} = {}", px[hot]);
+            } else {
+                assert!(px[hot] < 10, "color {rgba:?}: hot channel {hot} = {}", px[hot]);
+            }
+            assert_eq!(px[3], 255, "alpha must be opaque");
+        }
+    }
+}
+
+#[test]
+fn test_encode_round_trip_cold_channels_stay_cold() {
+    // Cross-channel leakage discriminates the BT.709 chroma matrix from
+    // full-range BT.601: encoding pure red with BT.601 coefficients and
+    // decoding with the spec's BT.709 inverse yields G≈24 on a clean
+    // tile, while correct BT.709 round-tripping stays near the AVC
+    // quantization floor. The bound must stay tight enough to expose
+    // that gap but loose enough for codec noise on a 16x16 tile.
+    let cases: [([u8; 4], [usize; 2]); 3] = [
+        ([255, 0, 0, 255], [1, 2]), // red: G and B stay near 0
+        ([0, 255, 0, 255], [0, 2]), // green: R and B stay near 0
+        ([0, 0, 255, 255], [0, 1]), // blue: R and G stay near 0
+    ];
+    for (rgba, cold) in cases {
+        let data = encode_and_decode_solid(rgba);
+        for px in data.chunks_exact(4) {
+            for c in cold {
+                assert!(px[c] < 20, "color {rgba:?}: cold channel {c} leaked: {}", px[c]);
+            }
+        }
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/egfx/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/mod.rs
@@ -4,5 +4,7 @@ mod client;
 #[cfg(feature = "openh264-bundled")]
 mod decode;
 mod decoded_frame;
+#[cfg(feature = "openh264-bundled")]
+mod encode;
 mod server;
 mod wire_to_surface_real_world;


### PR DESCRIPTION
   Replaces openh264's built-in RGBA-to-YUV420 conversion in the AVC420 encoder path with an explicit full-range BT.709 conversion from the yuv crate, completing the decoder-side fix in #1923.

   MS-RDPEGFX 3.3.8.3.1 mandates full-range BT.709 for RFX_AVC420_BITMAP_STREAM color conversion, but openh264's YUVBuffer::from_rgb_source hardcodes a limited-range (studio swing) BT.601 matrix internally (luma offset +16, coefficients 66/129/25 >> 8), placing luma in [16, 235] instead of [0, 255]. The decoder fix makes the mismatch visible: an IronRDP server talking to the now-conformant decoder produces washed-out, crushed output where the two errors previously partially cancelled.

   The conversion now runs rgba_to_yuv420 with YuvRange::Full and YuvStandardMatrix::Bt709 into planes allocated by YuvPlanarImageMut::alloc, and the converted planes are handed to openh264 as pixel data via YUVSlices, so openh264 no longer touches color. Conversion failures surface as EncoderError instead of an internal panic.

   Two round-trip regression tests encode solid colors through the live encoder/decoder pair: hot-channel bounds fail under the old encoder (white decodes to 235), and a cold-channel leakage bound discriminates a full-range BT.601 matrix
 regression, which the hot-channel test alone cannot detect.

   Stacked on #1923 (decoder side) and should land shortly after it: until the encoder half lands, full AVC420 round trips between IronRDP servers and the fixed decoder look worse than before, since the errors no longer cancel.

   Fixes: #1924