### PR TITLE
docs(pr-automation): clarify review pipeline intent

### DIFF
--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -1,20 +1,20 @@
 ## Concurrency model
 
-We’re using Helmcode for the automated classifier and reviewer pipeline.
-We get at most 5 parallel requests.
+The Helmcode key permits at most 25 parallel requests.
 
-To use the 5 parallel requests as efficiently as possible:
+Allocate more capacity to slower review pipelines than to fast classifiers:
 
-- Run at most two classifier agents in parallel.
-- Run at most one reviewer pipeline with at most 3 specialist reviews in parallel.
+- Run at most 4 classifier agents in parallel.
+- Run at most 7 reviewer pipelines, each with at most 3 specialist reviews in parallel.
 
-That totals at most 5 parallel requests at any time.
+That totals at most 25 parallel requests at any time: 4 for classifiers and 21 for review pipelines.
 All model-output schemas are internal and unversioned.
 
 For simplicity, derive static concurrency lanes from the pull request number instead of using an external semaphore service.
 
 ```text
-classifier-lane = (pr-number % 2) + 1 // = 1 or 2
+classifier-lane = (pr-number % 4) + 1 // 1 through 4
+review-pipeline-lane = (pr-number % 7) + 1 // 1 through 7
 ```
 
 At the classifier job level:
@@ -30,13 +30,13 @@ And for the reviewer pipeline job:
 
 ```yaml
 concurrency:
-  group: llm-reviewer-pipeline
+  group: llm-reviewer-pipeline-${{ review-pipeline-lane }}
   cancel-in-progress: false
   queue: max
 ```
 
-`llm-reviewer-pipeline` group must lock the entire review pipeline, not each reviewer job.
-The review pipeline must therefore live in a reusable workflow, with `llm-reviewer-pipeline` concurrency on its caller job.
+Each reviewer-pipeline lane must lock the entire review pipeline, not each reviewer job.
+The review pipeline must therefore live in a reusable workflow, with lane concurrency on its caller job.
 
 ## Classification
 

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -44,12 +44,15 @@ The review pipeline must therefore live in a reusable workflow, with `llm-review
 
 ## Reviewer pipeline
 
-- Select specialists, identify which are required, and call `review-pipeline.yml`.
+- Require valid classification for the exact PR head; missing, stale, or invalid classification is an invocation error.
+- Select specialists and identify which are required from that classification, then call `review-pipeline.yml`.
 - Publish only after all required specialists succeed and the general review passes validation.
 
 The published comments include the name of the specialist that found the finding.
 Render severity as `critical :purple_circle:`, `high :red_circle:`, `medium :orange_circle:`, or `low :yellow_circle:`.
 Append `:question:` for questions, and show `:green_circle:` in the main comment when no findings are found.
+Disclose reduced coverage from optional reviewer failures in the published review and review check, naming each failed reviewer.
+Keep detailed failure reasons in the workflow summary only.
 
 ### Stage recovery
 
@@ -57,7 +60,7 @@ Append `:question:` for questions, and show `:green_circle:` in the main comment
 - A later workflow run starts a fresh recovery budget.
 - Keep all eligibility checks, resource limits, and stale-head protections in effect.
 - Never publish the same review twice, and count only published reviews toward the two-review limit.
-- Show the pipeline-reported recovery outcome, every failed-stage reason, and per-stage metrics including unavailable usage in the review check and workflow summary.
+- Show the pipeline-reported recovery outcome and LLM-stage metrics including unavailable usage in the review check and workflow summary.
 - Link to the summary from the `AI automated review` check; keep metrics out of review comments.
 
 ## Activation policy
@@ -85,4 +88,4 @@ Normal classification-to-review dispatch is edge-triggered and occurs only when 
 Adding `ai-review/allow-oversized` forces reclassification and may dispatch on the same SHA when the resulting classification state is unchanged.
 Unrelated label events and repeated non-explicit unchanged classifications must not dispatch.
 
-Force mode bypasses policy gates but not evidence, validation, filesystem, citation, publication, or stale-head safeguards.
+Force mode bypasses policy gates but not classification prerequisites, evidence, validation, filesystem, citation, publication, or stale-head safeguards.

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -1,7 +1,7 @@
 ## Reviewer pipeline
 
 `review-pipeline.yml` is a reusable GitHub Actions workflow with `workflow_call` as its only trigger.
-This lets specialists run in parallel while the caller applies a global concurrency limit to the entire pipeline.
+The caller limits concurrent pipelines to seven using static lanes, each held for the entire pipeline.
 The caller owns publication.
 
 ```text
@@ -23,7 +23,7 @@ Supported specialists include:
 - skeptical
 - code compressor
 
-Run selected specialists in a multi-job matrix, with at most three running at once.
+Run selected specialists in a multi-job matrix, with at most three running at once per pipeline.
 
 ### Stage recovery
 

--- a/.github/workflows/review-pipeline.intent.md
+++ b/.github/workflows/review-pipeline.intent.md
@@ -31,7 +31,8 @@ Stage recovery happens within one workflow invocation and keeps the results of s
 
 - Retry a stage once, after a delay, when the provider fails transiently.
 - Recheck the head and review prerequisites before a delayed retry.
-- Supply a review-specific validator and let the action handle bounded output repair.
+- Produce schema-conforming output with minimal, bounded repair and review-specific semantic validation.
+- Report each rejected output attempt's validation reason with bounded, sanitized diagnostics.
 - Never discard findings during output repair; fail the stage if repair cannot produce valid output.
 
 Reusing results across workflow runs is not required.
@@ -40,12 +41,12 @@ A later run starts fresh.
 ### Outputs
 
 - Return a validated general review only when every required specialist succeeds.
-- Return every failed stage and its reason to the caller.
+- Return every stage's outcome and failure reason, distinguishing reduced coverage from full completion.
 
-Return per-stage metrics, including failed attempts and marking unavailable data:
+Return metrics only for LLM-powered stages, including failed attempts and marking unavailable data:
 
-- Token usage.
-- Elapsed time.
+- Clearly labeled input, output, and total token usage, accumulated across requests.
+- Elapsed time in seconds; label summed durations as cumulative rather than wall-clock time.
 - Request-retry count.
 - Output-repair count.
 - Stage-recovery count.


### PR DESCRIPTION
Record the review contract after a forced run skipped protocol review and published despite an optional specialist failure.

Require exact-head classification even in force mode and disclose reduced coverage while keeping detailed failure reasons in the workflow summary.
Specify actionable validation diagnostics and LLM-only metrics with explicit token counts and elapsed seconds.
Allocate four classifier lanes and seven review-pipeline lanes within the Helmcode key's 25-request limit, retaining whole-pipeline locking and at most three parallel specialists per pipeline.

Update intent only; workflow implementation is unchanged.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>