### PR TITLE
fix(web): report invalid image extraction regions

### DIFF
--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -24,7 +24,7 @@ harness = true
 [dev-dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "svc", "dvc", "echo"] }
+ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "graphics", "svc", "dvc", "echo"] }
 ironrdp-cfg.path = "../ironrdp-cfg"
 ironrdp-async.path = "../ironrdp-async"
 ironrdp-agent.path = "../ironrdp-agent"

--- a/crates/ironrdp-testsuite-extra/tests/main.rs
+++ b/crates/ironrdp-testsuite-extra/tests/main.rs
@@ -11,3 +11,6 @@ mod gateway_detect;
 mod rdpeudp_tokio;
 mod vmconnect;
 mod volume;
+
+#[path = "../../ironrdp-web/src/image.rs"]
+mod web_image;

--- a/crates/ironrdp-web/src/image.rs
+++ b/crates/ironrdp-web/src/image.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
+use anyhow::Context as _;
 use ironrdp::pdu::geometry::{InclusiveRectangle, Rectangle as _};
 use ironrdp::session::image::DecodedImage;
 use ironrdp_core::WriteBuf;
@@ -10,7 +11,19 @@ pub(crate) fn extract_partial_image(
     image: &DecodedImage,
     region: InclusiveRectangle,
     buffer: &mut WriteBuf,
-) -> InclusiveRectangle {
+) -> anyhow::Result<InclusiveRectangle> {
+    if region.left > region.right
+        || region.top > region.bottom
+        || region.right >= image.width()
+        || region.bottom >= image.height()
+    {
+        anyhow::bail!(
+            "invalid region {region:?} for image with dimensions {}x{}",
+            image.width(),
+            image.height()
+        );
+    }
+
     // PERF: needs actual benchmark to find a better heuristic
     if region.height() > 64 || region.width() > 512 {
         extract_whole_rows(image, region, buffer)
@@ -24,7 +37,7 @@ fn extract_smallest_rectangle(
     image: &DecodedImage,
     region: InclusiveRectangle,
     buffer: &mut WriteBuf,
-) -> InclusiveRectangle {
+) -> anyhow::Result<InclusiveRectangle> {
     let pixel_size = usize::from(image.pixel_format().bytes_per_pixel());
 
     let image_width = usize::from(image.width());
@@ -37,14 +50,21 @@ fn extract_smallest_rectangle(
     let region_stride = region_width * pixel_size;
 
     let dst_buf_size = region_width * region_height * pixel_size;
-    let dst = buffer.unfilled_to(dst_buf_size);
 
     let src = image.data();
+
+    let dst = buffer.unfilled_to(dst_buf_size);
 
     for row in 0..region_height {
         let src_begin = image_stride * (region_top + row) + region_left * pixel_size;
         let src_end = src_begin + region_stride;
-        let src_slice = &src[src_begin..src_end];
+        let src_slice = src.get(src_begin..src_end).with_context(|| {
+            format!(
+                "invalid region {region:?} for image with dimensions {}x{}",
+                image.width(),
+                image.height()
+            )
+        })?;
 
         let target_begin = region_stride * row;
         let target_end = target_begin + region_stride;
@@ -55,11 +75,15 @@ fn extract_smallest_rectangle(
 
     buffer.advance(dst_buf_size);
 
-    region
+    Ok(region)
 }
 
 // Faster for high-height and bigger images
-fn extract_whole_rows(image: &DecodedImage, region: InclusiveRectangle, buffer: &mut WriteBuf) -> InclusiveRectangle {
+fn extract_whole_rows(
+    image: &DecodedImage,
+    region: InclusiveRectangle,
+    buffer: &mut WriteBuf,
+) -> anyhow::Result<InclusiveRectangle> {
     let pixel_size = usize::from(image.pixel_format().bytes_per_pixel());
 
     let image_width = usize::from(image.width());
@@ -73,14 +97,97 @@ fn extract_whole_rows(image: &DecodedImage, region: InclusiveRectangle, buffer: 
     let src_begin = region_top * image_stride;
     let src_end = (region_bottom + 1) * image_stride;
     let len = src_end - src_begin;
+    let src_slice = src.get(src_begin..src_end).with_context(|| {
+        format!(
+            "invalid region {region:?} for image with dimensions {}x{}",
+            image.width(),
+            image.height()
+        )
+    })?;
 
-    buffer.unfilled_to(len).copy_from_slice(&src[src_begin..src_end]);
+    buffer.unfilled_to(len).copy_from_slice(src_slice);
     buffer.advance(len);
 
-    InclusiveRectangle {
+    Ok(InclusiveRectangle {
         left: 0,
         top: region.top,
         right: image.width() - 1,
         bottom: region.bottom,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp::graphics::image_processing::PixelFormat;
+
+    fn region(left: u16, top: u16, right: u16, bottom: u16) -> InclusiveRectangle {
+        InclusiveRectangle {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    #[test]
+    fn extracts_small_rectangle_into_reused_buffer() {
+        let image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let region = region(1, 1, 2, 2);
+        let mut buffer = WriteBuf::new();
+        buffer.write_slice(&[0xaa, 0xbb]);
+
+        assert_eq!(
+            extract_partial_image(&image, region.clone(), &mut buffer).unwrap(),
+            region
+        );
+
+        let mut expected = vec![0xaa, 0xbb];
+        expected.extend_from_slice(&image.data()[20..28]);
+        expected.extend_from_slice(&image.data()[36..44]);
+        assert_eq!(buffer.filled(), expected);
+    }
+
+    #[test]
+    fn extracts_whole_rows_into_reused_buffer() {
+        let image = DecodedImage::new(PixelFormat::RgbA32, 4, 65);
+        let region = region(1, 0, 2, 64);
+        let mut buffer = WriteBuf::new();
+        buffer.write_slice(&[0xaa, 0xbb]);
+
+        assert_eq!(
+            extract_partial_image(&image, region, &mut buffer).unwrap(),
+            InclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: 3,
+                bottom: 64,
+            }
+        );
+
+        let mut expected = vec![0xaa, 0xbb];
+        expected.extend_from_slice(image.data());
+        assert_eq!(buffer.filled(), expected);
+    }
+
+    #[test]
+    fn rejects_invalid_regions_without_advancing_buffer() {
+        let image = DecodedImage::new(PixelFormat::RgbA32, 4, 65);
+        let mut buffer = WriteBuf::new();
+        buffer.write_slice(&[0xaa, 0xbb]);
+
+        for region in [
+            region(3, 0, 2, 0),
+            region(0, 2, 0, 1),
+            region(0, 64, 0, 65),
+            region(0, 0, 4, 64),
+        ] {
+            assert!(extract_partial_image(&image, region, &mut buffer).is_err());
+            assert_eq!(buffer.filled(), [0xaa, 0xbb]);
+        }
+
+        let empty_image = DecodedImage::new(PixelFormat::RgbA32, 0, 0);
+        assert!(extract_partial_image(&empty_image, region(0, 0, 0, 0), &mut buffer).is_err());
+        assert_eq!(buffer.filled(), [0xaa, 0xbb]);
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -923,7 +923,7 @@ impl iron_remote_desktop::Session for Session {
                             .context("Send frame to writer task")?;
                     }
                     ActiveStageOutput::GraphicsUpdate(region) => {
-                        let region = extract_partial_image(&image, region, &mut draw_buffer);
+                        let region = extract_partial_image(&image, region, &mut draw_buffer)?;
                         gui.draw(draw_buffer.filled_mut(), region)
                             .context("draw updated region")?;
                         draw_buffer.clear();


### PR DESCRIPTION
- Return a contextual error when the web renderer receives a malformed or out-of-image extraction region, rather than panicking while slicing the framebuffer.
- Propagate extraction failures before drawing while preserving `WriteBuf` reuse, cursor commit behavior, valid output rectangles, and the small-rectangle versus whole-row heuristic.
- Run the regression coverage through the centralized extra testsuite without changing Cargo test flags.

Current graphics producers are expected to supply valid regions, so this is defensive error handling for an invariant violation, not a demonstrated reachable protocol crash or a general panic-freedom guarantee.

This keeps the useful error-propagation direction from #993 and the [review decision](https://github.com/Devolutions/IronRDP/pull/993#issuecomment-5592549297), with thanks to @AlexYusiuk for the original contribution. It deliberately excludes the global `clippy::indexing_slicing` rollout and changes to already-safe canvas pixel indexing or internally-sized destination slices.