### PR TITLE
ci(pr-automation): delay maintainer handoff

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -551,7 +551,6 @@ test("classification gate reuses completed state but forces oversized retries", 
     available: true, required: true, reason: "",
     externalId: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
     completed: true,
-    largerEvidence: true,
   });
   assert.equal(reads, 2);
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1513,7 +1513,8 @@ test("size/XXL remains informational and does not suppress classification", () =
   const desired = state.labelSets.flatMap((set) => set.desired);
   assert.deepEqual(desired.sort(), ["breaking-change", "contributor/first-time", "risk/high",
     "scope/core", "scope/web", "size/XXL"]);
-  assert.deepEqual(state.addLabels, ["maintainer-required"]);
+  assert.deepEqual(state.addLabels, []);
+  assert.deepEqual(state.removeLabels, ["maintainer-required"]);
   assert.deepEqual(state.comments, []);
   assert.equal(state.check.title, "Classification complete");
   assert.equal(state.check.machineState.automaticReviewEligible, true);
@@ -1535,6 +1536,8 @@ test("a duplicate verdict is withdrawn once it no longer holds", () => {
       : { detected: false, similar_pr_number: null, similar_pr_url: null, confidence: 0, rationale: "" } }),
   });
   const flagged = state(true);
+  assert.deepEqual(flagged.addLabels, ["maintainer-required"]);
+  assert.deepEqual(flagged.removeLabels, []);
   assert.deepEqual(flagged.comments.map((comment) => comment.kind), ["duplicate"]);
   assert.equal(flagged.removeCommentMarkers.includes(DUPLICATE_MARKER), false);
   // Removing only the label would leave a comment contradicting the labels the same run wrote.
@@ -1750,17 +1753,27 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(unavailable.reason, "contributor history unavailable: GitHub API unavailable");
   assert.equal(unavailable.removeCommentMarkers.includes(CONTRIBUTOR_INELIGIBLE_MARKER), false);
 
+  const ciPending = resolveReviewState({
+    ...args, gate: { ...args.gate, ok: false, ciGreen: false },
+  });
+  assert.equal(ciPending.reason, "CI has not succeeded");
+  assert.deepEqual(ciPending.addLabels, []);
+  assert.deepEqual(ciPending.removeLabels, ["maintainer-required"]);
+
   const secondReview = resolveReviewState({
     ...args, labels: ["ai-reviewed/1", "risk/high"],
     gate: { ...args.gate, ok: false, secondReviewEligible: false },
   });
   assert.equal(secondReview.reason, "second review is not eligible");
+  assert.deepEqual(secondReview.addLabels, []);
+  assert.deepEqual(secondReview.removeLabels, []);
 
   const policy = resolveReviewState({
     ...args, labels: ["risk/low", "duplicate"],
     gate: { ...args.gate, policyEligible: false, protocolRelated: false },
   });
   assert.equal(policy.reason, "review is not eligible");
+  assert.deepEqual(policy.addLabels, ["maintainer-required"]);
 });
 
 test("a later eligible review removes the contributor-ineligible comment", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -548,9 +548,12 @@ test("classification gate reuses completed state but forces oversized retries", 
 
   const retry = await resolveClassificationGate({ ...args, retryWithLargerEvidence: true });
   assert.deepEqual(retry, {
-    available: true, required: true, reason: "", largerEvidence: true,
+    available: true, required: true, reason: "",
+    externalId: `${CLASSIFIER_SCHEMA_VERSION}:${SHA}`,
+    completed: true,
+    largerEvidence: true,
   });
-  assert.equal(reads, 1);
+  assert.equal(reads, 2);
 
   const unavailable = await resolveClassificationGate({
     ...args,
@@ -1436,6 +1439,26 @@ test("successful classification preserves the first-time contributor label", () 
   });
   assert.deepEqual(state.labelSets.find((set) => set.owned.includes("contributor/first-time")).desired,
     ["contributor/first-time"]);
+});
+
+test("same-head reclassification preserves an existing maintainer handoff", () => {
+  const deterministic = {
+    ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S",
+    sizeLabels: ["size/S"], firstTime: false,
+  };
+  const classify = (completed) => resolveClassificationState({
+    expectedSha: SHA,
+    labels: ["maintainer-required"],
+    deterministic,
+    classifier: classifier(),
+    classificationGate: { available: true, completed },
+    semver: { head_sha: SHA, status: "not-suspected" },
+  });
+
+  assert.deepEqual(classify(true).addLabels, ["maintainer-required"]);
+  assert.deepEqual(classify(true).removeLabels, []);
+  assert.deepEqual(classify(false).addLabels, []);
+  assert.deepEqual(classify(false).removeLabels, ["maintainer-required"]);
 });
 
 test("terminal review count stops only the review pipeline", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1786,13 +1786,18 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.deepEqual(ciPending.addLabels, []);
   assert.deepEqual(ciPending.removeLabels, ["maintainer-required"]);
 
-  const secondReview = resolveReviewState({
-    ...args, labels: ["ai-reviewed/1", "risk/high"],
-    gate: { ...args.gate, ok: false, secondReviewEligible: false },
-  });
-  assert.equal(secondReview.reason, "second review is not eligible");
-  assert.deepEqual(secondReview.addLabels, []);
-  assert.deepEqual(secondReview.removeLabels, []);
+  for (const labels of [
+    ["ai-reviewed/1", "risk/high"],
+    ["ai-reviewed/1", "risk/high", "maintainer-required"],
+  ]) {
+    const secondReview = resolveReviewState({
+      ...args, labels,
+      gate: { ...args.gate, ok: false, ciGreen: false, secondReviewEligible: false },
+    });
+    assert.equal(secondReview.reason, "second review is not eligible");
+    assert.deepEqual(secondReview.addLabels, []);
+    assert.deepEqual(secondReview.removeLabels, []);
+  }
 
   const policy = resolveReviewState({
     ...args, labels: ["risk/low", "duplicate"],

--- a/.github/pr-automation/classification-gate.js
+++ b/.github/pr-automation/classification-gate.js
@@ -25,7 +25,6 @@ async function resolveClassificationGate({
       reason: "",
       externalId,
       completed,
-      ...(retryWithLargerEvidence ? { largerEvidence: true } : {}),
     };
   } catch (error) {
     return {

--- a/.github/pr-automation/classification-gate.js
+++ b/.github/pr-automation/classification-gate.js
@@ -8,9 +8,6 @@ async function resolveClassificationGate({
   if (force) {
     return { available: true, required: true, reason: "", force: true };
   }
-  if (retryWithLargerEvidence) {
-    return { available: true, required: true, reason: "", largerEvidence: true };
-  }
   try {
     const { data } = await github.rest.checks.listForRef({
       owner, repo, ref: expectedSha, check_name: "AI classification", per_page: 100,
@@ -22,7 +19,14 @@ async function resolveClassificationGate({
         run.app?.slug === "github-actions" && state?.automaticReviewEligible === true &&
         run.output?.title === "Classification complete";
     });
-    return { available: true, required: !completed, reason: "", externalId, completed };
+    return {
+      available: true,
+      required: retryWithLargerEvidence || !completed,
+      reason: "",
+      externalId,
+      completed,
+      ...(retryWithLargerEvidence ? { largerEvidence: true } : {}),
+    };
   } catch (error) {
     return {
       available: false,

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -319,10 +319,10 @@ function resolveReviewState({
         : "contributor history unavailable";
       return fail(reason);
     }
-    if (gate.ciGreen !== true) return fail("CI has not succeeded", false, null, "remove");
     if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) {
       return fail("second review is not eligible", false, null, "preserve");
     }
+    if (gate.ciGreen !== true) return fail("CI has not succeeded", false, null, "remove");
     if (!gate.ok) return fail("review gate unavailable");
   }
   const reviewerResult = validateNormalizedFinalReview(reviewer, expectedSha);

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -161,7 +161,8 @@ function resolveClassificationState({
     { owned: ["breaking-change"], desired: breaking ? ["breaking-change"] : [] },
   ];
   const legitimacyStopped = model.likely_non_legitimate;
-  const maintainerRequired = duplicate || legitimacyStopped || existing.has("ai-reviewed/2");
+  const maintainerRequired = duplicate || legitimacyStopped || existing.has("ai-reviewed/2") ||
+    (existing.has("maintainer-required") && classificationGate?.completed === true);
   const addLabels = [
     ...(maintainerRequired ? ["maintainer-required"] : []),
     ...(legitimacyStopped ? [LEGITIMACY_LABEL] : []),

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -164,10 +164,12 @@ function resolveClassificationState({
     { owned: ["breaking-change"], desired: breaking ? ["breaking-change"] : [] },
   ];
   const legitimacyStopped = model.likely_non_legitimate;
+  const maintainerRequired = duplicate || legitimacyStopped || existing.has("ai-reviewed/2");
   const addLabels = [
-    "maintainer-required",
+    ...(maintainerRequired ? ["maintainer-required"] : []),
     ...(legitimacyStopped ? [LEGITIMACY_LABEL] : []),
   ];
+  const removeLabels = maintainerRequired ? [] : ["maintainer-required"];
   const comments = [
     ...(duplicate ? [{
       kind: "duplicate", marker: DUPLICATE_MARKER,
@@ -181,7 +183,7 @@ function resolveClassificationState({
     }] : []),
   ];
   return {
-    ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments, auditComments,
+    ok: true, mode: "classification", expectedSha, labelSets, addLabels, removeLabels, comments, auditComments,
     dispatchReview: !forced,
     removeCommentMarkers: [
       // A later push can make a previously reported duplicate or oversized verdict wrong, and stale
@@ -258,7 +260,7 @@ function resolveReviewState({
 } = {}) {
   const existing = labelsOf(labels);
   const forced = force === true;
-  const fail = (reason, report = false, contributorComment = null) => {
+  const fail = (reason, report = false, contributorComment = null, labelAction = "add") => {
     const comments = [
       forced ? null : quotaComment(rateLimit),
       evidenceLimitComment(reason),
@@ -266,7 +268,10 @@ function resolveReviewState({
     ].filter(Boolean);
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
-      labelSets: [], addLabels: ["maintainer-required"], comments,
+      labelSets: [],
+      addLabels: labelAction === "add" ? ["maintainer-required"] : [],
+      removeLabels: labelAction === "remove" ? ["maintainer-required"] : [],
+      comments,
       removeCommentMarkers: [
         ...(comments.some((comment) => comment.kind === "evidence-limit") ? [] : [EVIDENCE_LIMIT_MARKER]),
         FORK_QUOTA_MARKER,
@@ -298,7 +303,10 @@ function resolveReviewState({
     }
     const classification = validateReviewGate({ ...gate, ok: true }, expectedSha);
     if (!classification.ok) return fail(classification.reason);
-    if (gate.classificationCheck !== true || gate.ciGreen !== true) return fail("review gate unavailable");
+    if (gate.classificationCheck !== true) return fail("review gate unavailable");
+    if (!reviewPolicyEligible({
+      labels, legitimacyStopped: gate.legitimacyStopped,
+    })) return fail("review is not eligible");
     if (contributor?.status === "ineligible") {
       const reason = Number.isSafeInteger(contributor.merged)
         ? `contributor history ineligible (merged: ${contributor.merged}, required: ${ELIGIBLE_MERGED_PRS})`
@@ -314,12 +322,10 @@ function resolveReviewState({
         : "contributor history unavailable";
       return fail(reason);
     }
+    if (gate.ciGreen !== true) return fail("CI has not succeeded", false, null, "remove");
     if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) {
-      return fail("second review is not eligible");
+      return fail("second review is not eligible", false, null, "preserve");
     }
-    if (!reviewPolicyEligible({
-      labels, legitimacyStopped: gate.legitimacyStopped,
-    })) return fail("review is not eligible");
     if (!gate.ok) return fail("review gate unavailable");
   }
   const reviewerResult = validateNormalizedFinalReview(reviewer, expectedSha);

--- a/.github/workflows/labeler.intent.md
+++ b/.github/workflows/labeler.intent.md
@@ -69,6 +69,10 @@ Classify every non-draft, human-authored pull request that passes the integrity 
 Run automated review after CI succeeds for the exact classified head.
 Run the second review after a later push reaches green exact-head CI, and stop automatic review at `ai-reviewed/2`.
 
+Use `maintainer-required` only when maintainer action is the next step.
+On the normal review path, apply it only after exact-head CI succeeds and an automated review reports no findings or reaches `ai-reviewed/2`.
+Apply it earlier only when automation stops and needs maintainer intervention.
+
 `OWNER` and `MEMBER` authors are always eligible.
 Other authors need one pull request from the same immutable human author merged into `master`.
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -111,6 +111,7 @@ jobs:
     outputs:
       required: ${{ steps.gate.outputs.required }}
       available: ${{ steps.gate.outputs.available }}
+      completed: ${{ steps.gate.outputs.completed }}
       reason: ${{ steps.gate.outputs.reason }}
     steps:
       - uses: actions/checkout@v6
@@ -137,6 +138,7 @@ jobs:
             });
             core.setOutput("required", decision.required);
             core.setOutput("available", decision.available);
+            core.setOutput("completed", decision.completed === true);
             core.setOutput("reason", decision.reason);
             if (decision.error) core.warning(`Classification gate unavailable: ${decision.error}`);
             core.info(JSON.stringify({
@@ -467,6 +469,7 @@ jobs:
           CLASSIFIER_REASON: ${{ needs.classifier.outputs.failure-reason }}
           DUPLICATE_CANDIDATES: ${{ needs.classifier.outputs.duplicate-candidates }}
           CLASSIFICATION_GATE_AVAILABLE: ${{ needs.classification-gate.outputs.available }}
+          CLASSIFICATION_GATE_COMPLETED: ${{ needs.classification-gate.outputs.completed }}
           CLASSIFICATION_GATE_REASON: ${{ needs.classification-gate.outputs.reason }}
           FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
           SEMVER: ${{ needs.semver.outputs.compatibility }}
@@ -485,6 +488,7 @@ jobs:
               duplicateCandidates: parse(process.env.DUPLICATE_CANDIDATES, []),
               classificationGate: {
                 available: process.env.CLASSIFICATION_GATE_AVAILABLE === "true",
+                completed: process.env.CLASSIFICATION_GATE_COMPLETED === "true",
                 reason: process.env.CLASSIFICATION_GATE_REASON || "",
               },
               rateLimit: parse(process.env.FORK_RATE_LIMIT, {}),


### PR DESCRIPTION
Reserve maintainer-required for points where maintainer action is next.

Clear stale handoff state during classification and non-green CI, then restore it after clean or final reviews and when automation stops.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>