### PR TITLE
ci(pr-automation): classify after final review

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -1,7 +1,7 @@
 # Pull request automation
 
 `.github/workflows/labeler.yml` classifies ready, open pull requests and calls `.github/workflows/review-pipeline.yml` for at most two automated reviews.
-Automatic routes stop at `ai-reviewed/2` unless a maintainer uses force mode.
+Automatic review stops at `ai-reviewed/2` unless a maintainer uses force mode; classification keeps running.
 Manual `workflow_dispatch` requests and forced reviews require a successful GitHub Actions-owned `AI classification` check for the current head with valid machine state.
 They fail visibly before any reviewer starts when that prerequisite is missing, stale, or invalid; automatic CI and classification-complete races instead skip normally.
 Model analysis fails closed when the reviewable pull request diff exceeds the applicable evidence limit.

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -233,7 +233,6 @@ test("automatic review requires exact-head CI and only reruns after a later push
   assert.match(reviewGate, /const secondReviewEligible = !labels\.includes\("ai-reviewed\/1"\) \|\| !reviewAtHead/);
   assert.match(reviewGate,
     /ok: classificationCheck && ciGreen && secondReviewEligible && policyEligible/);
-  assert.match(workflowJob(workflow, "classification-gate"), /'ai-reviewed\/2'/);
   assert.match(reviewPipeline, /review-gate\.outputs\.eligible == 'true'/);
   assert.match(reviewPipeline, /needs\.resolve-pr\.outputs\.force == 'true'/);
   const resolvePrJob = workflowJob(workflow, "resolve-pr");
@@ -1439,6 +1438,31 @@ test("successful classification preserves the first-time contributor label", () 
     ["contributor/first-time"]);
 });
 
+test("terminal review count stops only the review pipeline", () => {
+  const workflow = readWorkflow();
+  for (const job of ["classification-gate", "semver", "classifier"]) {
+    assert.equal(workflowJob(workflow, job).includes("ai-reviewed/2"), false);
+  }
+  const deterministic = {
+    ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S",
+    sizeLabels: ["size/S"], firstTime: false,
+  };
+  const state = resolveClassificationState({
+    expectedSha: SHA,
+    labels: ["ai-reviewed/2", "risk/low"],
+    deterministic,
+    classifier: classifier({ risk: "medium" }),
+    semver: { head_sha: SHA, status: "not-suspected" },
+  });
+
+  assert.equal(state.failed, undefined);
+  assert.equal(state.check.title, "Classification complete");
+  assert.deepEqual(state.labelSets.find((set) => set.owned.includes("risk/unknown")).desired,
+    ["risk/medium"]);
+  assert.equal(state.dispatchReview, false);
+  assert.equal(reviewPolicyEligible({ labels: ["ai-reviewed/2", "risk/medium"] }), false);
+});
+
 test("all classified changes are reviewable unless a legitimacy or count gate blocks them", () => {
   assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: true }), true);
   assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: false }), true);
@@ -1624,7 +1648,7 @@ test("forced classification bypasses policy, quota, and cache but still validate
   };
   const args = {
     expectedSha: SHA,
-    labels: ["ai-reviewed/2"],
+    labels: [],
     deterministic,
     classifier: classifier(),
     classificationGate: { available: false, reason: "checks unavailable" },

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -101,13 +101,9 @@ function resolveClassificationState({
   expectedSha, labels, deterministic, classifier, classificationGate,
   classifierReason, changedPaths, duplicateCandidates, prNumber, semver, rateLimit, force,
 } = {}) {
-  const existing = labelsOf(labels);
   const forced = force === true;
   const failureRateLimit = forced ? undefined : rateLimit;
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
-  if (!forced && existing.has("ai-reviewed/2")) {
-    return failedClassification(expectedSha, deterministic, "terminal AI review count", failureRateLimit);
-  }
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
   if (!forced && rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", failureRateLimit, semverStatus);
@@ -182,7 +178,7 @@ function resolveClassificationState({
   ];
   return {
     ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments, auditComments,
-    dispatchReview: !forced,
+    dispatchReview: !forced && !labelsOf(labels).has("ai-reviewed/2"),
     removeCommentMarkers: [
       // A later push can make a previously reported duplicate or oversized verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -67,7 +67,8 @@ Keep detailed failure reasons in the workflow summary only.
 
 Classify every non-draft, human-authored pull request that passes the integrity and capacity gates.
 Run automated review after CI succeeds for the exact classified head.
-Run the second review after a later push reaches green exact-head CI, and stop automatic review at `ai-reviewed/2`.
+Run the second review after a later push reaches green exact-head CI.
+At `ai-reviewed/2`, the review pipeline stops; classification and its labels keep updating.
 
 `OWNER` and `MEMBER` authors are always eligible.
 Other authors need one pull request from the same immutable human author merged into `master`.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -103,9 +103,7 @@ jobs:
     needs: resolve-pr
     if: >-
       needs.resolve-pr.outputs.ok == 'true' &&
-      needs.resolve-pr.outputs.classification-requested == 'true' &&
-      (needs.resolve-pr.outputs.force == 'true' ||
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2'))
+      needs.resolve-pr.outputs.classification-requested == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -249,8 +247,7 @@ jobs:
       needs.resolve-pr.outputs.classification-requested == 'true' &&
       (needs.resolve-pr.outputs.force == 'true' ||
       (needs.classification-gate.outputs.available == 'true' &&
-      needs.classification-gate.outputs.required == 'true' &&
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
+      needs.classification-gate.outputs.required == 'true'))
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -353,8 +350,7 @@ jobs:
       (needs.classification-gate.outputs.available == 'true' &&
       needs.classification-gate.outputs.required == 'true' &&
       needs.fork-rate-limit.result == 'success' &&
-      needs.fork-rate-limit.outputs.allowed == 'true' &&
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
+      needs.fork-rate-limit.outputs.allowed == 'true'))
     runs-on: ubuntu-latest
     concurrency:
       group: llm-classifier-${{ needs.resolve-pr.outputs.classifier-lane }}


### PR DESCRIPTION
Keep classification and label reconciliation active after ai-reviewed/2 while preventing another automated review dispatch.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>