### PR TITLE
ci(pr-automation): report review check diagnostics

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -3,6 +3,8 @@
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const { createRequire } = require("node:module");
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { SIZE_LABELS, addedLinesByPath, analyzeFiles, parseLabelerRules } = require("./deterministic-analysis");
@@ -82,6 +84,50 @@ function readReviewWorkflow(githubDirectory = path.join(__dirname, "..")) {
     .replace(/\r\n/g, "\n");
 }
 
+function resolveReviewScript(workflow = readWorkflow()) {
+  const job = workflowJob(workflow, "resolve-review-state");
+  const match = job.match(/script: \|\n((?: {13}.*\n?)+)/);
+  assert.ok(match, "resolve-review-state script is missing");
+  return match[1].replace(/^ {13}/gm, "");
+}
+
+async function runResolveReviewScript({ report, pipelineResult = "success" }) {
+  const outputs = new Map();
+  const summary = [];
+  const core = {
+    setOutput: (name, value) => outputs.set(name, value),
+    info: () => {},
+    summary: {
+      addHeading: () => core.summary,
+      addRaw: (value) => { summary.push(value); return core.summary; },
+      addList: () => core.summary,
+      write: async () => {},
+    },
+  };
+  const rootRequire = createRequire(path.join(__dirname, "..", "..", "labeler.js"));
+  const reportModule = path.join(__dirname, "review-report.js");
+  const requireWithReport = (name) => name === "./.github/pr-automation/review-report"
+    ? fs.existsSync(reportModule) ? rootRequire(name) : { parseReport: () => report }
+    : rootRequire(name);
+  const process = { env: {
+    HEAD_SHA: SHA, BASE_SHA: "c".repeat(40),
+    GATE: JSON.stringify({
+      ok: true, head_sha: SHA, labels: ["risk/low"], classificationCheck: true, ciGreen: true,
+      protocolRelated: false, risk: "low",
+      specialistReviewers: [], contributor: { status: "eligible" },
+    }),
+    REVIEW_GATE_RESULT: "success", FORK_RATE_LIMIT: JSON.stringify({ status: "allowed" }),
+    FORK_RATE_LIMIT_RESULT: "success", RAW_OUTPUT: JSON.stringify(review({ findings: [] })),
+    REVIEWER_REASON: "", REVIEW_REPORT: JSON.stringify(report), REVIEW_PIPELINE_RESULT: pipelineResult,
+    FORCE: "false", LABELS: JSON.stringify(["risk/low"]), REVIEW_MARKER_ID: "123",
+    SUMMARY_URL: "https://github.example/actions/runs/123",
+  } };
+  await new AsyncFunction("core", "require", "process", resolveReviewScript())(
+    core, requireWithReport, process,
+  );
+  return { state: JSON.parse(outputs.get("state")), summary: summary.join("\n") };
+}
+
 test("reusable review keeps inherited secrets inside the trusted workflow", () => {
   const caller = workflowJob(readWorkflow(), "review-pipeline");
   const reviewWorkflow = readReviewWorkflow();
@@ -140,11 +186,7 @@ test("automatic review requires exact-head CI and only reruns after a later push
   assert.match(reviewState, /REVIEW_REPORT: \$\{\{ needs\.review-pipeline\.outputs\.report \}\}/);
   assert.match(reviewState, /parseReport\(process\.env\.REVIEW_REPORT\)/);
   assert.match(reviewState, /report\.status === "success" \? parse\(process\.env\.RAW_OUTPUT, null\) : null/);
-  assert.match(reviewState, /value === null \? "unavailable" : String\(value\)/);
-  assert.ok(
-    reviewState.indexOf("metrics.tokens === null") < reviewState.indexOf("metrics.tokens.input"),
-    "aggregate tokens are checked for null before their fields are rendered",
-  );
+  assert.match(reviewState, /renderReviewReport/);
   assert.match(reviewState, /REVIEW_GATE_RESULT: \$\{\{ needs\.review-gate\.result \}\}/);
   assert.match(reviewState, /FORK_RATE_LIMIT_RESULT: \$\{\{ needs\.fork-rate-limit\.result \}\}/);
   assert.match(reviewState, /REVIEW_PIPELINE_RESULT: \$\{\{ needs\.review-pipeline\.result \}\}/);
@@ -188,6 +230,88 @@ test("review outcome requires validated final output", () => {
   assert.equal(reviewOutcome({ reportStatus: "success", state: {}, recovered: true }), "recovered");
   assert.equal(reviewOutcome({ reportStatus: "success", state: {}, recovered: false }), "complete");
   assert.equal(reviewOutcome({ reportStatus: "failed", state: {}, recovered: true }), "unavailable");
+});
+
+test("resolve review state renders bounded recovery diagnostics in the check and summary", async () => {
+  const stages = [
+    {
+      id: "evidence", status: "success", attempts: 1,
+      metrics: { tokens: null, elapsed_ms: 0, request_retries: null, output_repairs: null },
+    },
+    {
+      id: "general", status: "success", attempts: 2,
+      previous_reason: "retry declined | malformed <payload>",
+      metrics: {
+        tokens: { input: 0, output: 4, complete: false },
+        elapsed_ms: 0, request_retries: 0, output_repairs: 0,
+      },
+    },
+    {
+      id: "validate", status: "success", attempts: 1,
+      metrics: { tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null },
+    },
+  ];
+  const recovered = await runResolveReviewScript({
+    report: {
+      v: 1, status: "success", stages: [
+        ...stages.slice(0, 2),
+        {
+          id: "aggregate", status: "success", attempts: 1,
+          metrics: { tokens: null, elapsed_ms: 0, request_retries: null, output_repairs: null },
+        },
+        stages[2],
+      ],
+      metrics: {
+        tokens: { input: 0, output: 4 }, tokens_complete: false,
+        elapsed_ms: 0, request_retries: 0, output_repairs: 0, stage_retries: 1,
+      },
+    },
+  });
+  assert.match(recovered.state.check.summary, /Validated automated review was produced after stage recovery/);
+  assert.match(recovered.state.check.summary, /retry declined \\| malformed &lt;payload&gt;/);
+  assert.match(recovered.state.check.summary, /0\/4\/(?:unknown|unavailable) \\\(partial\\\)/);
+  assert.match(recovered.state.check.summary, /\| 0 \|/);
+  assert.match(recovered.state.check.summary, /unavailable/);
+  assert.match(recovered.state.check.summary, /View the workflow summary/);
+  assert.equal(recovered.state.check.conclusion, "success");
+  assert.match(recovered.summary, /retry declined \\| malformed &lt;payload&gt;/);
+  assert.match(recovered.summary, /Per-stage metrics/);
+
+  const terminal = await runResolveReviewScript({
+    report: {
+      v: 1, status: "failed",
+      stages: [{
+        id: "protocol", status: "failed", attempts: 2, reason: "provider unavailable",
+        category: "retry-declined", metrics: {
+          tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null,
+        },
+      }],
+      metrics: {
+        tokens: null, tokens_complete: false, elapsed_ms: null, request_retries: null,
+        output_repairs: null, stage_retries: 1,
+      },
+    },
+  });
+  assert.match(terminal.state.check.summary, /provider unavailable/);
+  assert.match(terminal.state.check.summary, /retry-declined/);
+  assert.match(terminal.state.check.summary, /unavailable/);
+  assert.equal(terminal.state.check.conclusion, "neutral");
+
+  const missing = await runResolveReviewScript({
+    report: {
+      v: 1, status: "failed",
+      stages: [{
+        id: "pipeline", status: "failed", attempts: 1, reason: "no usable report",
+        metrics: { tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null },
+      }],
+      metrics: {
+        tokens: null, tokens_complete: false, elapsed_ms: null, request_retries: null,
+        output_repairs: null, stage_retries: null,
+      },
+    },
+  });
+  assert.match(missing.state.check.summary, /no usable report/);
+  assert.match(missing.state.check.summary, /unavailable/);
 });
 
 test("review skip summary explains gate and quota failures", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -311,7 +311,7 @@ test("resolve review state renders bounded recovery diagnostics in the check and
       },
     },
   });
-  assert.match(terminal.state.check.summary, /provider unavailable/);
+  assert.match(terminal.state.check.summary, /protocol: provider unavailable/);
   assert.match(terminal.state.check.summary, /retry-declined/);
   assert.match(terminal.state.check.summary, /unavailable/);
   assert.equal(terminal.state.check.conclusion, "neutral");

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -352,6 +352,9 @@ test("resolve review state renders bounded recovery diagnostics in the check and
     summaryUrl: "https://github.example/actions/runs/123",
   });
   assert.ok(Buffer.byteLength(bounded.checkSummary) < 24 * 1024);
+  assert.match(bounded.checkSummary, /9 omitted to bound output/);
+  assert.doesNotMatch(bounded.checkSummary, /stage-15-/);
+  assert.match(bounded.workflowSummary, /stage-15-/);
 });
 
 test("review skip summary explains gate and quota failures", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -335,9 +335,9 @@ test("resolve review state renders bounded recovery diagnostics in the check and
   const bounded = renderReviewReport({
     report: {
       stages: Array.from({ length: 16 }, (_, index) => ({
-        id: `stage-${index}-${"x".repeat(300)}`, status: "failed", attempts: 2,
-        reason: "r".repeat(300), category: "retry-declined",
-        previous_reason: "p".repeat(300),
+        id: `stage-${index}-${"'".repeat(300)}`, status: "failed", attempts: 2,
+        reason: "'".repeat(300), category: "retry-declined",
+        previous_reason: "'".repeat(300),
         metrics: {
           tokens: { input: 0, output: 0, total: 0, complete: true },
           elapsed_ms: 0, request_retries: 0, output_repairs: 0,
@@ -351,7 +351,7 @@ test("resolve review state renders bounded recovery diagnostics in the check and
     outcome: "unavailable", detail: "review unavailable",
     summaryUrl: "https://github.example/actions/runs/123",
   });
-  assert.ok(Buffer.byteLength(bounded.checkSummary) < 24 * 1024);
+  assert.ok(Buffer.byteLength(bounded.checkSummary) < 65_535);
   assert.match(bounded.checkSummary, /9 omitted to bound output/);
   assert.doesNotMatch(bounded.checkSummary, /stage-15-/);
   assert.match(bounded.workflowSummary, /stage-15-/);

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -27,6 +27,7 @@ const {
 } = require("./write-state");
 const { forkRateLimit } = require("./fork-rate-limit");
 const { reviewSkipReasons } = require("./review-skip-summary");
+const { renderReviewReport } = require("./review-report-summary");
 const {
   MAX_BODY_LENGTH, MAX_COMMENT_LENGTH, MAX_COMMENTS, fetchReviewContext,
 } = require("./fetch-review-context");
@@ -280,12 +281,30 @@ test("resolve review state renders bounded recovery diagnostics in the check and
   const terminal = await runResolveReviewScript({
     report: {
       v: 1, status: "failed",
-      stages: [{
-        id: "protocol", status: "failed", attempts: 2, reason: "provider unavailable",
-        category: "retry-declined", metrics: {
-          tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null,
+      stages: [
+        {
+          id: "evidence", status: "success", required: true,
+          metrics: { tokens: null, elapsed_ms: 0, request_retries: null, output_repairs: null },
         },
-      }],
+        {
+          id: "protocol", status: "failed", required: true, attempts: 2, reason: "provider unavailable",
+          category: "retry-declined", metrics: {
+            tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null,
+          },
+        },
+        {
+          id: "aggregate", status: "success", required: true,
+          metrics: { tokens: null, elapsed_ms: 0, request_retries: null, output_repairs: null },
+        },
+        {
+          id: "general", status: "success", required: true,
+          metrics: { tokens: null, elapsed_ms: 0, request_retries: null, output_repairs: null },
+        },
+        {
+          id: "validate", status: "success", required: true,
+          metrics: { tokens: null, elapsed_ms: null, request_retries: null, output_repairs: null },
+        },
+      ],
       metrics: {
         tokens: null, tokens_complete: false, elapsed_ms: null, request_retries: null,
         output_repairs: null, stage_retries: 1,
@@ -312,6 +331,27 @@ test("resolve review state renders bounded recovery diagnostics in the check and
   });
   assert.match(missing.state.check.summary, /no usable report/);
   assert.match(missing.state.check.summary, /unavailable/);
+
+  const bounded = renderReviewReport({
+    report: {
+      stages: Array.from({ length: 16 }, (_, index) => ({
+        id: `stage-${index}-${"x".repeat(300)}`, status: "failed", attempts: 2,
+        reason: "r".repeat(300), category: "retry-declined",
+        previous_reason: "p".repeat(300),
+        metrics: {
+          tokens: { input: 0, output: 0, total: 0, complete: true },
+          elapsed_ms: 0, request_retries: 0, output_repairs: 0,
+        },
+      })),
+      metrics: {
+        tokens: { input: 0, output: 0, total: 0 }, tokens_complete: true,
+        elapsed_ms: 0, request_retries: 0, output_repairs: 0, stage_retries: 16,
+      },
+    },
+    outcome: "unavailable", detail: "review unavailable",
+    summaryUrl: "https://github.example/actions/runs/123",
+  });
+  assert.ok(Buffer.byteLength(bounded.checkSummary) < 24 * 1024);
 });
 
 test("review skip summary explains gate and quota failures", () => {

--- a/.github/pr-automation/review-report-summary.js
+++ b/.github/pr-automation/review-report-summary.js
@@ -1,21 +1,15 @@
 "use strict";
 
 const { REVIEWER_ORDER } = require("./routing");
+const { escapeMarkdown } = require("./write-state");
 
 const MAX_CHECK_STAGES = REVIEWER_ORDER.length + 4;
 const MAX_WORKFLOW_STAGES = 64;
-const MAX_TEXT_LENGTH = 300;
+const MAX_CHECK_TEXT_LENGTH = 250;
+const MAX_WORKFLOW_TEXT_LENGTH = 300;
 
-function escapeMarkdown(value) {
-  return String(value).replace(/\\/g, "\\\\")
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;").replace(/'/g, "&#39;").replace(/`/g, "&#96;")
-    .replace(/@(?=[\w-])/g, "`@`").replace(/(?<!&)#(?=\d)/g, "`#`")
-    .replace(/[[\]()!*_~|]/g, "\\$&");
-}
-
-function text(value) {
-  return escapeMarkdown(String(value ?? "").slice(0, MAX_TEXT_LENGTH) || "unknown");
+function text(value, maxTextLength) {
+  return escapeMarkdown(String(value ?? "").slice(0, maxTextLength) || "unknown");
 }
 
 function metric(value) {
@@ -29,8 +23,8 @@ function tokens(tokens, complete = tokens?.complete) {
   return `${values.join("/")} ${complete ? "" : "(partial)"}`.trim();
 }
 
-function table(headers, rows) {
-  const line = (columns) => `| ${columns.map(text).join(" | ")} |`;
+function table(headers, rows, maxTextLength) {
+  const line = (columns) => `| ${columns.map((column) => text(column, maxTextLength)).join(" | ")} |`;
   return [line(headers), `| ${headers.map(() => "---").join(" | ")} |`, ...rows.map(line)].join("\n");
 }
 
@@ -46,7 +40,7 @@ function failureAttempts(stages) {
   });
 }
 
-function diagnostics(report, outcome, maxStages) {
+function diagnostics(report, outcome, maxStages, maxTextLength) {
   const stages = report.stages.slice(0, maxStages);
   const omittedStages = report.stages.length - stages.length;
   const attempts = failureAttempts(stages);
@@ -54,14 +48,14 @@ function diagnostics(report, outcome, maxStages) {
   const metrics = report.metrics;
   const failedAttempts = attempts.length === 0
     ? "No stage failure was reported."
-    : table(["Stage", "Attempt", "Reason"], attempts);
+    : table(["Stage", "Attempt", "Reason"], attempts, maxTextLength);
   const totalMetrics = table(["Metric", "Total"], [
     ["Tokens", tokens(metrics.tokens, metrics.tokens_complete)],
     ["Elapsed (ms)", metric(metrics.elapsed_ms)],
     ["Request retries", metric(metrics.request_retries)],
     ["Output repairs", metric(metrics.output_repairs)],
     ["Stage retries", metric(metrics.stage_retries)],
-  ]);
+  ], maxTextLength);
   const stageRows = stages.map((stage) => [
     stage.id, stage.status, stage.attempts, tokens(stage.metrics.tokens),
     metric(stage.metrics.elapsed_ms), metric(stage.metrics.request_retries),
@@ -73,7 +67,7 @@ function diagnostics(report, outcome, maxStages) {
   }
   const stageMetrics = table(
     ["Stage", "Status", "Attempts", "Tokens", "Elapsed (ms)", "Request retries", "Output repairs"],
-    stageRows,
+    stageRows, maxTextLength,
   );
   return [
     `Review outcome: **${outcome}**.`,
@@ -90,8 +84,8 @@ function diagnostics(report, outcome, maxStages) {
 }
 
 function renderReviewReport({ report, outcome, detail, summaryUrl }) {
-  const checkDiagnostics = diagnostics(report, outcome, MAX_CHECK_STAGES);
-  const workflowDiagnostics = diagnostics(report, outcome, MAX_WORKFLOW_STAGES);
+  const checkDiagnostics = diagnostics(report, outcome, MAX_CHECK_STAGES, MAX_CHECK_TEXT_LENGTH);
+  const workflowDiagnostics = diagnostics(report, outcome, MAX_WORKFLOW_STAGES, MAX_WORKFLOW_TEXT_LENGTH);
   const heading = {
     complete: "Automated review complete",
     recovered: "Automated review recovered",
@@ -101,7 +95,7 @@ function renderReviewReport({ report, outcome, detail, summaryUrl }) {
     ? "Validated automated review is bound to this commit."
     : outcome === "recovered"
       ? "Validated automated review was produced after stage recovery."
-      : `Automated review is unavailable: ${text(detail || "review unavailable")}. Maintainer review is required.`;
+      : `Automated review is unavailable: ${text(detail || "review unavailable", MAX_CHECK_TEXT_LENGTH)}. Maintainer review is required.`;
   return {
     title: heading,
     checkSummary: `${outcomeText}\n\n${checkDiagnostics}\n\n[View the workflow summary](${summaryUrl})`,

--- a/.github/pr-automation/review-report-summary.js
+++ b/.github/pr-automation/review-report-summary.js
@@ -2,7 +2,8 @@
 
 const { REVIEWER_ORDER } = require("./routing");
 
-const MAX_STAGES = REVIEWER_ORDER.length + 4;
+const MAX_CHECK_STAGES = REVIEWER_ORDER.length + 4;
+const MAX_WORKFLOW_STAGES = 64;
 const MAX_TEXT_LENGTH = 300;
 
 function escapeMarkdown(value) {
@@ -45,22 +46,12 @@ function failureAttempts(stages) {
   });
 }
 
-function renderReviewReport({ report, outcome, detail, summaryUrl }) {
-  const stages = report.stages.slice(0, MAX_STAGES);
+function diagnostics(report, outcome, maxStages) {
+  const stages = report.stages.slice(0, maxStages);
   const omittedStages = report.stages.length - stages.length;
   const attempts = failureAttempts(stages);
   if (omittedStages > 0) attempts.push(["additional stages", "unknown", `${omittedStages} omitted to bound output`]);
   const metrics = report.metrics;
-  const heading = {
-    complete: "Automated review complete",
-    recovered: "Automated review recovered",
-    unavailable: "Automated review unavailable",
-  }[outcome];
-  const outcomeText = outcome === "complete"
-    ? "Validated automated review is bound to this commit."
-    : outcome === "recovered"
-      ? "Validated automated review was produced after stage recovery."
-      : `Automated review is unavailable: ${text(detail || "review unavailable")}. Maintainer review is required.`;
   const failedAttempts = attempts.length === 0
     ? "No stage failure was reported."
     : table(["Stage", "Attempt", "Reason"], attempts);
@@ -71,15 +62,20 @@ function renderReviewReport({ report, outcome, detail, summaryUrl }) {
     ["Output repairs", metric(metrics.output_repairs)],
     ["Stage retries", metric(metrics.stage_retries)],
   ]);
+  const stageRows = stages.map((stage) => [
+    stage.id, stage.status, stage.attempts, tokens(stage.metrics.tokens),
+    metric(stage.metrics.elapsed_ms), metric(stage.metrics.request_retries),
+    metric(stage.metrics.output_repairs),
+  ]);
+  if (omittedStages > 0) {
+    stageRows.push(["additional stages", "unknown", "unknown", "unknown", "unknown", "unknown",
+      `${omittedStages} omitted to bound output`]);
+  }
   const stageMetrics = table(
     ["Stage", "Status", "Attempts", "Tokens", "Elapsed (ms)", "Request retries", "Output repairs"],
-    stages.map((stage) => [
-      stage.id, stage.status, stage.attempts, tokens(stage.metrics.tokens),
-      metric(stage.metrics.elapsed_ms), metric(stage.metrics.request_retries),
-      metric(stage.metrics.output_repairs),
-    ]),
+    stageRows,
   );
-  const diagnostics = [
+  return [
     `Review outcome: **${outcome}**.`,
     "",
     "### Failed stage attempts",
@@ -91,10 +87,25 @@ function renderReviewReport({ report, outcome, detail, summaryUrl }) {
     "### Per-stage metrics",
     stageMetrics,
   ].join("\n");
+}
+
+function renderReviewReport({ report, outcome, detail, summaryUrl }) {
+  const checkDiagnostics = diagnostics(report, outcome, MAX_CHECK_STAGES);
+  const workflowDiagnostics = diagnostics(report, outcome, MAX_WORKFLOW_STAGES);
+  const heading = {
+    complete: "Automated review complete",
+    recovered: "Automated review recovered",
+    unavailable: "Automated review unavailable",
+  }[outcome];
+  const outcomeText = outcome === "complete"
+    ? "Validated automated review is bound to this commit."
+    : outcome === "recovered"
+      ? "Validated automated review was produced after stage recovery."
+      : `Automated review is unavailable: ${text(detail || "review unavailable")}. Maintainer review is required.`;
   return {
     title: heading,
-    checkSummary: `${outcomeText}\n\n${diagnostics}\n\n[View the workflow summary](${summaryUrl})`,
-    workflowSummary: `# Automated review\n\n${diagnostics}`,
+    checkSummary: `${outcomeText}\n\n${checkDiagnostics}\n\n[View the workflow summary](${summaryUrl})`,
+    workflowSummary: `# Automated review\n\n${workflowDiagnostics}`,
   };
 }
 

--- a/.github/pr-automation/review-report-summary.js
+++ b/.github/pr-automation/review-report-summary.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const MAX_STAGES = 32;
+const MAX_STAGES = 8;
 const MAX_TEXT_LENGTH = 300;
 
 function escapeMarkdown(value) {

--- a/.github/pr-automation/review-report-summary.js
+++ b/.github/pr-automation/review-report-summary.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const MAX_STAGES = 32;
+const MAX_TEXT_LENGTH = 300;
+
+function escapeMarkdown(value) {
+  return String(value).replace(/\\/g, "\\\\")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;").replace(/`/g, "&#96;")
+    .replace(/@(?=[\w-])/g, "`@`").replace(/(?<!&)#(?=\d)/g, "`#`")
+    .replace(/[[\]()!*_~|]/g, "\\$&");
+}
+
+function text(value) {
+  return escapeMarkdown(String(value ?? "").slice(0, MAX_TEXT_LENGTH) || "unknown");
+}
+
+function metric(value) {
+  return value === null ? "unavailable" : value === undefined ? "unknown" : String(value);
+}
+
+function tokens(tokens, complete = tokens?.complete) {
+  if (tokens === null) return "unavailable";
+  if (tokens === undefined) return "unknown";
+  const values = ["input", "output", "total"].map((name) => metric(tokens[name]));
+  return `${values.join("/")} ${complete ? "" : "(partial)"}`.trim();
+}
+
+function table(headers, rows) {
+  const line = (columns) => `| ${columns.map(text).join(" | ")} |`;
+  return [line(headers), `| ${headers.map(() => "---").join(" | ")} |`, ...rows.map(line)].join("\n");
+}
+
+function failureAttempts(stages) {
+  return stages.flatMap((stage) => {
+    const finalReason = stage.reason && stage.category
+      ? `${stage.reason} (${stage.category})`
+      : stage.reason || stage.category;
+    return [
+      ...(stage.previous_reason ? [[stage.id, "first attempt", stage.previous_reason]] : []),
+      ...(stage.status === "failed" ? [[stage.id, "final attempt", finalReason || "unknown"]] : []),
+    ];
+  });
+}
+
+function renderReviewReport({ report, outcome, detail, summaryUrl }) {
+  const stages = report.stages.slice(0, MAX_STAGES);
+  const omittedStages = report.stages.length - stages.length;
+  const attempts = failureAttempts(stages);
+  if (omittedStages > 0) attempts.push(["additional stages", "unknown", `${omittedStages} omitted to bound output`]);
+  const metrics = report.metrics;
+  const heading = {
+    complete: "Automated review complete",
+    recovered: "Automated review recovered",
+    unavailable: "Automated review unavailable",
+  }[outcome];
+  const outcomeText = outcome === "complete"
+    ? "Validated automated review is bound to this commit."
+    : outcome === "recovered"
+      ? "Validated automated review was produced after stage recovery."
+      : `Automated review is unavailable: ${text(detail || "review unavailable")}. Maintainer review is required.`;
+  const failedAttempts = attempts.length === 0
+    ? "No stage failure was reported."
+    : table(["Stage", "Attempt", "Reason"], attempts);
+  const totalMetrics = table(["Metric", "Total"], [
+    ["Tokens", tokens(metrics.tokens, metrics.tokens_complete)],
+    ["Elapsed (ms)", metric(metrics.elapsed_ms)],
+    ["Request retries", metric(metrics.request_retries)],
+    ["Output repairs", metric(metrics.output_repairs)],
+    ["Stage retries", metric(metrics.stage_retries)],
+  ]);
+  const stageMetrics = table(
+    ["Stage", "Status", "Attempts", "Tokens", "Elapsed (ms)", "Request retries", "Output repairs"],
+    stages.map((stage) => [
+      stage.id, stage.status, stage.attempts, tokens(stage.metrics.tokens),
+      metric(stage.metrics.elapsed_ms), metric(stage.metrics.request_retries),
+      metric(stage.metrics.output_repairs),
+    ]),
+  );
+  const diagnostics = [
+    `Review outcome: **${outcome}**.`,
+    "",
+    "### Failed stage attempts",
+    failedAttempts,
+    "",
+    "### Metrics",
+    totalMetrics,
+    "",
+    "### Per-stage metrics",
+    stageMetrics,
+  ].join("\n");
+  return {
+    title: heading,
+    checkSummary: `${outcomeText}\n\n${diagnostics}\n\n[View the workflow summary](${summaryUrl})`,
+    workflowSummary: `# Automated review\n\n${diagnostics}`,
+  };
+}
+
+module.exports = { renderReviewReport };

--- a/.github/pr-automation/review-report-summary.js
+++ b/.github/pr-automation/review-report-summary.js
@@ -1,6 +1,8 @@
 "use strict";
 
-const MAX_STAGES = 8;
+const { REVIEWER_ORDER } = require("./routing");
+
+const MAX_STAGES = REVIEWER_ORDER.length + 4;
 const MAX_TEXT_LENGTH = 300;
 
 function escapeMarkdown(value) {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -721,7 +721,7 @@ jobs:
              const report = parseReport(process.env.REVIEW_REPORT);
              const recovered = report.stages.filter((stage) => stage.attempts === 2);
              const failureReasons = report.stages.filter((stage) => stage.status === "failed")
-               .map((stage) => stage.reason || stage.category);
+               .map((stage) => `${stage.id}: ${stage.reason || stage.category}`);
              const reviewerReason = report.status === "failed"
                ? failureReasons.join("; ") || process.env.REVIEWER_REASON || "review pipeline failed"
                : process.env.REVIEWER_REASON;

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -709,7 +709,8 @@ jobs:
           script: |
              const { resolveReviewState, reviewOutcome } = require("./.github/pr-automation/resolve-state");
              const { reviewSkipReasons } = require("./.github/pr-automation/review-skip-summary");
-             const { parseReport, stageIds } = require("./.github/pr-automation/review-report");
+             const { parseReport } = require("./.github/pr-automation/review-report");
+             const { renderReviewReport } = require("./.github/pr-automation/review-report-summary");
              const parse = (value, fallback) => { try { return JSON.parse(value || ""); } catch { return fallback; } };
              const force = process.env.FORCE === "true";
              const gate = parse(process.env.GATE, force ? {
@@ -718,13 +719,9 @@ jobs:
                specialistReviewers: ["skeptical", "code-compressor"], contributor: { status: "forced" },
              } : {});
              const report = parseReport(process.env.REVIEW_REPORT);
-             const failures = report.stages.filter((stage) => stage.status === "failed");
              const recovered = report.stages.filter((stage) => stage.attempts === 2);
-             const failureReasons = failures.map((stage) => `${stage.id}: ${stage.reason || stage.category}`);
-             const failedAttempts = report.stages.flatMap((stage) => [
-               ...(stage.previous_reason ? [`${stage.id} (first attempt): ${stage.previous_reason}`] : []),
-               ...(stage.status === "failed" ? [`${stage.id}: ${stage.reason || stage.category}`] : []),
-             ]);
+             const failureReasons = report.stages.filter((stage) => stage.status === "failed")
+               .map((stage) => stage.reason || stage.category);
              const reviewerReason = report.status === "failed"
                ? failureReasons.join("; ") || process.env.REVIEWER_REASON || "review pipeline failed"
                : process.env.REVIEWER_REASON;
@@ -761,64 +758,21 @@ jobs:
                  .addList(reasons)
                  .write();
              } else {
-               const metrics = report.metrics;
-               const formatMetric = (value) => value === null ? "unavailable" : String(value);
                const outcome = reviewOutcome({
                  reportStatus: report.status, state, recovered: recovered.length > 0,
                });
-               const title = {
-                 complete: "Automated review complete",
-                 recovered: "Automated review recovered",
-                 unavailable: "Automated review unavailable",
-               }[outcome];
                const detail = state.failed === true ? state.reason || reviewerReason : reviewerReason;
+               const rendered = renderReviewReport({
+                 report, outcome, detail, summaryUrl: process.env.SUMMARY_URL,
+               });
                if (state.check) {
-                 state.check.title = title;
-                 state.check.summary = `${outcome === "complete"
-                   ? "Validated automated review is bound to this commit."
-                   : outcome === "recovered"
-                     ? "Validated automated review was produced after stage recovery."
-                     : `Automated review is unavailable: ${detail || "review unavailable"}. Maintainer review is required.`}\n\n` +
-                   `[View the workflow summary](${process.env.SUMMARY_URL})`;
+                 state.check.title = rendered.title;
+                 state.check.summary = rendered.checkSummary;
                  state.check.conclusion = outcome === "unavailable" ? "neutral" : "success";
                  core.setOutput("state", JSON.stringify(state));
                }
                await core.summary
-                 .addHeading("Automated review")
-                 .addRaw(`Review outcome: **${outcome}**.`, true)
-                 .addRaw(`Stages: ${stageIds(report).join(", ")}.`, true)
-                 .addHeading("Failed stage attempts")
-                 .addList(failedAttempts.length === 0
-                   ? ["No stage failure was reported."]
-                   : failedAttempts)
-                 .addHeading("Metrics")
-                 .addTable([
-                   [{ data: "Metric", header: true }, { data: "Total", header: true }],
-                   [{ data: "Tokens" }, {
-                     data: metrics.tokens === null ? "unavailable"
-                       : `${formatMetric(metrics.tokens.input)} input, ${formatMetric(metrics.tokens.output)} output, ` +
-                         `${formatMetric(metrics.tokens.total)} total${metrics.tokens_complete ? "" : " (incomplete)"}`,
-                   }],
-                   ...["elapsed_ms", "request_retries", "output_repairs", "stage_retries"].map((name) => [
-                     { data: name }, { data: formatMetric(metrics[name]) },
-                   ]),
-                 ])
-                 .addHeading("Per-stage metrics")
-                 .addTable([
-                   [{ data: "Stage", header: true }, { data: "Status", header: true },
-                     { data: "Attempts", header: true }, { data: "Tokens", header: true },
-                     { data: "Elapsed (ms)", header: true }, { data: "Request retries", header: true },
-                     { data: "Output repairs", header: true }],
-                   ...report.stages.map((stage) => [
-                     { data: stage.id }, { data: stage.status }, { data: String(stage.attempts) },
-                     { data: stage.metrics.tokens === null ? "unavailable"
-                       : `${stage.metrics.tokens.input}/${stage.metrics.tokens.output}/${stage.metrics.tokens.total}` +
-                         (stage.metrics.tokens.complete ? "" : " (incomplete)") },
-                     { data: stage.metrics.elapsed_ms === null ? "unavailable" : String(stage.metrics.elapsed_ms) },
-                     { data: stage.metrics.request_retries === null ? "unavailable" : String(stage.metrics.request_retries) },
-                     { data: stage.metrics.output_repairs === null ? "unavailable" : String(stage.metrics.output_repairs) },
-                   ]),
-                 ])
+                 .addRaw(rendered.workflowSummary, true)
                  .write();
              }
 


### PR DESCRIPTION
Expose normalized recovery diagnostics in the AI automated review check and workflow summary.

Keep failed attempts, unavailable or partial measurements, and the summary link visible without publishing metrics in review comments.

Depends on #1922.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>