### PR TITLE
fix(rdpeusb): stop releasing the device sink interface

### DIFF
--- a/crates/ironrdp-rdpeusb/src/server.rs
+++ b/crates/ironrdp-rdpeusb/src/server.rs
@@ -746,10 +746,6 @@ impl DvcProcessor for UrbdrcDeviceServer {
                 self.udev_iface = Some(udev_iface);
                 self.no_ack_isoch_write_jitter_buf_size = Some(no_ack_isoch_write_jitter_buf_size);
                 self.state = DeviceState::Ready;
-                resp.push(Box::new(InterfaceRelease {
-                    msg_id: self.msg_alloc.alloc(),
-                    iface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
-                }));
                 resp.push(Box::new(RegisterRequestCallback {
                     msg_id: self.msg_alloc.alloc(),
                     udev_iface,

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/server.rs
@@ -231,14 +231,9 @@ fn new_device_sequence() {
     let resp = server
         .process(11, &encode_pdu(&UrbdrcClientDevicePdu::AddDev(add_device)))
         .expect("add device should succeed");
-    assert_eq!(resp.len(), 2);
+    assert_eq!(resp.len(), 1);
 
-    let UrbdrcServerDevicePdu::IfaceRelease(release) = decode_device_msg(&resp[0]) else {
-        panic!("expected device sink interface release");
-    };
-    assert_eq!(release.iface_id, proxy_iface_id(InterfaceId::DEVICE_SINK));
-
-    let UrbdrcServerDevicePdu::RegReqCb(register) = decode_device_msg(&resp[1]) else {
+    let UrbdrcServerDevicePdu::RegReqCb(register) = decode_device_msg(&resp[0]) else {
         panic!("expected request callback registration");
     };
     assert_eq!(register.udev_iface, udev_iface);


### PR DESCRIPTION
mstsc closes the per-device channel right after ADD_DEVICE when the server releases it, aborting every redirected device. A Windows server never sends this release.

So we align with windows server.