### PR TITLE
feat: add headless corpus replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
   success:
     name: Success
     if: ${{ always() }}
-    needs: [formatting, test-settings, typos, openai-agent, checks, fuzz, web, ffi, feature-matrix-setup, feature-matrix]
+    needs: [formatting, test-settings, typos, openai-agent, checks, fuzz, corpus-replay, web, ffi, feature-matrix-setup, feature-matrix]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,32 @@ jobs:
       - name: Lock files
         run: cargo xtask check locks -v
 
+  corpus-replay:
+    name: Corpus replay
+    needs: [formatting]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: Corpus cache
+        uses: actions/cache@v5
+        with:
+          path: ./dependencies/wireshark-rdp
+          key: ${{ runner.os }}-benchmark-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
+
+      - name: Fetch corpus
+        run: cargo xtask bench corpus-fetch
+
+      - name: Replay corpus
+        run: cargo xtask bench replay
+
   web:
     name: Web Client
     needs: [formatting]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,8 @@ jobs:
         with:
           path: ./bench-data/wireshark-rdp
           key: ${{ runner.os }}-benchmark-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-benchmark-corpus-
 
       - name: Fetch corpus
         run: cargo xtask bench corpus-fetch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Corpus cache
         uses: actions/cache@v5
         with:
-          path: ./dependencies/wireshark-rdp
+          path: ./bench-data/wireshark-rdp
           key: ${{ runner.os }}-benchmark-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
 
       - name: Fetch corpus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,6 @@ jobs:
         with:
           path: ./bench-data/wireshark-rdp
           key: ${{ runner.os }}-benchmark-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-benchmark-corpus-
 
       - name: Fetch corpus
         run: cargo xtask bench corpus-fetch

--- a/crates/ironrdp-bench/corpus.toml
+++ b/crates/ironrdp-bench/corpus.toml
@@ -7,159 +7,186 @@ id = "clipboard-various-formats"
 file = "rdp-clipboard-various-formats1.pcapng"
 sha256 = "537058172eade338c4bdadf4fdbdd80c839a8370c643c7a51ea2b976b7778d73"
 intent = "Clipboard redirection with text, images, rich text, and file copy formats."
+expect = { outcome = "partial", summary = { client_pdus = 341, server_pdus = 12427, connection_pdus = 12427, client_observation_pdus = 341, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 1940736, truncated_pdu_gaps = 12768, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 12768, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "credential-guard-accepted"
 file = "rdp-credential-guard-accepted1.pcapng"
 sha256 = "3196565f3b31d3c13ebb595fca662a96c1d2e9c21e29902a5eb190c0e05005c4"
 intent = "RDP with NLA and Remote Credential Guard accepted by the server."
+expect = { outcome = "partial", summary = { client_pdus = 98, server_pdus = 202, connection_pdus = 202, client_observation_pdus = 98, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 60300, truncated_pdu_gaps = 300, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 300, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "credential-guard-rejected"
 file = "rdp-credential-guard-rejected1.pcapng"
 sha256 = "80552836675c68bddc15b2a2cc9782c51a6a467039108bc75d1a76172766f975"
 intent = "RDP with NLA and Remote Credential Guard rejected by the server."
+expect = { outcome = "partial", summary = { client_pdus = 55, server_pdus = 71, connection_pdus = 71, client_observation_pdus = 55, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12726, truncated_pdu_gaps = 252, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 126, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "nla-kerberos-password-1"
 file = "rdp-nla-kerberos-auth1.pcapng"
 sha256 = "2d6cb5c030acd849d6104a7c640a2769a7351168465d098cc64b7d098b16c03f"
 intent = "RDP NLA with Kerberos password authentication using a UPN."
+expect = { outcome = "partial", summary = { client_pdus = 40, server_pdus = 86, connection_pdus = 86, client_observation_pdus = 40, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12726, truncated_pdu_gaps = 252, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 126, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "nla-kerberos-password-2"
 file = "rdp-nla-kerberos-auth2.pcapng"
 sha256 = "403ee5c14066fddba95e24f7931629ec9ad3ae96d9f3a8837843d6851cb857f8"
 intent = "RDP NLA with Kerberos password authentication using a domain account."
+expect = { outcome = "partial", summary = { client_pdus = 25, server_pdus = 75, connection_pdus = 75, client_observation_pdus = 25, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 7300, truncated_pdu_gaps = 200, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 100, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "nla-ntlm-rejected-ip"
 file = "rdp-nla-ntlm-rejected1.pcapng"
 sha256 = "8fcc046baf9b6c4962a9b3a49ad1554b55760da4364e80fb63339a1a74f22134"
 intent = "RDP NLA with NTLM rejected after connecting by IP address."
+expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "nla-ntlm-rejected-after-kerberos"
 file = "rdp-nla-ntlm-rejected2.pcapng"
 sha256 = "cd7cb64e7d7dd71a3227d3b3d27a6de4d59e65fa01ad97fe6cacc0015867815f"
 intent = "RDP NLA Kerberos password attempt followed by a rejected NTLM downgrade."
+expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "nla-kerberos-smartcard-1"
 file = "rdp-nla-smartcard-auth1.pcapng"
 sha256 = "34ceff904e52e2964c2f100a90d726fc45a5f29ab7d90e535a6807959ea34f18"
 intent = "RDP NLA with Kerberos smartcard authentication."
+expect = { outcome = "partial", summary = { client_pdus = 654, server_pdus = 94, connection_pdus = 94, client_observation_pdus = 654, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 56848, truncated_pdu_gaps = 748, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 748, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "nla-kerberos-smartcard-2"
 file = "rdp-nla-smartcard-auth2.pcapng"
 sha256 = "cfc4d559b62a0e31e45cf771a28dc72a3473cc7061e5e157241fedb17b1e36ff"
 intent = "RDP NLA with Kerberos smartcard authentication for a protected user."
+expect = { outcome = "partial", summary = { client_pdus = 503, server_pdus = 129, connection_pdus = 129, client_observation_pdus = 503, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 71416, truncated_pdu_gaps = 632, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 632, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "no-nla-accepted"
 file = "rdp-no-nla-accepted1.pcapng"
 sha256 = "1146ef447ad88e58f25d14adf81581233c8265bf49140fa6f7a172fd30f3c402"
 intent = "RDP without NLA accepted by the server."
+expect = { outcome = "partial", summary = { client_pdus = 666, server_pdus = 740, connection_pdus = 15, client_observation_pdus = 666, fast_path_pdus = 20, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 662, other_server_message_pdus = 1, graphics_updates = 78, final_dimensions = "1024x768", fingerprint = "5f280762f289c4420327a0b8b6e302ccfc3a40465a2eed9bf2dc2fa833ec7b19", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 11248, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "no-nla-rejected"
 file = "rdp-no-nla-rejected1.pcapng"
 sha256 = "d4be2c78e635a60f17a89d3cedd15bbd4e6420247feffedf399429e038fafea5"
 intent = "RDP without NLA rejected by the server."
+expect = { outcome = "unsupported", stage = "decrypt", reason = "standard-security" }
 
 [[capture]]
 id = "no-nla-smartcard"
 file = "rdp-no-nla-smartcard-auth1.pcapng"
 sha256 = "b29eedb9e81ed6fab7e0730951880e78fc60c3d64bfb6b37e4fa604ea3a30ff2"
 intent = "RDP without NLA using smartcard authentication."
+expect = { outcome = "partial", summary = { client_pdus = 903, server_pdus = 934, connection_pdus = 15, client_observation_pdus = 903, fast_path_pdus = 12, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 864, other_server_message_pdus = 1, graphics_updates = 79, final_dimensions = "1024x768", fingerprint = "51069cfd256a082e8bf9aa9d159ebc1c1d82c5f0bf7991f07d61bfa09eb81426", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 14696, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "no-tls-accepted"
 file = "rdp-no-tls-accepted1.pcapng"
 sha256 = "c13b629a67ed0b9503f5810baca605a305b7aa88192b9feec5315a4ae4d98b13"
 intent = "RDP without NLA or TLS accepted by the server."
+expect = { outcome = "unsupported", stage = "decrypt", reason = "standard-security" }
 
 [[capture]]
 id = "gateway-different-credentials-password"
 file = "rdp-rdg-diff-creds-kerberos-password.pcapng"
 sha256 = "9f4764bb1a095f4601475b879ae4aa27cd770b06f73153e74243a62cef26e4a3"
 intent = "RD Gateway and RDP server with different Kerberos password credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-different-credentials-smartcard"
 file = "rdp-rdg-diff-creds-kerberos-smartcard.pcapng"
 sha256 = "eeebb5343f4140887c7ca1c04153c031ed3c37a85e288d5829e0bb18cbd77611"
 intent = "RD Gateway and RDP server with different Kerberos smartcard credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-no-kdc-proxy-ntlm-downgrade-failure"
 file = "rdp-rdg-no-kdc-proxy-ntlm-downgrade-failure.pcapng"
 sha256 = "e8ef972799f437e6742430c155ae7dadb734afe671227433e7069a2f4761a6fc"
 intent = "RD Gateway without KDC proxy where NTLM downgrade fails."
+expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "gateway-no-kdc-proxy-ntlm-downgrade-success"
 file = "rdp-rdg-no-kdc-proxy-ntlm-downgrade-success.pcapng"
 sha256 = "5973f58fdb05f1ab952119b2fac38ec3b18cd001d069309f72c76ab1fd3cd8dc"
 intent = "RD Gateway without KDC proxy where NTLM downgrade succeeds."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-kdc-proxy-password-1"
 file = "rdp-rdg-same-creds-kerberos-password-success1.pcapng"
 sha256 = "470ae7d40db4070d82bc5b98e314746f7344ff690895b6808d51cba77a0daa0f"
 intent = "RD Gateway KDC proxy with shared Kerberos password credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-kdc-line-of-sight-password-2"
 file = "rdp-rdg-same-creds-kerberos-password-success2.pcapng"
 sha256 = "dac06102cb606c6a349c73b1c8fa1e1bc7e25f8829b120f9bcdda24f1387160d"
 intent = "RD Gateway KDC line-of-sight with shared Kerberos password credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-kdc-proxy-smartcard-1"
 file = "rdp-rdg-same-creds-kerberos-smartcard-success1.pcapng"
 sha256 = "213a84ab2750f0d0e6b4f532b2c0d1146688897df34d3c51748c0b7c27d1ab1e"
 intent = "RD Gateway KDC proxy with shared Kerberos smartcard credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "gateway-kdc-line-of-sight-smartcard-2"
 file = "rdp-rdg-same-creds-kerberos-smartcard-success2.pcapng"
 sha256 = "506975b387e2db499aab2a780cf1859447bb6d914703cda0915c9721671628e0"
 intent = "RD Gateway KDC line-of-sight with shared Kerberos smartcard credentials."
+expect = { outcome = "unsupported", stage = "gateway", reason = "missing-tunneled-tls-secret" }
 
 [[capture]]
 id = "restricted-admin-accepted"
 file = "rdp-restricted-admin-accepted1.pcapng"
 sha256 = "ac66138a736535e1a2955459154bd837815ad40dfcb1d2b18e8a93a6dadd6355"
 intent = "RDP with NLA and Restricted Admin Mode accepted by the server."
+expect = { outcome = "partial", summary = { client_pdus = 19, server_pdus = 244, connection_pdus = 244, client_observation_pdus = 19, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12361, truncated_pdu_gaps = 263, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 263, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "restricted-admin-rejected"
 file = "rdp-restricted-admin-rejected1.pcapng"
 sha256 = "f05a42387cc3fb9a971abfd30ec52d2b9c173120a6407b6e1b1431c13a7e5ffb"
 intent = "RDP with NLA and Restricted Admin Mode rejected by the server."
+expect = { outcome = "partial", summary = { client_pdus = 10, server_pdus = 10, connection_pdus = 10, client_observation_pdus = 10, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 260, truncated_pdu_gaps = 40, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 20, unsupported_gaps = 0 } }
 
 [[capture]]
 id = "vmconnect-local-basic"
 file = "rdp-vmconnect-local-basic-session-mode1.pcapng"
 sha256 = "395fd31e78c94f99d9d6920529fa89262557bb49ed3f8f5d9924bb6568ecff08"
 intent = "Local Hyper-V VMConnect using implicit credentials in basic session mode."
+expect = { outcome = "unsupported", stage = "read", reason = "unsupported-transport" }
 
 [[capture]]
 id = "vmconnect-local-enhanced"
 file = "rdp-vmconnect-local-enhanced-session-mode1.pcapng"
 sha256 = "14dc3e445051985c257a1ef78852ce3cc9e79df3f7e9ea066af08a3a2f193f6f"
 intent = "Local Hyper-V VMConnect using implicit credentials in enhanced session mode."
+expect = { outcome = "unsupported", stage = "read", reason = "unsupported-transport" }
 
 [[capture]]
 id = "vmconnect-remote-basic"
 file = "rdp-vmconnect-remote-basic-session-mode1.pcapng"
 sha256 = "3283d92ab7c95070fbc14d41975909c8853eb6b2ef5568078311f0ceb6532606"
 intent = "Remote Hyper-V VMConnect using explicit credentials in basic session mode."
+expect = { outcome = "unsupported", stage = "read", reason = "unsupported-transport" }
 
 [[capture]]
 id = "vmconnect-remote-enhanced"
 file = "rdp-vmconnect-remote-enhanced-session-mode1.pcapng"
 sha256 = "e011364124486dcbb106389b781b11d4dbfdcac1e01680fe7a1d6223b8749371"
 intent = "Remote Hyper-V VMConnect using explicit credentials in enhanced session mode."
+expect = { outcome = "unsupported", stage = "read", reason = "unsupported-transport" }

--- a/crates/ironrdp-bench/corpus.toml
+++ b/crates/ironrdp-bench/corpus.toml
@@ -7,70 +7,70 @@ id = "clipboard-various-formats"
 file = "rdp-clipboard-various-formats1.pcapng"
 sha256 = "537058172eade338c4bdadf4fdbdd80c839a8370c643c7a51ea2b976b7778d73"
 intent = "Clipboard redirection with text, images, rich text, and file copy formats."
-expect = { outcome = "partial", summary = { client_pdus = 341, server_pdus = 12427, connection_pdus = 12427, client_observation_pdus = 341, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 1940736, truncated_pdu_gaps = 12768, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 12768, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 341, server_pdus = 12427, connection_pdus = 12427, client_observation_pdus = 341, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 152, truncated_pdu_gaps = 1, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "9356ccd8046a07ee5041ca577dff2ad1a0950eae0e7b3c8dff7001754d1bcae4" } }
 
 [[capture]]
 id = "credential-guard-accepted"
 file = "rdp-credential-guard-accepted1.pcapng"
 sha256 = "3196565f3b31d3c13ebb595fca662a96c1d2e9c21e29902a5eb190c0e05005c4"
 intent = "RDP with NLA and Remote Credential Guard accepted by the server."
-expect = { outcome = "partial", summary = { client_pdus = 98, server_pdus = 202, connection_pdus = 202, client_observation_pdus = 98, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 60300, truncated_pdu_gaps = 300, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 300, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 98, server_pdus = 202, connection_pdus = 202, client_observation_pdus = 98, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 201, truncated_pdu_gaps = 1, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "009356054d8c678e4df400e41f9205a57488af08a37f77a76ade0406586519d4" } }
 
 [[capture]]
 id = "credential-guard-rejected"
 file = "rdp-credential-guard-rejected1.pcapng"
 sha256 = "80552836675c68bddc15b2a2cc9782c51a6a467039108bc75d1a76172766f975"
 intent = "RDP with NLA and Remote Credential Guard rejected by the server."
-expect = { outcome = "partial", summary = { client_pdus = 55, server_pdus = 71, connection_pdus = 71, client_observation_pdus = 55, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12726, truncated_pdu_gaps = 252, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 126, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 55, server_pdus = 71, connection_pdus = 71, client_observation_pdus = 55, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 101, truncated_pdu_gaps = 2, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "054153597b81deeaa40efcd918ede674cfaea5ec0956f9d89f7348311870c69f" } }
 
 [[capture]]
 id = "nla-kerberos-password-1"
 file = "rdp-nla-kerberos-auth1.pcapng"
 sha256 = "2d6cb5c030acd849d6104a7c640a2769a7351168465d098cc64b7d098b16c03f"
 intent = "RDP NLA with Kerberos password authentication using a UPN."
-expect = { outcome = "partial", summary = { client_pdus = 40, server_pdus = 86, connection_pdus = 86, client_observation_pdus = 40, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12726, truncated_pdu_gaps = 252, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 126, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 40, server_pdus = 86, connection_pdus = 86, client_observation_pdus = 40, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 101, truncated_pdu_gaps = 2, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "8657169e8c5c17f97af5aa3ead8a0e4a5fe5dd98fa6d8dccbd0c6b973dd6d616" } }
 
 [[capture]]
 id = "nla-kerberos-password-2"
 file = "rdp-nla-kerberos-auth2.pcapng"
 sha256 = "403ee5c14066fddba95e24f7931629ec9ad3ae96d9f3a8837843d6851cb857f8"
 intent = "RDP NLA with Kerberos password authentication using a domain account."
-expect = { outcome = "partial", summary = { client_pdus = 25, server_pdus = 75, connection_pdus = 75, client_observation_pdus = 25, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 7300, truncated_pdu_gaps = 200, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 100, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 25, server_pdus = 75, connection_pdus = 75, client_observation_pdus = 25, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 73, truncated_pdu_gaps = 2, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "00ddf421bddff96f800e879807774a4caa31020fa42e7dbd63bd09feac46fe2b" } }
 
 [[capture]]
 id = "nla-ntlm-rejected-ip"
 file = "rdp-nla-ntlm-rejected1.pcapng"
 sha256 = "8fcc046baf9b6c4962a9b3a49ad1554b55760da4364e80fb63339a1a74f22134"
 intent = "RDP NLA with NTLM rejected after connecting by IP address."
-expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
+expect = { outcome = "unsupported", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "nla-ntlm-rejected-after-kerberos"
 file = "rdp-nla-ntlm-rejected2.pcapng"
 sha256 = "cd7cb64e7d7dd71a3227d3b3d27a6de4d59e65fa01ad97fe6cacc0015867815f"
 intent = "RDP NLA Kerberos password attempt followed by a rejected NTLM downgrade."
-expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
+expect = { outcome = "unsupported", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "nla-kerberos-smartcard-1"
 file = "rdp-nla-smartcard-auth1.pcapng"
 sha256 = "34ceff904e52e2964c2f100a90d726fc45a5f29ab7d90e535a6807959ea34f18"
 intent = "RDP NLA with Kerberos smartcard authentication."
-expect = { outcome = "partial", summary = { client_pdus = 654, server_pdus = 94, connection_pdus = 94, client_observation_pdus = 654, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 56848, truncated_pdu_gaps = 748, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 748, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 654, server_pdus = 94, connection_pdus = 94, client_observation_pdus = 654, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 76, truncated_pdu_gaps = 1, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "a37c653ea033e90e34a35732a9f3e20dcd0e72c9b71369f033cd5b8401c0cd6a" } }
 
 [[capture]]
 id = "nla-kerberos-smartcard-2"
 file = "rdp-nla-smartcard-auth2.pcapng"
 sha256 = "cfc4d559b62a0e31e45cf771a28dc72a3473cc7061e5e157241fedb17b1e36ff"
 intent = "RDP NLA with Kerberos smartcard authentication for a protected user."
-expect = { outcome = "partial", summary = { client_pdus = 503, server_pdus = 129, connection_pdus = 129, client_observation_pdus = 503, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 71416, truncated_pdu_gaps = 632, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 632, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 503, server_pdus = 129, connection_pdus = 129, client_observation_pdus = 503, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 113, truncated_pdu_gaps = 1, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "b39b02b19c834f444473c3fb4ac13e1db1c1697bc2f17eb902546335b208901c" } }
 
 [[capture]]
 id = "no-nla-accepted"
 file = "rdp-no-nla-accepted1.pcapng"
 sha256 = "1146ef447ad88e58f25d14adf81581233c8265bf49140fa6f7a172fd30f3c402"
 intent = "RDP without NLA accepted by the server."
-expect = { outcome = "partial", summary = { client_pdus = 666, server_pdus = 740, connection_pdus = 15, client_observation_pdus = 666, fast_path_pdus = 20, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 662, other_server_message_pdus = 1, graphics_updates = 78, final_dimensions = "1024x768", fingerprint = "5f280762f289c4420327a0b8b6e302ccfc3a40465a2eed9bf2dc2fa833ec7b19", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 11248, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 666, server_pdus = 740, connection_pdus = 15, client_observation_pdus = 666, fast_path_pdus = 20, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 662, other_server_message_pdus = 1, graphics_updates = 78, final_dimensions = "1024x768", fingerprint = "5f280762f289c4420327a0b8b6e302ccfc3a40465a2eed9bf2dc2fa833ec7b19", lifecycle = "active", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 8, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0, gap_fingerprint = "4b8da452635699c6de2820276840579b4f05cf92f9f636c707737312456934f1" } }
 
 [[capture]]
 id = "no-nla-rejected"
@@ -84,7 +84,7 @@ id = "no-nla-smartcard"
 file = "rdp-no-nla-smartcard-auth1.pcapng"
 sha256 = "b29eedb9e81ed6fab7e0730951880e78fc60c3d64bfb6b37e4fa604ea3a30ff2"
 intent = "RDP without NLA using smartcard authentication."
-expect = { outcome = "partial", summary = { client_pdus = 903, server_pdus = 934, connection_pdus = 15, client_observation_pdus = 903, fast_path_pdus = 12, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 864, other_server_message_pdus = 1, graphics_updates = 79, final_dimensions = "1024x768", fingerprint = "51069cfd256a082e8bf9aa9d159ebc1c1d82c5f0bf7991f07d61bfa09eb81426", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 14696, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 903, server_pdus = 934, connection_pdus = 15, client_observation_pdus = 903, fast_path_pdus = 12, io_channel_pdus = 4, message_channel_pdus = 38, static_channel_pdus = 864, other_server_message_pdus = 1, graphics_updates = 79, final_dimensions = "1024x768", fingerprint = "51069cfd256a082e8bf9aa9d159ebc1c1d82c5f0bf7991f07d61bfa09eb81426", lifecycle = "active", framing_gaps = 0, truncated_pdu_gaps = 0, static_channel_gaps = 8, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 0, unsupported_gaps = 0, gap_fingerprint = "1c6187ca6547aa904e0e752f5122a592f9eca8b68d2aa4315076536a7039a7ec" } }
 
 [[capture]]
 id = "no-tls-accepted"
@@ -112,7 +112,7 @@ id = "gateway-no-kdc-proxy-ntlm-downgrade-failure"
 file = "rdp-rdg-no-kdc-proxy-ntlm-downgrade-failure.pcapng"
 sha256 = "e8ef972799f437e6742430c155ae7dadb734afe671227433e7069a2f4761a6fc"
 intent = "RD Gateway without KDC proxy where NTLM downgrade fails."
-expect = { outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }
+expect = { outcome = "unsupported", stage = "negotiate", reason = "missing-rdp-state" }
 
 [[capture]]
 id = "gateway-no-kdc-proxy-ntlm-downgrade-success"
@@ -154,14 +154,14 @@ id = "restricted-admin-accepted"
 file = "rdp-restricted-admin-accepted1.pcapng"
 sha256 = "ac66138a736535e1a2955459154bd837815ad40dfcb1d2b18e8a93a6dadd6355"
 intent = "RDP with NLA and Restricted Admin Mode accepted by the server."
-expect = { outcome = "partial", summary = { client_pdus = 19, server_pdus = 244, connection_pdus = 244, client_observation_pdus = 19, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 12361, truncated_pdu_gaps = 263, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 263, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 19, server_pdus = 244, connection_pdus = 244, client_observation_pdus = 19, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 47, truncated_pdu_gaps = 1, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "e2c867999540dae9199681db6dccfa2b98285561c6a766986fc32daada6130a1" } }
 
 [[capture]]
 id = "restricted-admin-rejected"
 file = "rdp-restricted-admin-rejected1.pcapng"
 sha256 = "f05a42387cc3fb9a971abfd30ec52d2b9c173120a6407b6e1b1431c13a7e5ffb"
 intent = "RDP with NLA and Restricted Admin Mode rejected by the server."
-expect = { outcome = "partial", summary = { client_pdus = 10, server_pdus = 10, connection_pdus = 10, client_observation_pdus = 10, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", framing_gaps = 260, truncated_pdu_gaps = 40, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 20, unsupported_gaps = 0 } }
+expect = { outcome = "partial", summary = { client_pdus = 10, server_pdus = 10, connection_pdus = 10, client_observation_pdus = 10, fast_path_pdus = 0, io_channel_pdus = 0, message_channel_pdus = 0, static_channel_pdus = 0, other_server_message_pdus = 0, graphics_updates = 0, final_dimensions = "-", fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", lifecycle = "never-activated", framing_gaps = 13, truncated_pdu_gaps = 2, static_channel_gaps = 0, dynamic_channel_gaps = 0, session_gaps = 0, incomplete_activation_gaps = 1, unsupported_gaps = 0, gap_fingerprint = "4adf2896039f8febc1b61997f29ab289ad889f8514f31476aedbe1cbfbe5d8b9" } }
 
 [[capture]]
 id = "vmconnect-local-basic"

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -11,6 +11,18 @@ Full TLS 1.2 and TLS 1.3 captures, including resumed sessions, are supported for
 TLS 1.2 requires `CLIENT_RANDOM`, while TLS 1.3 requires `CLIENT_HANDSHAKE_TRAFFIC_SECRET`, `SERVER_HANDSHAKE_TRAFFIC_SECRET`, `CLIENT_TRAFFIC_SECRET_0`, and `SERVER_TRAFFIC_SECRET_0`.
 Mid-stream TLS captures without a ClientHello and ServerHello remain unsupported.
 
+## Headless replay
+
+Use `--summary` to perform headless passive replay without writing files:
+
+```shell
+cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- --summary capture.pcapng
+```
+
+The summary reports only stable routing counters, framebuffer dimensions, an optional output fingerprint, and categorized gaps.
+`prepare_capture` separates capture ingestion, decryption, and negotiation recovery from `PreparedReplay::replay`, which starts with fresh session state on every execution.
+Framebuffers are observed by reference during headless replay, so summaries do not allocate snapshots unless an output consumer explicitly does so.
+
 ## Exporting frames
 
 Run the CLI with a pcapng capture that contains the TLS key-log material required by the replay pipeline.

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -20,7 +20,8 @@ cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- --summary ca
 ```
 
 The summary reports only stable routing counters, framebuffer dimensions, an optional output fingerprint, and categorized gaps.
-`prepare_capture` separates capture ingestion, decryption, and negotiation recovery from `PreparedReplay::replay`, which starts with fresh session state on every execution.
+Pass `--gaps` to print at most 16 payload-free gap locations and reason codes.
+`read_capture` performs capture ingestion, while `prepare_capture` separates decryption and negotiation recovery from `PreparedReplay::replay`, which starts with fresh session state on every execution.
 Framebuffers are observed by reference during headless replay, so summaries do not allocate snapshots unless an output consumer explicitly does so.
 
 ## Exporting frames

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -15,7 +15,10 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use ironrdp_capture_replay::{ExportOptions, ReplayOptions, export_capture, prepare_capture, read_capture};
+use ironrdp_capture_replay::{
+    ExportOptions, ReplayDirection, ReplayGap, ReplayGapKind, ReplayGapReason, ReplayLifecycle, ReplayOptions,
+    export_capture, prepare_capture, read_capture,
+};
 use zeroize::Zeroize as _;
 
 fn main() -> ExitCode {
@@ -41,7 +44,13 @@ fn run() -> Result<(), Box<dyn core::error::Error>> {
     let arguments = parse_arguments(std::env::args_os().skip(1)).map_err(usage_error)?;
     let mut capture = match read_capture(&arguments.capture) {
         Ok(capture) => capture,
-        Err(error) if arguments.summary => return print_summary_error(error),
+        Err(error @ (ironrdp_capture_replay::ReplayError::Io(_) | ironrdp_capture_replay::ReplayError::Pcap(_))) => {
+            return Err(error.into());
+        }
+        Err(error) if arguments.summary => {
+            print_summary_error(error);
+            return Ok(());
+        }
         Err(error) => return Err(error.into()),
     };
     if let Some(key_log) = &arguments.key_log {
@@ -58,9 +67,15 @@ fn run() -> Result<(), Box<dyn core::error::Error>> {
         }) {
             Ok(execution) => {
                 print_summary(&execution.summary);
+                if arguments.show_gaps {
+                    print_gaps(&execution.report.gaps);
+                }
                 Ok(())
             }
-            Err(error) => print_summary_error(error),
+            Err(error) => {
+                print_summary_error(error);
+                Ok(())
+            }
         };
     }
     let summary = export_capture(
@@ -85,11 +100,13 @@ struct Arguments {
     key_log: Option<PathBuf>,
     replace: bool,
     summary: bool,
+    show_gaps: bool,
 }
 
 fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Arguments, String> {
     let mut replace = false;
     let mut summary = false;
+    let mut show_gaps = false;
     let mut key_log = None;
     let mut paths = Vec::new();
     let mut arguments = arguments.peekable();
@@ -98,6 +115,8 @@ fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Argument
             replace = true;
         } else if argument == "--summary" {
             summary = true;
+        } else if argument == "--gaps" {
+            show_gaps = true;
         } else if argument == "--keylog" {
             key_log = Some(PathBuf::from(arguments.next().ok_or_else(usage)?));
         } else if argument.to_string_lossy().starts_with('-') {
@@ -120,17 +139,17 @@ fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Argument
         key_log,
         replace,
         summary,
+        show_gaps,
     })
 }
 
 fn usage() -> String {
-    "usage: ironrdp-capture-replay [--replace] [--keylog <tls-keys.log>] <capture.pcapng> <output-directory>\n       ironrdp-capture-replay --summary [--keylog <tls-keys.log>] <capture.pcapng>".to_owned()
+    "usage: ironrdp-capture-replay [--replace] [--keylog <tls-keys.log>] <capture.pcapng> <output-directory>\n       ironrdp-capture-replay --summary [--gaps] [--keylog <tls-keys.log>] <capture.pcapng>".to_owned()
 }
 
-fn print_summary_error(error: ironrdp_capture_replay::ReplayError) -> Result<(), Box<dyn core::error::Error>> {
+fn print_summary_error(error: ironrdp_capture_replay::ReplayError) {
     let (stage, reason) = error.summary_code();
     println!("status=error\tstage={stage}\treason={reason}");
-    Ok(())
 }
 
 fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
@@ -141,8 +160,13 @@ fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
         || "-".to_owned(),
         |bytes| bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
     );
+    let gap_fingerprint = summary
+        .gap_fingerprint
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
     println!(
-        "status=ok\tclient-pdus={}\tserver-pdus={}\tconnection-pdus={}\tclient-observation-pdus={}\tfast-path-pdus={}\tio-channel-pdus={}\tmessage-channel-pdus={}\tstatic-channel-pdus={}\tother-server-message-pdus={}\tgraphics-updates={}\tfinal-dimensions={dimensions}\tfingerprint={fingerprint}\tframing-gaps={}\ttruncated-pdu-gaps={}\tstatic-channel-gaps={}\tdynamic-channel-gaps={}\tsession-gaps={}\tincomplete-activation-gaps={}\tunsupported-gaps={}",
+        "status=ok\tclient-pdus={}\tserver-pdus={}\tconnection-pdus={}\tclient-observation-pdus={}\tfast-path-pdus={}\tio-channel-pdus={}\tmessage-channel-pdus={}\tstatic-channel-pdus={}\tother-server-message-pdus={}\tgraphics-updates={}\tfinal-dimensions={dimensions}\tfingerprint={fingerprint}\tlifecycle={}\tframing-gaps={}\ttruncated-pdu-gaps={}\tstatic-channel-gaps={}\tdynamic-channel-gaps={}\tsession-gaps={}\tincomplete-activation-gaps={}\tunsupported-gaps={}\tgap-fingerprint={gap_fingerprint}",
         summary.client_pdus,
         summary.server_pdus,
         summary.connection_pdus,
@@ -153,6 +177,7 @@ fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
         summary.static_channel_pdus,
         summary.other_server_message_pdus,
         summary.graphics_updates,
+        lifecycle_name(summary.lifecycle),
         summary.framing_gaps,
         summary.truncated_pdu_gaps,
         summary.static_channel_gaps,
@@ -161,4 +186,67 @@ fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
         summary.incomplete_activation_gaps,
         summary.unsupported_gaps,
     );
+}
+
+fn lifecycle_name(lifecycle: ReplayLifecycle) -> &'static str {
+    match lifecycle {
+        ReplayLifecycle::NeverActivated => "never-activated",
+        ReplayLifecycle::Active => "active",
+        ReplayLifecycle::Deactivated => "deactivated",
+    }
+}
+
+fn print_gaps(gaps: &[ReplayGap]) {
+    const MAX_GAP_DETAILS: usize = 16;
+
+    for gap in gaps.iter().take(MAX_GAP_DETAILS) {
+        println!(
+            "gap=packet:{}\tdirection:{}\tkind:{}\treason:{}\tskipped-bytes:{}",
+            gap.packet,
+            direction_name(gap.direction),
+            gap_kind_name(gap.kind),
+            gap_reason_name(gap.reason),
+            gap.skipped_bytes,
+        );
+    }
+    if gaps.len() > MAX_GAP_DETAILS {
+        println!("gap-details-truncated={}", gaps.len() - MAX_GAP_DETAILS);
+    }
+}
+
+fn direction_name(direction: ReplayDirection) -> &'static str {
+    match direction {
+        ReplayDirection::Client => "client",
+        ReplayDirection::Server => "server",
+    }
+}
+
+fn gap_kind_name(kind: ReplayGapKind) -> &'static str {
+    match kind {
+        ReplayGapKind::Framing => "framing",
+        ReplayGapKind::TruncatedPdu => "truncated-pdu",
+        ReplayGapKind::StaticChannel => "static-channel",
+        ReplayGapKind::DynamicChannel => "dynamic-channel",
+        ReplayGapKind::Session => "session",
+        ReplayGapKind::IncompleteActivation => "incomplete-activation",
+        ReplayGapKind::Unsupported => "unsupported",
+    }
+}
+
+fn gap_reason_name(reason: ReplayGapReason) -> &'static str {
+    match reason {
+        ReplayGapReason::Framing => "framing",
+        ReplayGapReason::TruncatedPdu => "truncated-pdu",
+        ReplayGapReason::StaticChannelPdu => "static-channel-pdu",
+        ReplayGapReason::StaticChannelEncode => "static-channel-encode",
+        ReplayGapReason::StaticChannelDecode => "static-channel-decode",
+        ReplayGapReason::StaticChannelBulkDecompression => "static-channel-bulk-decompression",
+        ReplayGapReason::StaticChannelBitmapSourceLength => "static-channel-bitmap-source-length",
+        ReplayGapReason::StaticChannelProcessor => "static-channel-processor",
+        ReplayGapReason::StaticChannelOther => "static-channel-other",
+        ReplayGapReason::DynamicChannel => "dynamic-channel",
+        ReplayGapReason::Session => "session",
+        ReplayGapReason::IncompleteActivation => "incomplete-activation",
+        ReplayGapReason::Unsupported => "unsupported",
+    }
 }

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -41,10 +41,13 @@ fn run() -> Result<(), Box<dyn core::error::Error>> {
     let arguments = parse_arguments(std::env::args_os().skip(1)).map_err(usage_error)?;
     let mut capture = match read_capture(&arguments.capture) {
         Ok(capture) => capture,
-        Err(error @ (ironrdp_capture_replay::ReplayError::Io(_) | ironrdp_capture_replay::ReplayError::Pcap(_))) => {
-            return Err(error.into());
-        }
-        Err(error) if arguments.summary => {
+        Err(error)
+            if arguments.summary
+                && !matches!(
+                    error,
+                    ironrdp_capture_replay::ReplayError::Io(_) | ironrdp_capture_replay::ReplayError::Pcap(_)
+                ) =>
+        {
             print_summary_error(error);
             return Ok(());
         }
@@ -121,6 +124,9 @@ fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Argument
         } else {
             paths.push(argument);
         }
+    }
+    if show_gaps && !summary || replace && summary {
+        return Err(usage());
     }
     let (capture, output) = if summary {
         let [capture]: [OsString; 1] = paths.try_into().map_err(|_| usage())?;
@@ -200,5 +206,43 @@ fn print_gaps(gaps: &[ReplayGap]) {
     }
     if gaps.len() > MAX_GAP_DETAILS {
         println!("gap-details-truncated={}", gaps.len() - MAX_GAP_DETAILS);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_mode_inappropriate_flags() {
+        assert!(parse_arguments(["--gaps", "capture.pcapng", "output"].into_iter().map(OsString::from)).is_err());
+        assert!(
+            parse_arguments(
+                ["--summary", "--replace", "capture.pcapng"]
+                    .into_iter()
+                    .map(OsString::from)
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn accepts_mode_appropriate_flags() {
+        assert!(
+            parse_arguments(
+                ["--summary", "--gaps", "capture.pcapng"]
+                    .into_iter()
+                    .map(OsString::from)
+            )
+            .is_ok()
+        );
+        assert!(
+            parse_arguments(
+                ["--replace", "capture.pcapng", "output"]
+                    .into_iter()
+                    .map(OsString::from)
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -15,10 +15,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use ironrdp_capture_replay::{
-    ExportOptions, ReplayDirection, ReplayGap, ReplayGapKind, ReplayGapReason, ReplayLifecycle, ReplayOptions,
-    export_capture, prepare_capture, read_capture,
-};
+use ironrdp_capture_replay::{ExportOptions, ReplayGap, ReplayOptions, export_capture, prepare_capture, read_capture};
 use zeroize::Zeroize as _;
 
 fn main() -> ExitCode {
@@ -177,7 +174,7 @@ fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
         summary.static_channel_pdus,
         summary.other_server_message_pdus,
         summary.graphics_updates,
-        lifecycle_name(summary.lifecycle),
+        summary.lifecycle,
         summary.framing_gaps,
         summary.truncated_pdu_gaps,
         summary.static_channel_gaps,
@@ -188,14 +185,6 @@ fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
     );
 }
 
-fn lifecycle_name(lifecycle: ReplayLifecycle) -> &'static str {
-    match lifecycle {
-        ReplayLifecycle::NeverActivated => "never-activated",
-        ReplayLifecycle::Active => "active",
-        ReplayLifecycle::Deactivated => "deactivated",
-    }
-}
-
 fn print_gaps(gaps: &[ReplayGap]) {
     const MAX_GAP_DETAILS: usize = 16;
 
@@ -203,50 +192,13 @@ fn print_gaps(gaps: &[ReplayGap]) {
         println!(
             "gap=packet:{}\tdirection:{}\tkind:{}\treason:{}\tskipped-bytes:{}",
             gap.packet,
-            direction_name(gap.direction),
-            gap_kind_name(gap.kind),
-            gap_reason_name(gap.reason),
+            gap.direction,
+            gap.kind(),
+            gap.reason,
             gap.skipped_bytes,
         );
     }
     if gaps.len() > MAX_GAP_DETAILS {
         println!("gap-details-truncated={}", gaps.len() - MAX_GAP_DETAILS);
-    }
-}
-
-fn direction_name(direction: ReplayDirection) -> &'static str {
-    match direction {
-        ReplayDirection::Client => "client",
-        ReplayDirection::Server => "server",
-    }
-}
-
-fn gap_kind_name(kind: ReplayGapKind) -> &'static str {
-    match kind {
-        ReplayGapKind::Framing => "framing",
-        ReplayGapKind::TruncatedPdu => "truncated-pdu",
-        ReplayGapKind::StaticChannel => "static-channel",
-        ReplayGapKind::DynamicChannel => "dynamic-channel",
-        ReplayGapKind::Session => "session",
-        ReplayGapKind::IncompleteActivation => "incomplete-activation",
-        ReplayGapKind::Unsupported => "unsupported",
-    }
-}
-
-fn gap_reason_name(reason: ReplayGapReason) -> &'static str {
-    match reason {
-        ReplayGapReason::Framing => "framing",
-        ReplayGapReason::TruncatedPdu => "truncated-pdu",
-        ReplayGapReason::StaticChannelPdu => "static-channel-pdu",
-        ReplayGapReason::StaticChannelEncode => "static-channel-encode",
-        ReplayGapReason::StaticChannelDecode => "static-channel-decode",
-        ReplayGapReason::StaticChannelBulkDecompression => "static-channel-bulk-decompression",
-        ReplayGapReason::StaticChannelBitmapSourceLength => "static-channel-bitmap-source-length",
-        ReplayGapReason::StaticChannelProcessor => "static-channel-processor",
-        ReplayGapReason::StaticChannelOther => "static-channel-other",
-        ReplayGapReason::DynamicChannel => "dynamic-channel",
-        ReplayGapReason::Session => "session",
-        ReplayGapReason::IncompleteActivation => "incomplete-activation",
-        ReplayGapReason::Unsupported => "unsupported",
     }
 }

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -15,7 +15,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use ironrdp_capture_replay::{ExportOptions, export_capture, read_capture};
+use ironrdp_capture_replay::{ExportOptions, ReplayOptions, export_capture, prepare_capture, read_capture};
 use zeroize::Zeroize as _;
 
 fn main() -> ExitCode {
@@ -39,17 +39,34 @@ fn usage_error(message: String) -> Box<dyn core::error::Error> {
 
 fn run() -> Result<(), Box<dyn core::error::Error>> {
     let arguments = parse_arguments(std::env::args_os().skip(1)).map_err(usage_error)?;
-    let mut capture = read_capture(&arguments.capture)?;
+    let mut capture = match read_capture(&arguments.capture) {
+        Ok(capture) => capture,
+        Err(error) if arguments.summary => return print_summary_error(error),
+        Err(error) => return Err(error.into()),
+    };
     if let Some(key_log) = &arguments.key_log {
         let mut key_log = std::fs::read_to_string(key_log)
             .map_err(|error| usage_error(format!("failed to read {}: {error}", key_log.display())))?;
         capture.add_tls_key_log(&key_log);
         key_log.zeroize();
     }
+    if arguments.summary {
+        return match prepare_capture(&capture).and_then(|prepared| {
+            prepared.replay_with_options(ReplayOptions {
+                calculate_output_fingerprint: true,
+            })
+        }) {
+            Ok(execution) => {
+                print_summary(&execution.summary);
+                Ok(())
+            }
+            Err(error) => print_summary_error(error),
+        };
+    }
     let summary = export_capture(
         &capture,
         &ExportOptions {
-            directory: arguments.output,
+            directory: arguments.output.expect("export mode requires an output directory"),
             replace: arguments.replace,
         },
     )?;
@@ -64,19 +81,23 @@ fn run() -> Result<(), Box<dyn core::error::Error>> {
 
 struct Arguments {
     capture: PathBuf,
-    output: PathBuf,
+    output: Option<PathBuf>,
     key_log: Option<PathBuf>,
     replace: bool,
+    summary: bool,
 }
 
 fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Arguments, String> {
     let mut replace = false;
+    let mut summary = false;
     let mut key_log = None;
     let mut paths = Vec::new();
     let mut arguments = arguments.peekable();
     while let Some(argument) = arguments.next() {
         if argument == "--replace" {
             replace = true;
+        } else if argument == "--summary" {
+            summary = true;
         } else if argument == "--keylog" {
             key_log = Some(PathBuf::from(arguments.next().ok_or_else(usage)?));
         } else if argument.to_string_lossy().starts_with('-') {
@@ -85,16 +106,59 @@ fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Argument
             paths.push(argument);
         }
     }
-    let [capture, output]: [OsString; 2] = paths.try_into().map_err(|_| usage())?;
+    let (capture, output) = if summary {
+        let [capture]: [OsString; 1] = paths.try_into().map_err(|_| usage())?;
+        (capture, None)
+    } else {
+        let [capture, output]: [OsString; 2] = paths.try_into().map_err(|_| usage())?;
+        (capture, Some(PathBuf::from(output)))
+    };
 
     Ok(Arguments {
         capture: PathBuf::from(capture),
-        output: PathBuf::from(output),
+        output,
         key_log,
         replace,
+        summary,
     })
 }
 
 fn usage() -> String {
-    "usage: ironrdp-capture-replay [--replace] [--keylog <tls-keys.log>] <capture.pcapng> <output-directory>".to_owned()
+    "usage: ironrdp-capture-replay [--replace] [--keylog <tls-keys.log>] <capture.pcapng> <output-directory>\n       ironrdp-capture-replay --summary [--keylog <tls-keys.log>] <capture.pcapng>".to_owned()
+}
+
+fn print_summary_error(error: ironrdp_capture_replay::ReplayError) -> Result<(), Box<dyn core::error::Error>> {
+    let (stage, reason) = error.summary_code();
+    println!("status=error\tstage={stage}\treason={reason}");
+    Ok(())
+}
+
+fn print_summary(summary: &ironrdp_capture_replay::ReplaySummary) {
+    let dimensions = summary
+        .final_dimensions
+        .map_or_else(|| "-".to_owned(), |(width, height)| format!("{width}x{height}"));
+    let fingerprint = summary.output_fingerprint.map_or_else(
+        || "-".to_owned(),
+        |bytes| bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
+    );
+    println!(
+        "status=ok\tclient-pdus={}\tserver-pdus={}\tconnection-pdus={}\tclient-observation-pdus={}\tfast-path-pdus={}\tio-channel-pdus={}\tmessage-channel-pdus={}\tstatic-channel-pdus={}\tother-server-message-pdus={}\tgraphics-updates={}\tfinal-dimensions={dimensions}\tfingerprint={fingerprint}\tframing-gaps={}\ttruncated-pdu-gaps={}\tstatic-channel-gaps={}\tdynamic-channel-gaps={}\tsession-gaps={}\tincomplete-activation-gaps={}\tunsupported-gaps={}",
+        summary.client_pdus,
+        summary.server_pdus,
+        summary.connection_pdus,
+        summary.client_observation_pdus,
+        summary.fast_path_pdus,
+        summary.io_channel_pdus,
+        summary.message_channel_pdus,
+        summary.static_channel_pdus,
+        summary.other_server_message_pdus,
+        summary.graphics_updates,
+        summary.framing_gaps,
+        summary.truncated_pdu_gaps,
+        summary.static_channel_gaps,
+        summary.dynamic_channel_gaps,
+        summary.session_gaps,
+        summary.incomplete_activation_gaps,
+        summary.unsupported_gaps,
+    );
 }

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -62,3 +62,29 @@ pub enum ReplayError {
     #[error("capture gateway tunnel framing is invalid: {0}")]
     GatewayFraming(String),
 }
+
+impl ReplayError {
+    /// Stable stage and reason identifiers suitable for payload-free summaries.
+    pub fn summary_code(&self) -> (&'static str, &'static str) {
+        match self {
+            Self::Io(_) => ("read", "io"),
+            Self::Pcap(_) => ("read", "pcap"),
+            Self::UnsupportedTransport => ("read", "unsupported-transport"),
+            Self::MissingTcpFlow => ("read", "missing-tcp-flow"),
+            Self::StandardSecurity => ("decrypt", "standard-security"),
+            Self::UnsupportedTls => ("decrypt", "unsupported-tls"),
+            Self::MissingTlsSecret => ("decrypt", "missing-tls-secret"),
+            Self::MissingTunneledTlsSecret => ("gateway", "missing-tunneled-tls-secret"),
+            Self::TlsAuthentication => ("decrypt", "tls-authentication"),
+            Self::TlsKeyUpdate => ("decrypt", "tls-key-update"),
+            Self::MissingRdpState => ("negotiate", "missing-rdp-state"),
+            Self::MissingChannelMap => ("negotiate", "missing-channel-map"),
+            Self::MissingUserChannel => ("negotiate", "missing-user-channel"),
+            Self::MissingShareId => ("negotiate", "missing-share-id"),
+            Self::ContradictoryRoutingState => ("negotiate", "contradictory-routing-state"),
+            Self::MissingDrdynvcChannel => ("route", "missing-drdynvc-channel"),
+            Self::DynamicChannelAttachment => ("route", "dynamic-channel-attachment"),
+            Self::GatewayFraming(_) => ("gateway", "framing"),
+        }
+    }
+}

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -19,8 +19,9 @@ pub use gateway_rpch::{extract_rpch_from_flows, extract_rpch_tunneled_rdp};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{
-    CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport,
-    ReplayRoute, ReplayRouter, replay_capture,
+    CapturedActivation, CapturedDynamicChannel, PreparedReplay, ReplayDirection, ReplayEvent, ReplayExecution,
+    ReplayGap, ReplayGapKind, ReplayOptions, ReplayReport, ReplayRoute, ReplayRouter, ReplaySummary, prepare_capture,
+    replay_capture,
 };
 pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -20,8 +20,8 @@ pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{
     CapturedActivation, CapturedDynamicChannel, PreparedReplay, ReplayDirection, ReplayEvent, ReplayExecution,
-    ReplayGap, ReplayGapKind, ReplayOptions, ReplayReport, ReplayRoute, ReplayRouter, ReplaySummary, prepare_capture,
-    replay_capture,
+    ReplayGap, ReplayGapKind, ReplayGapReason, ReplayLifecycle, ReplayOptions, ReplayReport, ReplayRoute, ReplayRouter,
+    ReplaySummary, prepare_capture, replay_capture,
 };
 pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -506,12 +506,14 @@ mod tests {
                 packet: 20,
                 direction: ReplayDirection::Server,
                 kind: ReplayGapKind::Framing,
+                reason: crate::ReplayGapReason::Framing,
                 skipped_bytes: 3,
             }],
             dynamic_channels: vec![CapturedDynamicChannel {
                 id: 7,
                 name: "CLIENT_RANDOM decrypted payload".to_owned(),
             }],
+            lifecycle: crate::ReplayLifecycle::Active,
         }
     }
 

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
-use crate::routing::{ReplayFrame, prepare_replay_capture};
+use crate::prepare_capture;
+use crate::routing::ReplayFrame;
 use crate::{Capture, ReplayDirection, ReplayError, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport, ReplayRoute};
 
 /// Options that control replay artifact export.
@@ -68,16 +69,19 @@ pub enum ExportError {
 ///
 /// The destination receives nothing unless every PNG and tabular file was written successfully.
 pub fn export_capture(capture: &Capture, options: &ExportOptions) -> Result<ExportSummary, ExportError> {
-    let (mut router, plaintext) = prepare_replay_capture(capture).map_err(ExportError::Replay)?;
+    let prepared = prepare_capture(capture).map_err(ExportError::Replay)?;
     validate_output_directory(&options.directory, options.replace)?;
 
     let parent = output_parent(&options.directory);
     fs::create_dir_all(parent).map_err(ExportError::PrepareOutput)?;
     let staging = create_staging_directory(parent, &options.directory)?;
     let mut output = StagedOutput::new(staging);
-    let result = router
-        .route_plaintext_with_frame_sink(&plaintext, &mut |frame| output.write_frame(frame))
-        .and_then(|report| finalize_staged_output(&mut output, &report, options));
+    let result = {
+        let mut router = crate::ReplayRouter::new(prepared.activation.clone()).map_err(ExportError::Replay)?;
+        router
+            .route_plaintext_with_frame_sink(&prepared.plaintext, &mut |frame| output.write_frame(frame))
+            .and_then(|report| finalize_staged_output(&mut output, &report, options))
+    };
     match result {
         Ok(summary) => Ok(summary),
         Err(error) => {
@@ -128,7 +132,7 @@ impl StagedOutput {
         }
     }
 
-    fn write_frame(&mut self, frame: ReplayFrame) -> Result<(), ExportError> {
+    fn write_frame(&mut self, frame: ReplayFrame<'_>) -> Result<(), ExportError> {
         let name = format!("frame_{:06}.png", self.frame_count);
         encode_png(&self.directory.join(name), &frame)?;
         self.frame_metadata.push_str(&format!(
@@ -281,13 +285,13 @@ fn replace_output_directory(staging: &Path, directory: &Path, replace: bool) -> 
     fs::rename(staging, directory).map_err(ExportError::FinalizeOutput)
 }
 
-fn encode_png(path: &Path, frame: &ReplayFrame) -> Result<(), ExportError> {
+fn encode_png(path: &Path, frame: &ReplayFrame<'_>) -> Result<(), ExportError> {
     let file = fs::File::create(path).map_err(ExportError::WriteOutput)?;
     let mut encoder = png::Encoder::new(file, u32::from(frame.width), u32::from(frame.height));
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder.write_header().map_err(ExportError::EncodePng)?;
-    writer.write_image_data(&frame.pixels).map_err(ExportError::EncodePng)?;
+    writer.write_image_data(frame.pixels).map_err(ExportError::EncodePng)?;
     writer.finish().map_err(ExportError::EncodePng)?;
     Ok(())
 }
@@ -377,8 +381,8 @@ mod tests {
         let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
         let mut output = StagedOutput::new(staging.clone());
         let report = report();
-        output.write_frame(frame(12, [0x11, 0x22, 0x33, 0xff])).unwrap();
-        output.write_frame(frame(47, [0x44, 0x55, 0x66, 0xff])).unwrap();
+        output.write_frame(frame(12, &[0x11, 0x22, 0x33, 0xff])).unwrap();
+        output.write_frame(frame(47, &[0x44, 0x55, 0x66, 0xff])).unwrap();
         output.write_diagnostics(&report).unwrap();
         replace_output_directory(&staging, &directory, false).unwrap();
 
@@ -445,7 +449,7 @@ mod tests {
         fs::write(directory.join("keep"), "old").unwrap();
         let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
         let mut output = StagedOutput::new(staging);
-        output.write_frame(frame(12, [0x11, 0x22, 0x33, 0xff])).unwrap();
+        output.write_frame(frame(12, &[0x11, 0x22, 0x33, 0xff])).unwrap();
 
         let summary = finalize_staged_output(
             &mut output,
@@ -511,12 +515,12 @@ mod tests {
         }
     }
 
-    fn frame(packet: usize, pixels: [u8; 4]) -> ReplayFrame {
+    fn frame<'a>(packet: usize, pixels: &'a [u8; 4]) -> ReplayFrame<'a> {
         ReplayFrame {
             packet,
             width: 1,
             height: 1,
-            pixels: pixels.to_vec(),
+            pixels,
         }
     }
 

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::prepare_capture;
 use crate::routing::ReplayFrame;
-use crate::{Capture, ReplayDirection, ReplayError, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport, ReplayRoute};
+use crate::{Capture, ReplayError, ReplayEvent, ReplayGap, ReplayReport, ReplayRoute};
 
 /// Options that control replay artifact export.
 #[derive(Clone, Debug)]
@@ -303,7 +303,7 @@ fn events_tsv(events: &[ReplayEvent]) -> String {
             "{}\t{}\t{}\t{:?}\t{}\n",
             index + 1,
             event.packet,
-            direction_name(event.direction),
+            event.direction,
             event.action,
             route_name(event.route),
         ));
@@ -317,8 +317,8 @@ fn gaps_tsv(gaps: &[ReplayGap]) -> String {
         output.push_str(&format!(
             "{}\t{}\t{}\t{}\n",
             gap.packet,
-            direction_name(gap.direction),
-            gap_kind_name(gap.kind),
+            gap.direction,
+            gap.kind(),
             gap.skipped_bytes,
         ));
     }
@@ -333,13 +333,6 @@ fn dynamic_channels_tsv(report: &ReplayReport) -> String {
     output
 }
 
-fn direction_name(direction: ReplayDirection) -> &'static str {
-    match direction {
-        ReplayDirection::Client => "client",
-        ReplayDirection::Server => "server",
-    }
-}
-
 fn route_name(route: ReplayRoute) -> &'static str {
     match route {
         ReplayRoute::Connection => "connection",
@@ -352,18 +345,6 @@ fn route_name(route: ReplayRoute) -> &'static str {
     }
 }
 
-fn gap_kind_name(kind: ReplayGapKind) -> &'static str {
-    match kind {
-        ReplayGapKind::Framing => "framing",
-        ReplayGapKind::TruncatedPdu => "truncated-pdu",
-        ReplayGapKind::StaticChannel => "static-channel",
-        ReplayGapKind::DynamicChannel => "dynamic-channel",
-        ReplayGapKind::Session => "session",
-        ReplayGapKind::IncompleteActivation => "incomplete-activation",
-        ReplayGapKind::Unsupported => "unsupported",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use core::sync::atomic::{AtomicUsize, Ordering};
@@ -371,7 +352,7 @@ mod tests {
     use ironrdp_pdu::Action;
 
     use super::*;
-    use crate::CapturedDynamicChannel;
+    use crate::{CapturedDynamicChannel, ReplayDirection};
 
     static NEXT_DIRECTORY: AtomicUsize = AtomicUsize::new(0);
 
@@ -505,7 +486,6 @@ mod tests {
             gaps: vec![ReplayGap {
                 packet: 20,
                 direction: ReplayDirection::Server,
-                kind: ReplayGapKind::Framing,
                 reason: crate::ReplayGapReason::Framing,
                 skipped_bytes: 3,
             }],

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -20,6 +20,7 @@ use ironrdp_pdu::{Action, decode_err, find_size, mcs};
 use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
+use sha2::{Digest as _, Sha256};
 
 use crate::tls::decrypt_tls_streams;
 use crate::{
@@ -90,15 +91,15 @@ pub struct ReplayEvent {
     pub route: ReplayRoute,
 }
 
-#[derive(Clone, Eq, PartialEq)]
-pub(crate) struct ReplayFrame {
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) struct ReplayFrame<'a> {
     pub packet: usize,
     pub width: u16,
     pub height: u16,
-    pub pixels: Vec<u8>,
+    pub pixels: &'a [u8],
 }
 
-impl core::fmt::Debug for ReplayFrame {
+impl core::fmt::Debug for ReplayFrame<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ReplayFrame")
             .field("packet", &self.packet)
@@ -159,6 +160,103 @@ pub struct ReplayReport {
     pub gaps: Vec<ReplayGap>,
     /// Dynamic channels attached from recorded DVC create requests.
     pub dynamic_channels: Vec<CapturedDynamicChannel>,
+}
+
+/// Configuration for one replay execution.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReplayOptions {
+    /// Hash every rendered framebuffer update for a deterministic output fingerprint.
+    pub calculate_output_fingerprint: bool,
+}
+
+/// Payload-free work completed by one replay execution.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ReplaySummary {
+    /// Number of framed client-to-server PDUs consumed from the capture.
+    pub client_pdus: usize,
+    /// Number of framed server-to-client PDUs consumed from the capture.
+    pub server_pdus: usize,
+    /// Number of connection and activation PDUs observed.
+    pub connection_pdus: usize,
+    /// Number of client PDUs retained as observations.
+    pub client_observation_pdus: usize,
+    /// Number of server Fast-Path PDUs routed.
+    pub fast_path_pdus: usize,
+    /// Number of server I/O channel PDUs routed.
+    pub io_channel_pdus: usize,
+    /// Number of server message-channel PDUs routed.
+    pub message_channel_pdus: usize,
+    /// Number of server static-channel PDUs routed.
+    pub static_channel_pdus: usize,
+    /// Number of server MCS PDUs retained outside captured active channels.
+    pub other_server_message_pdus: usize,
+    /// Number of composited framebuffer updates observed.
+    pub graphics_updates: usize,
+    /// Dimensions of the final composited framebuffer update, when one was observed.
+    pub final_dimensions: Option<(u16, u16)>,
+    /// SHA-256 over ordered framebuffer updates, when requested.
+    pub output_fingerprint: Option<[u8; 32]>,
+    /// Number of framing gaps.
+    pub framing_gaps: usize,
+    /// Number of truncated-PDU gaps.
+    pub truncated_pdu_gaps: usize,
+    /// Number of static-channel gaps.
+    pub static_channel_gaps: usize,
+    /// Number of dynamic-channel gaps.
+    pub dynamic_channel_gaps: usize,
+    /// Number of active-session gaps.
+    pub session_gaps: usize,
+    /// Number of incomplete-activation gaps.
+    pub incomplete_activation_gaps: usize,
+    /// Number of unsupported replay gaps.
+    pub unsupported_gaps: usize,
+}
+
+/// A prepared replay that can be executed repeatedly without reparsing or decrypting a capture.
+#[derive(Clone, Debug)]
+pub struct PreparedReplay {
+    pub(crate) activation: CapturedActivation,
+    pub(crate) plaintext: Plaintext,
+}
+
+/// Report and payload-free summary from one fresh replay execution.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplayExecution {
+    /// Detailed routing report.
+    pub report: ReplayReport,
+    /// Deterministic replay counters and optional output fingerprint.
+    pub summary: ReplaySummary,
+}
+
+impl PreparedReplay {
+    /// Execute the prepared replay with fresh session and channel state.
+    pub fn replay(&self) -> Result<ReplayExecution, ReplayError> {
+        self.replay_with_options(ReplayOptions::default())
+    }
+
+    /// Execute the prepared replay with the selected summary options.
+    pub fn replay_with_options(&self, options: ReplayOptions) -> Result<ReplayExecution, ReplayError> {
+        let mut router = ReplayRouter::new(self.activation.clone())?;
+        let mut summary = ReplaySummary::default();
+        let mut fingerprint = options.calculate_output_fingerprint.then(Sha256::new);
+        let report = match router.route_plaintext_with_frame_sink(&self.plaintext, &mut |frame| {
+            summary.graphics_updates += 1;
+            summary.final_dimensions = Some((frame.width, frame.height));
+            if let Some(hasher) = &mut fingerprint {
+                hasher.update(frame.width.to_le_bytes());
+                hasher.update(frame.height.to_le_bytes());
+                hasher.update(frame.pixels);
+            }
+            Ok::<_, Infallible>(())
+        }) {
+            Ok(report) => report,
+            Err(error) => match error {},
+        };
+        summarize_report(&mut summary, &report);
+        summary.output_fingerprint = fingerprint.map(|hasher| hasher.finalize().into());
+
+        Ok(ReplayExecution { report, summary })
+    }
 }
 
 /// Offline router configured exclusively from captured RDP state.
@@ -277,7 +375,7 @@ impl ReplayRouter {
     pub(crate) fn route_plaintext_with_frame_sink<E>(
         &mut self,
         plaintext: &Plaintext,
-        frame_sink: &mut impl FnMut(ReplayFrame) -> Result<(), E>,
+        frame_sink: &mut impl for<'a> FnMut(ReplayFrame<'a>) -> Result<(), E>,
     ) -> Result<ReplayReport, E> {
         let mut report = ReplayReport::default();
         let mut messages = framed_stream(&plaintext.client, ReplayDirection::Client, &mut report.gaps);
@@ -342,7 +440,7 @@ impl ReplayRouter {
         &mut self,
         message: &CapturedPdu,
         report: &mut ReplayReport,
-        frame_sink: &mut impl FnMut(ReplayFrame) -> Result<(), E>,
+        frame_sink: &mut impl for<'a> FnMut(ReplayFrame<'a>) -> Result<(), E>,
     ) -> Result<(ReplayRoute, bool), E> {
         let route = match message.action {
             Action::FastPath => ReplayRoute::FastPath,
@@ -367,6 +465,9 @@ impl ReplayRouter {
         };
         if route == ReplayRoute::StaticChannel {
             self.observe_dvc_lifecycle(message, report);
+            if !self.is_drdynvc_message(message) {
+                return Ok((route, false));
+            }
         }
         if route == ReplayRoute::OtherServerMessage {
             return Ok((route, false));
@@ -381,7 +482,7 @@ impl ReplayRouter {
                         packet: message.packet,
                         width: self.image.width(),
                         height: self.image.height(),
-                        pixels: self.image.data().to_vec(),
+                        pixels: self.image.data(),
                     })?;
                 }
                 self.drain_egfx_output(message.packet, report, frame_sink)?;
@@ -443,6 +544,7 @@ impl ReplayRouter {
         if Some(context.channel_id) != self.drdynvc_channel_id {
             return;
         }
+
         self.dvc_lifecycle
             .channel_processor_downcast_mut::<DynamicChannelDiscovery>()
             .expect("DynamicChannelDiscovery must retain its concrete type")
@@ -495,11 +597,17 @@ impl ReplayRouter {
         }
     }
 
+    fn is_drdynvc_message(&self, message: &CapturedPdu) -> bool {
+        mcs::decode_send_data_indication(&message.bytes)
+            .ok()
+            .is_some_and(|context| Some(context.channel_id) == self.drdynvc_channel_id)
+    }
+
     fn drain_egfx_output<E>(
         &mut self,
         packet: usize,
         report: &mut ReplayReport,
-        frame_sink: &mut impl FnMut(ReplayFrame) -> Result<(), E>,
+        frame_sink: &mut impl for<'a> FnMut(ReplayFrame<'a>) -> Result<(), E>,
     ) -> Result<(), E> {
         let channel_ids = self.egfx_dynamic_channels.iter().copied().collect::<Vec<_>>();
         for channel_id in channel_ids {
@@ -531,7 +639,7 @@ impl ReplayRouter {
                     packet,
                     width: self.egfx_framebuffer.width,
                     height: self.egfx_framebuffer.height,
-                    pixels: self.egfx_framebuffer.pixels.clone(),
+                    pixels: &self.egfx_framebuffer.pixels,
                 })?;
             }
         }
@@ -555,11 +663,11 @@ impl ReplayRouter {
 
 /// Decrypt, recover captured activation state, and route a direct TCP RDP capture.
 pub fn replay_capture(capture: &Capture) -> Result<ReplayReport, ReplayError> {
-    let (mut router, plaintext) = prepare_replay_capture(capture)?;
-    Ok(router.route_plaintext(&plaintext))
+    Ok(prepare_capture(capture)?.replay()?.report)
 }
 
-pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter, Plaintext), ReplayError> {
+/// Decrypt and recover a capture once for repeated offline replay executions.
+pub fn prepare_capture(capture: &Capture) -> Result<PreparedReplay, ReplayError> {
     let mut decrypted = Vec::new();
     let mut decrypt_error = None;
     for flow in core::iter::once(&capture.flow).chain(capture.gateway_alternates.iter()) {
@@ -583,11 +691,41 @@ pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter,
             None => return Err(decrypt_error.unwrap_or(ReplayError::MissingRdpState)),
         }
     };
-    let router = ReplayRouter::new(CapturedActivation {
+    let activation = CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),
-    })?;
-    Ok((router, plaintext))
+    };
+    ReplayRouter::new(activation.clone())?;
+    Ok(PreparedReplay { activation, plaintext })
+}
+
+fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
+    for event in &report.events {
+        match event.direction {
+            ReplayDirection::Client => summary.client_pdus += 1,
+            ReplayDirection::Server => summary.server_pdus += 1,
+        }
+        match event.route {
+            ReplayRoute::Connection => summary.connection_pdus += 1,
+            ReplayRoute::ClientObservation => summary.client_observation_pdus += 1,
+            ReplayRoute::FastPath => summary.fast_path_pdus += 1,
+            ReplayRoute::IoChannel => summary.io_channel_pdus += 1,
+            ReplayRoute::MessageChannel => summary.message_channel_pdus += 1,
+            ReplayRoute::StaticChannel => summary.static_channel_pdus += 1,
+            ReplayRoute::OtherServerMessage => summary.other_server_message_pdus += 1,
+        }
+        for gap in &report.gaps {
+            match gap.kind {
+                ReplayGapKind::Framing => summary.framing_gaps += 1,
+                ReplayGapKind::TruncatedPdu => summary.truncated_pdu_gaps += 1,
+                ReplayGapKind::StaticChannel => summary.static_channel_gaps += 1,
+                ReplayGapKind::DynamicChannel => summary.dynamic_channel_gaps += 1,
+                ReplayGapKind::Session => summary.session_gaps += 1,
+                ReplayGapKind::IncompleteActivation => summary.incomplete_activation_gaps += 1,
+                ReplayGapKind::Unsupported => summary.unsupported_gaps += 1,
+            }
+        }
+    }
 }
 
 fn decrypt_tunneled_rdp(tunneled: &Plaintext, capture: &Capture) -> Result<Plaintext, ReplayError> {
@@ -1124,7 +1262,7 @@ mod tests {
                     ],
                 },
                 &mut |frame| {
-                    frames.push(frame);
+                    frames.push((frame.packet, frame.width, frame.height, frame.pixels.to_vec()));
                     Ok::<_, ()>(())
                 },
             )
@@ -1134,10 +1272,42 @@ mod tests {
             report.events.iter().map(|event| event.packet).collect::<Vec<_>>(),
             vec![1, 2, 3, 4]
         );
-        assert_eq!(frames.iter().map(|frame| frame.packet).collect::<Vec<_>>(), vec![3, 4]);
-        assert!(frames.iter().all(|frame| (frame.width, frame.height) == (32, 32)));
-        assert_eq!(&frames[0].pixels[..4], [0x33, 0x22, 0x11, 0xff]);
-        assert_eq!(&frames[1].pixels[..4], [0x66, 0x55, 0x44, 0xff]);
+        assert_eq!(frames.iter().map(|frame| frame.0).collect::<Vec<_>>(), vec![3, 4]);
+        assert!(frames.iter().all(|frame| (frame.1, frame.2) == (32, 32)));
+        assert_eq!(&frames[0].3[..4], [0x33, 0x22, 0x11, 0xff]);
+        assert_eq!(&frames[1].3[..4], [0x66, 0x55, 0x44, 0xff]);
+    }
+
+    #[test]
+    fn prepared_replay_resets_state_between_executions() {
+        let plaintext = Plaintext {
+            client: Vec::new(),
+            server: vec![
+                (1, demand_active()),
+                (2, font_map()),
+                (3, bitmap_fast_path([0x11, 0x22, 0x33, 0xff])),
+            ],
+        };
+        let prepared = PreparedReplay {
+            activation: activation(),
+            plaintext,
+        };
+
+        let first = prepared
+            .replay_with_options(ReplayOptions {
+                calculate_output_fingerprint: true,
+            })
+            .unwrap();
+        let second = prepared
+            .replay_with_options(ReplayOptions {
+                calculate_output_fingerprint: true,
+            })
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.summary.graphics_updates, 1);
+        assert_eq!(first.summary.final_dimensions, Some((32, 32)));
+        assert!(first.summary.output_fingerprint.is_some());
     }
 
     #[test]
@@ -1348,7 +1518,7 @@ mod tests {
                     ],
                 },
                 &mut |frame| {
-                    frames.push(frame);
+                    frames.push((frame.packet, frame.width, frame.height, frame.pixels.to_vec()));
                     Ok::<_, ()>(())
                 },
             )
@@ -1362,14 +1532,14 @@ mod tests {
             }]
         );
         assert!(report.gaps.is_empty());
-        assert_eq!(frames.iter().map(|frame| frame.packet).collect::<Vec<_>>(), [10, 14]);
-        assert!(frames.iter().all(|frame| (frame.width, frame.height) == (3, 1)));
+        assert_eq!(frames.iter().map(|frame| frame.0).collect::<Vec<_>>(), [10, 14]);
+        assert!(frames.iter().all(|frame| (frame.1, frame.2) == (3, 1)));
         assert_eq!(
-            frames[0].pixels,
+            frames[0].3,
             [0x11, 0x22, 0x33, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         );
         assert_eq!(
-            frames[1].pixels,
+            frames[1].3,
             [0x11, 0x22, 0x33, 0xff, 0x44, 0x55, 0x66, 0xff, 0x77, 0x88, 0x99, 0xff]
         );
         assert!(router.egfx_dynamic_channels.contains(&channel_id));
@@ -1378,7 +1548,6 @@ mod tests {
     #[test]
     fn keeps_unknown_recorded_dvcs_opaque() {
         let mut router = ReplayRouter::new(activation()).unwrap();
-        let mut frames = Vec::new();
         let channel_id = 47;
         let report = router
             .route_plaintext_with_frame_sink(
@@ -1397,15 +1566,11 @@ mod tests {
                         ),
                     ],
                 },
-                &mut |frame| {
-                    frames.push(frame);
-                    Ok::<_, ()>(())
-                },
+                &mut |_frame| Ok::<_, ()>(()),
             )
             .unwrap();
 
         assert!(report.gaps.is_empty());
-        assert!(frames.is_empty());
         assert!(!router.egfx_dynamic_channels.contains(&channel_id));
         let drdynvc = router.stage.get_svc_processor_mut::<DrdynvcClient>().unwrap();
         assert!(

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -18,7 +18,7 @@ use ironrdp_pdu::rdp::client_info::{ClientInfoFlags, CompressionType};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{Action, decode_err, find_size, mcs};
 use ironrdp_session::image::DecodedImage;
-use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
+use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput, SessionErrorKind};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
 use sha2::{Digest as _, Sha256};
 
@@ -129,6 +129,49 @@ pub enum ReplayGapKind {
     Unsupported,
 }
 
+/// Stable, payload-free reason for a replay gap.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReplayGapReason {
+    /// RDP framing did not recognize bytes at the current offset.
+    Framing,
+    /// A framed RDP PDU ended before its declared boundary.
+    TruncatedPdu,
+    /// A static-channel PDU failed in the PDU layer.
+    StaticChannelPdu,
+    /// A static-channel PDU failed in the encoding layer.
+    StaticChannelEncode,
+    /// A static-channel PDU failed in the decoding layer.
+    StaticChannelDecode,
+    /// A static-channel PDU failed in bulk decompression.
+    StaticChannelBulkDecompression,
+    /// A static-channel PDU had an invalid bitmap source length.
+    StaticChannelBitmapSourceLength,
+    /// A static-channel PDU failed with a processor reason.
+    StaticChannelProcessor,
+    /// A static-channel PDU failed with a general or custom processor error.
+    StaticChannelOther,
+    /// A dynamic-channel message could not be routed.
+    DynamicChannel,
+    /// An active-session message could not be routed.
+    Session,
+    /// The capture ended before activation or reactivation completed.
+    IncompleteActivation,
+    /// A protocol path is not supported by the replay harness.
+    Unsupported,
+}
+
+/// Terminal activation state observed during a replay.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReplayLifecycle {
+    /// The capture never reached activation.
+    #[default]
+    NeverActivated,
+    /// The capture ended with an active session.
+    Active,
+    /// The capture deactivated after an active session.
+    Deactivated,
+}
+
 /// A safe, payload-free description of an unreplayable captured message.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReplayGap {
@@ -138,6 +181,8 @@ pub struct ReplayGap {
     pub direction: ReplayDirection,
     /// Layer that could not be replayed.
     pub kind: ReplayGapKind,
+    /// Stable reason for the gap without captured payload content.
+    pub reason: ReplayGapReason,
     /// Bytes skipped while resynchronizing after a framing error.
     pub skipped_bytes: usize,
 }
@@ -160,6 +205,8 @@ pub struct ReplayReport {
     pub gaps: Vec<ReplayGap>,
     /// Dynamic channels attached from recorded DVC create requests.
     pub dynamic_channels: Vec<CapturedDynamicChannel>,
+    /// Terminal activation state observed while routing the capture.
+    pub lifecycle: ReplayLifecycle,
 }
 
 /// Configuration for one replay execution.
@@ -196,6 +243,8 @@ pub struct ReplaySummary {
     pub final_dimensions: Option<(u16, u16)>,
     /// SHA-256 over ordered framebuffer updates, when requested.
     pub output_fingerprint: Option<[u8; 32]>,
+    /// Terminal activation state observed during replay.
+    pub lifecycle: ReplayLifecycle,
     /// Number of framing gaps.
     pub framing_gaps: usize,
     /// Number of truncated-PDU gaps.
@@ -210,6 +259,8 @@ pub struct ReplaySummary {
     pub incomplete_activation_gaps: usize,
     /// Number of unsupported replay gaps.
     pub unsupported_gaps: usize,
+    /// SHA-256 over ordered payload-free gap metadata.
+    pub gap_fingerprint: [u8; 32],
 }
 
 /// A prepared replay that can be executed repeatedly without reparsing or decrypting a capture.
@@ -428,11 +479,27 @@ impl ReplayRouter {
                     packet,
                     direction: ReplayDirection::Server,
                     kind: ReplayGapKind::IncompleteActivation,
+                    reason: ReplayGapReason::IncompleteActivation,
                     skipped_bytes: 0,
                 });
             }
         }
-        report.gaps.sort_by_key(|gap| gap.packet);
+        report.lifecycle = if activated {
+            ReplayLifecycle::Active
+        } else if ever_activated {
+            ReplayLifecycle::Deactivated
+        } else {
+            ReplayLifecycle::NeverActivated
+        };
+        report.gaps.sort_by_key(|gap| {
+            (
+                gap.packet,
+                gap_direction_code(gap.direction),
+                gap_kind_code(gap.kind),
+                gap.skipped_bytes,
+                gap_reason_code(gap.reason),
+            )
+        });
         Ok(report)
     }
 
@@ -493,16 +560,22 @@ impl ReplayRouter {
                         .any(|output| matches!(output, ActiveStageOutput::DeactivateAll)),
                 ))
             }
-            Err(_) => {
+            Err(error) => {
+                let unsupported = route == ReplayRoute::StaticChannel && self.take_unsupported_egfx_codec();
                 report.gaps.push(ReplayGap {
                     packet: message.packet,
                     direction: ReplayDirection::Server,
-                    kind: if route == ReplayRoute::StaticChannel && self.take_unsupported_egfx_codec() {
+                    kind: if unsupported {
                         ReplayGapKind::Unsupported
                     } else if route == ReplayRoute::StaticChannel {
                         ReplayGapKind::StaticChannel
                     } else {
                         ReplayGapKind::Session
+                    },
+                    reason: if unsupported {
+                        ReplayGapReason::Unsupported
+                    } else {
+                        session_gap_reason(route, error.kind())
                     },
                     skipped_bytes: 0,
                 });
@@ -554,6 +627,7 @@ impl ReplayRouter {
                 packet: message.packet,
                 direction: message.direction,
                 kind: ReplayGapKind::DynamicChannel,
+                reason: ReplayGapReason::DynamicChannel,
                 skipped_bytes: 0,
             });
             return;
@@ -591,6 +665,7 @@ impl ReplayRouter {
                     packet: channel.packet,
                     direction: ReplayDirection::Server,
                     kind: ReplayGapKind::DynamicChannel,
+                    reason: ReplayGapReason::DynamicChannel,
                     skipped_bytes: 0,
                 });
             }
@@ -625,6 +700,7 @@ impl ReplayRouter {
                         packet,
                         direction: ReplayDirection::Server,
                         kind: ReplayGapKind::Unsupported,
+                        reason: ReplayGapReason::Unsupported,
                         skipped_bytes: 0,
                     });
                     continue;
@@ -714,17 +790,92 @@ fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
             ReplayRoute::StaticChannel => summary.static_channel_pdus += 1,
             ReplayRoute::OtherServerMessage => summary.other_server_message_pdus += 1,
         }
-        for gap in &report.gaps {
-            match gap.kind {
-                ReplayGapKind::Framing => summary.framing_gaps += 1,
-                ReplayGapKind::TruncatedPdu => summary.truncated_pdu_gaps += 1,
-                ReplayGapKind::StaticChannel => summary.static_channel_gaps += 1,
-                ReplayGapKind::DynamicChannel => summary.dynamic_channel_gaps += 1,
-                ReplayGapKind::Session => summary.session_gaps += 1,
-                ReplayGapKind::IncompleteActivation => summary.incomplete_activation_gaps += 1,
-                ReplayGapKind::Unsupported => summary.unsupported_gaps += 1,
-            }
+    }
+    summary.lifecycle = report.lifecycle;
+    let mut gap_fingerprint = Sha256::new();
+    let mut gaps = report.gaps.iter().collect::<Vec<_>>();
+    gaps.sort_by_key(|gap| {
+        (
+            gap.packet,
+            gap_direction_code(gap.direction),
+            gap_kind_code(gap.kind),
+            gap.skipped_bytes,
+            gap_reason_code(gap.reason),
+        )
+    });
+    for gap in gaps {
+        match gap.kind {
+            ReplayGapKind::Framing => summary.framing_gaps += 1,
+            ReplayGapKind::TruncatedPdu => summary.truncated_pdu_gaps += 1,
+            ReplayGapKind::StaticChannel => summary.static_channel_gaps += 1,
+            ReplayGapKind::DynamicChannel => summary.dynamic_channel_gaps += 1,
+            ReplayGapKind::Session => summary.session_gaps += 1,
+            ReplayGapKind::IncompleteActivation => summary.incomplete_activation_gaps += 1,
+            ReplayGapKind::Unsupported => summary.unsupported_gaps += 1,
         }
+        gap_fingerprint.update(gap.packet.to_string().as_bytes());
+        gap_fingerprint.update([b':']);
+        gap_fingerprint.update([gap_direction_code(gap.direction)]);
+        gap_fingerprint.update([b':']);
+        gap_fingerprint.update([gap_kind_code(gap.kind)]);
+        gap_fingerprint.update([b':']);
+        gap_fingerprint.update([gap_reason_code(gap.reason)]);
+        gap_fingerprint.update([b':']);
+        gap_fingerprint.update(gap.skipped_bytes.to_string().as_bytes());
+        gap_fingerprint.update([b'\n']);
+    }
+    summary.gap_fingerprint = gap_fingerprint.finalize().into();
+}
+
+const fn gap_direction_code(direction: ReplayDirection) -> u8 {
+    match direction {
+        ReplayDirection::Client => b'C',
+        ReplayDirection::Server => b'S',
+    }
+}
+
+const fn gap_kind_code(kind: ReplayGapKind) -> u8 {
+    match kind {
+        ReplayGapKind::Framing => b'F',
+        ReplayGapKind::TruncatedPdu => b'T',
+        ReplayGapKind::StaticChannel => b'V',
+        ReplayGapKind::DynamicChannel => b'D',
+        ReplayGapKind::Session => b'R',
+        ReplayGapKind::IncompleteActivation => b'A',
+        ReplayGapKind::Unsupported => b'U',
+    }
+}
+
+const fn gap_reason_code(reason: ReplayGapReason) -> u8 {
+    match reason {
+        ReplayGapReason::Framing => b'F',
+        ReplayGapReason::TruncatedPdu => b'T',
+        ReplayGapReason::StaticChannelPdu => b'P',
+        ReplayGapReason::StaticChannelEncode => b'E',
+        ReplayGapReason::StaticChannelDecode => b'D',
+        ReplayGapReason::StaticChannelBulkDecompression => b'B',
+        ReplayGapReason::StaticChannelBitmapSourceLength => b'I',
+        ReplayGapReason::StaticChannelProcessor => b'R',
+        ReplayGapReason::StaticChannelOther => b'O',
+        ReplayGapReason::DynamicChannel => b'V',
+        ReplayGapReason::Session => b'S',
+        ReplayGapReason::IncompleteActivation => b'A',
+        ReplayGapReason::Unsupported => b'U',
+    }
+}
+
+fn session_gap_reason(route: ReplayRoute, error: &SessionErrorKind) -> ReplayGapReason {
+    if route != ReplayRoute::StaticChannel {
+        return ReplayGapReason::Session;
+    }
+    match error {
+        SessionErrorKind::Pdu(_) => ReplayGapReason::StaticChannelPdu,
+        SessionErrorKind::Encode(_) => ReplayGapReason::StaticChannelEncode,
+        SessionErrorKind::Decode(_) => ReplayGapReason::StaticChannelDecode,
+        SessionErrorKind::FastPathBulkDecompression(_) => ReplayGapReason::StaticChannelBulkDecompression,
+        SessionErrorKind::InvalidBitmapSourceLength => ReplayGapReason::StaticChannelBitmapSourceLength,
+        SessionErrorKind::Reason(_) => ReplayGapReason::StaticChannelProcessor,
+        SessionErrorKind::General | SessionErrorKind::Custom | _ => ReplayGapReason::StaticChannelOther,
     }
 }
 
@@ -804,6 +955,7 @@ fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut V
                     packet: packet_at(offset),
                     direction,
                     kind: ReplayGapKind::TruncatedPdu,
+                    reason: ReplayGapReason::TruncatedPdu,
                     skipped_bytes: 0,
                 });
                 break;
@@ -814,6 +966,7 @@ fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut V
                         packet: packet_at(offset),
                         direction,
                         kind: ReplayGapKind::Framing,
+                        reason: ReplayGapReason::Framing,
                         skipped_bytes: 1,
                     });
                     unframed = true;
@@ -1311,6 +1464,88 @@ mod tests {
     }
 
     #[test]
+    fn summarizes_each_gap_once() {
+        let static_channel_gap = ReplayGap {
+            packet: 7,
+            direction: ReplayDirection::Server,
+            kind: ReplayGapKind::StaticChannel,
+            reason: ReplayGapReason::StaticChannelPdu,
+            skipped_bytes: 0,
+        };
+        let report = ReplayReport {
+            events: vec![
+                ReplayEvent {
+                    packet: 1,
+                    direction: ReplayDirection::Client,
+                    action: Action::X224,
+                    route: ReplayRoute::ClientObservation,
+                },
+                ReplayEvent {
+                    packet: 2,
+                    direction: ReplayDirection::Server,
+                    action: Action::FastPath,
+                    route: ReplayRoute::FastPath,
+                },
+            ],
+            gaps: vec![static_channel_gap],
+            lifecycle: ReplayLifecycle::Active,
+            ..ReplayReport::default()
+        };
+        let mut summary = ReplaySummary::default();
+
+        summarize_report(&mut summary, &report);
+
+        assert_eq!(summary.client_pdus, 1);
+        assert_eq!(summary.server_pdus, 1);
+        assert_eq!(summary.static_channel_gaps, 1);
+        assert_eq!(summary.lifecycle, ReplayLifecycle::Active);
+    }
+
+    #[test]
+    fn summarizes_gaps_without_events() {
+        let gap = ReplayGap {
+            packet: 7,
+            direction: ReplayDirection::Server,
+            kind: ReplayGapKind::StaticChannel,
+            reason: ReplayGapReason::StaticChannelPdu,
+            skipped_bytes: 0,
+        };
+        let report = ReplayReport {
+            gaps: vec![gap],
+            ..ReplayReport::default()
+        };
+        let mut summary = ReplaySummary::default();
+
+        summarize_report(&mut summary, &report);
+
+        assert_eq!(summary.static_channel_gaps, 1);
+        assert_eq!(summary.lifecycle, ReplayLifecycle::NeverActivated);
+    }
+
+    #[test]
+    fn gap_fingerprint_identifies_gap_metadata() {
+        let report = ReplayReport {
+            gaps: vec![ReplayGap {
+                packet: 7,
+                direction: ReplayDirection::Server,
+                kind: ReplayGapKind::StaticChannel,
+                reason: ReplayGapReason::StaticChannelPdu,
+                skipped_bytes: 0,
+            }],
+            ..ReplayReport::default()
+        };
+        let mut summary = ReplaySummary::default();
+        summarize_report(&mut summary, &report);
+
+        let mut changed = report;
+        changed.gaps[0].packet = 8;
+        let mut changed_summary = ReplaySummary::default();
+        summarize_report(&mut changed_summary, &changed);
+
+        assert_ne!(summary.gap_fingerprint, changed_summary.gap_fingerprint);
+    }
+
+    #[test]
     fn discovers_and_attaches_recorded_dynamic_channels() {
         let mut router = ReplayRouter::new(activation()).unwrap();
         let report = router.route_plaintext(&Plaintext {
@@ -1628,6 +1863,7 @@ mod tests {
                 packet: 4,
                 direction: ReplayDirection::Server,
                 kind: ReplayGapKind::Unsupported,
+                reason: ReplayGapReason::Unsupported,
                 skipped_bytes: 0,
             }]
         );
@@ -1702,6 +1938,7 @@ mod tests {
                 packet: 6,
                 direction: ReplayDirection::Server,
                 kind: ReplayGapKind::Unsupported,
+                reason: ReplayGapReason::Unsupported,
                 skipped_bytes: 0,
             }]
         );
@@ -1796,6 +2033,7 @@ mod tests {
             packet: 17,
             direction: ReplayDirection::Server,
             kind: ReplayGapKind::IncompleteActivation,
+            reason: ReplayGapReason::IncompleteActivation,
             skipped_bytes: 0,
         }));
     }
@@ -1820,6 +2058,7 @@ mod tests {
                 packet: 9,
                 direction: ReplayDirection::Server,
                 kind: ReplayGapKind::Framing,
+                reason: ReplayGapReason::Framing,
                 skipped_bytes: 1,
             }]
         );

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -532,9 +532,6 @@ impl ReplayRouter {
         };
         if route == ReplayRoute::StaticChannel {
             self.observe_dvc_lifecycle(message, report);
-            if !self.is_drdynvc_message(message) {
-                return Ok((route, false));
-            }
         }
         if route == ReplayRoute::OtherServerMessage {
             return Ok((route, false));
@@ -670,12 +667,6 @@ impl ReplayRouter {
                 });
             }
         }
-    }
-
-    fn is_drdynvc_message(&self, message: &CapturedPdu) -> bool {
-        mcs::decode_send_data_indication(&message.bytes)
-            .ok()
-            .is_some_and(|context| Some(context.channel_id) == self.drdynvc_channel_id)
     }
 
     fn drain_egfx_output<E>(

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -59,6 +59,15 @@ pub enum ReplayDirection {
     Server,
 }
 
+impl core::fmt::Display for ReplayDirection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Client => "client",
+            Self::Server => "server",
+        })
+    }
+}
+
 /// The routing path selected for a captured RDP PDU.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReplayRoute {
@@ -129,6 +138,20 @@ pub enum ReplayGapKind {
     Unsupported,
 }
 
+impl core::fmt::Display for ReplayGapKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Framing => "framing",
+            Self::TruncatedPdu => "truncated-pdu",
+            Self::StaticChannel => "static-channel",
+            Self::DynamicChannel => "dynamic-channel",
+            Self::Session => "session",
+            Self::IncompleteActivation => "incomplete-activation",
+            Self::Unsupported => "unsupported",
+        })
+    }
+}
+
 /// Stable, payload-free reason for a replay gap.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReplayGapReason {
@@ -160,6 +183,47 @@ pub enum ReplayGapReason {
     Unsupported,
 }
 
+impl ReplayGapReason {
+    /// Return the stable category for this reason.
+    pub const fn kind(self) -> ReplayGapKind {
+        match self {
+            Self::Framing => ReplayGapKind::Framing,
+            Self::TruncatedPdu => ReplayGapKind::TruncatedPdu,
+            Self::StaticChannelPdu
+            | Self::StaticChannelEncode
+            | Self::StaticChannelDecode
+            | Self::StaticChannelBulkDecompression
+            | Self::StaticChannelBitmapSourceLength
+            | Self::StaticChannelProcessor
+            | Self::StaticChannelOther => ReplayGapKind::StaticChannel,
+            Self::DynamicChannel => ReplayGapKind::DynamicChannel,
+            Self::Session => ReplayGapKind::Session,
+            Self::IncompleteActivation => ReplayGapKind::IncompleteActivation,
+            Self::Unsupported => ReplayGapKind::Unsupported,
+        }
+    }
+}
+
+impl core::fmt::Display for ReplayGapReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Framing => "framing",
+            Self::TruncatedPdu => "truncated-pdu",
+            Self::StaticChannelPdu => "static-channel-pdu",
+            Self::StaticChannelEncode => "static-channel-encode",
+            Self::StaticChannelDecode => "static-channel-decode",
+            Self::StaticChannelBulkDecompression => "static-channel-bulk-decompression",
+            Self::StaticChannelBitmapSourceLength => "static-channel-bitmap-source-length",
+            Self::StaticChannelProcessor => "static-channel-processor",
+            Self::StaticChannelOther => "static-channel-other",
+            Self::DynamicChannel => "dynamic-channel",
+            Self::Session => "session",
+            Self::IncompleteActivation => "incomplete-activation",
+            Self::Unsupported => "unsupported",
+        })
+    }
+}
+
 /// Terminal activation state observed during a replay.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum ReplayLifecycle {
@@ -172,6 +236,16 @@ pub enum ReplayLifecycle {
     Deactivated,
 }
 
+impl core::fmt::Display for ReplayLifecycle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::NeverActivated => "never-activated",
+            Self::Active => "active",
+            Self::Deactivated => "deactivated",
+        })
+    }
+}
+
 /// A safe, payload-free description of an unreplayable captured message.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReplayGap {
@@ -179,12 +253,17 @@ pub struct ReplayGap {
     pub packet: usize,
     /// Stream direction containing the gap.
     pub direction: ReplayDirection,
-    /// Layer that could not be replayed.
-    pub kind: ReplayGapKind,
     /// Stable reason for the gap without captured payload content.
     pub reason: ReplayGapReason,
     /// Bytes skipped while resynchronizing after a framing error.
     pub skipped_bytes: usize,
+}
+
+impl ReplayGap {
+    /// Return the stable category for this gap.
+    pub const fn kind(self) -> ReplayGapKind {
+        self.reason.kind()
+    }
 }
 
 /// A dynamic channel recovered from a recorded DVC create request.
@@ -478,7 +557,6 @@ impl ReplayRouter {
                 report.gaps.push(ReplayGap {
                     packet,
                     direction: ReplayDirection::Server,
-                    kind: ReplayGapKind::IncompleteActivation,
                     reason: ReplayGapReason::IncompleteActivation,
                     skipped_bytes: 0,
                 });
@@ -491,15 +569,7 @@ impl ReplayRouter {
         } else {
             ReplayLifecycle::NeverActivated
         };
-        report.gaps.sort_by_key(|gap| {
-            (
-                gap.packet,
-                gap_direction_code(gap.direction),
-                gap_kind_code(gap.kind),
-                gap.skipped_bytes,
-                gap_reason_code(gap.reason),
-            )
-        });
+        report.gaps.sort_by_key(gap_sort_key);
         Ok(report)
     }
 
@@ -559,21 +629,15 @@ impl ReplayRouter {
             }
             Err(error) => {
                 let unsupported = route == ReplayRoute::StaticChannel && self.take_unsupported_egfx_codec();
+                let reason = if unsupported {
+                    ReplayGapReason::Unsupported
+                } else {
+                    session_gap_reason(route, error.kind())
+                };
                 report.gaps.push(ReplayGap {
                     packet: message.packet,
                     direction: ReplayDirection::Server,
-                    kind: if unsupported {
-                        ReplayGapKind::Unsupported
-                    } else if route == ReplayRoute::StaticChannel {
-                        ReplayGapKind::StaticChannel
-                    } else {
-                        ReplayGapKind::Session
-                    },
-                    reason: if unsupported {
-                        ReplayGapReason::Unsupported
-                    } else {
-                        session_gap_reason(route, error.kind())
-                    },
+                    reason,
                     skipped_bytes: 0,
                 });
                 Ok((route, false))
@@ -623,7 +687,6 @@ impl ReplayRouter {
             report.gaps.push(ReplayGap {
                 packet: message.packet,
                 direction: message.direction,
-                kind: ReplayGapKind::DynamicChannel,
                 reason: ReplayGapReason::DynamicChannel,
                 skipped_bytes: 0,
             });
@@ -661,7 +724,6 @@ impl ReplayRouter {
                 report.gaps.push(ReplayGap {
                     packet: channel.packet,
                     direction: ReplayDirection::Server,
-                    kind: ReplayGapKind::DynamicChannel,
                     reason: ReplayGapReason::DynamicChannel,
                     skipped_bytes: 0,
                 });
@@ -690,7 +752,6 @@ impl ReplayRouter {
                     report.gaps.push(ReplayGap {
                         packet,
                         direction: ReplayDirection::Server,
-                        kind: ReplayGapKind::Unsupported,
                         reason: ReplayGapReason::Unsupported,
                         skipped_bytes: 0,
                     });
@@ -762,7 +823,6 @@ pub fn prepare_capture(capture: &Capture) -> Result<PreparedReplay, ReplayError>
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),
     };
-    ReplayRouter::new(activation.clone())?;
     Ok(PreparedReplay { activation, plaintext })
 }
 
@@ -785,17 +845,9 @@ fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
     summary.lifecycle = report.lifecycle;
     let mut gap_fingerprint = Sha256::new();
     let mut gaps = report.gaps.iter().collect::<Vec<_>>();
-    gaps.sort_by_key(|gap| {
-        (
-            gap.packet,
-            gap_direction_code(gap.direction),
-            gap_kind_code(gap.kind),
-            gap.skipped_bytes,
-            gap_reason_code(gap.reason),
-        )
-    });
+    gaps.sort_by_key(|gap| gap_sort_key(gap));
     for gap in gaps {
-        match gap.kind {
+        match gap.kind() {
             ReplayGapKind::Framing => summary.framing_gaps += 1,
             ReplayGapKind::TruncatedPdu => summary.truncated_pdu_gaps += 1,
             ReplayGapKind::StaticChannel => summary.static_channel_gaps += 1,
@@ -808,7 +860,7 @@ fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
         gap_fingerprint.update([b':']);
         gap_fingerprint.update([gap_direction_code(gap.direction)]);
         gap_fingerprint.update([b':']);
-        gap_fingerprint.update([gap_kind_code(gap.kind)]);
+        gap_fingerprint.update([gap_kind_code(gap.kind())]);
         gap_fingerprint.update([b':']);
         gap_fingerprint.update([gap_reason_code(gap.reason)]);
         gap_fingerprint.update([b':']);
@@ -816,6 +868,16 @@ fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
         gap_fingerprint.update([b'\n']);
     }
     summary.gap_fingerprint = gap_fingerprint.finalize().into();
+}
+
+const fn gap_sort_key(gap: &ReplayGap) -> (usize, u8, u8, usize, u8) {
+    (
+        gap.packet,
+        gap_direction_code(gap.direction),
+        gap_kind_code(gap.kind()),
+        gap.skipped_bytes,
+        gap_reason_code(gap.reason),
+    )
 }
 
 const fn gap_direction_code(direction: ReplayDirection) -> u8 {
@@ -945,7 +1007,6 @@ fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut V
                 gaps.push(ReplayGap {
                     packet: packet_at(offset),
                     direction,
-                    kind: ReplayGapKind::TruncatedPdu,
                     reason: ReplayGapReason::TruncatedPdu,
                     skipped_bytes: 0,
                 });
@@ -956,7 +1017,6 @@ fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut V
                     gaps.push(ReplayGap {
                         packet: packet_at(offset),
                         direction,
-                        kind: ReplayGapKind::Framing,
                         reason: ReplayGapReason::Framing,
                         skipped_bytes: 1,
                     });
@@ -1359,7 +1419,37 @@ mod tests {
         let messages = framed_stream(&vec![(9, vec![3, 0, 0, 8])], ReplayDirection::Server, &mut gaps);
         assert!(messages.is_empty());
         assert_eq!(gaps[0].packet, 9);
-        assert_eq!(gaps[0].kind, ReplayGapKind::TruncatedPdu);
+        assert_eq!(gaps[0].kind(), ReplayGapKind::TruncatedPdu);
+    }
+
+    #[test]
+    fn derives_gap_kind_from_reason() {
+        for (reason, kind) in [
+            (ReplayGapReason::Framing, ReplayGapKind::Framing),
+            (ReplayGapReason::TruncatedPdu, ReplayGapKind::TruncatedPdu),
+            (ReplayGapReason::StaticChannelPdu, ReplayGapKind::StaticChannel),
+            (ReplayGapReason::StaticChannelEncode, ReplayGapKind::StaticChannel),
+            (ReplayGapReason::StaticChannelDecode, ReplayGapKind::StaticChannel),
+            (
+                ReplayGapReason::StaticChannelBulkDecompression,
+                ReplayGapKind::StaticChannel,
+            ),
+            (
+                ReplayGapReason::StaticChannelBitmapSourceLength,
+                ReplayGapKind::StaticChannel,
+            ),
+            (ReplayGapReason::StaticChannelProcessor, ReplayGapKind::StaticChannel),
+            (ReplayGapReason::StaticChannelOther, ReplayGapKind::StaticChannel),
+            (ReplayGapReason::DynamicChannel, ReplayGapKind::DynamicChannel),
+            (ReplayGapReason::Session, ReplayGapKind::Session),
+            (
+                ReplayGapReason::IncompleteActivation,
+                ReplayGapKind::IncompleteActivation,
+            ),
+            (ReplayGapReason::Unsupported, ReplayGapKind::Unsupported),
+        ] {
+            assert_eq!(reason.kind(), kind);
+        }
     }
 
     #[test]
@@ -1459,7 +1549,6 @@ mod tests {
         let static_channel_gap = ReplayGap {
             packet: 7,
             direction: ReplayDirection::Server,
-            kind: ReplayGapKind::StaticChannel,
             reason: ReplayGapReason::StaticChannelPdu,
             skipped_bytes: 0,
         };
@@ -1497,7 +1586,6 @@ mod tests {
         let gap = ReplayGap {
             packet: 7,
             direction: ReplayDirection::Server,
-            kind: ReplayGapKind::StaticChannel,
             reason: ReplayGapReason::StaticChannelPdu,
             skipped_bytes: 0,
         };
@@ -1519,7 +1607,6 @@ mod tests {
             gaps: vec![ReplayGap {
                 packet: 7,
                 direction: ReplayDirection::Server,
-                kind: ReplayGapKind::StaticChannel,
                 reason: ReplayGapReason::StaticChannelPdu,
                 skipped_bytes: 0,
             }],
@@ -1853,7 +1940,6 @@ mod tests {
             [ReplayGap {
                 packet: 4,
                 direction: ReplayDirection::Server,
-                kind: ReplayGapKind::Unsupported,
                 reason: ReplayGapReason::Unsupported,
                 skipped_bytes: 0,
             }]
@@ -1928,7 +2014,6 @@ mod tests {
             [ReplayGap {
                 packet: 6,
                 direction: ReplayDirection::Server,
-                kind: ReplayGapKind::Unsupported,
                 reason: ReplayGapReason::Unsupported,
                 skipped_bytes: 0,
             }]
@@ -2023,7 +2108,6 @@ mod tests {
         assert!(report.gaps.contains(&ReplayGap {
             packet: 17,
             direction: ReplayDirection::Server,
-            kind: ReplayGapKind::IncompleteActivation,
             reason: ReplayGapReason::IncompleteActivation,
             skipped_bytes: 0,
         }));
@@ -2048,7 +2132,6 @@ mod tests {
             vec![ReplayGap {
                 packet: 9,
                 direction: ReplayDirection::Server,
-                kind: ReplayGapKind::Framing,
                 reason: ReplayGapReason::Framing,
                 skipped_bytes: 1,
             }]

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -844,9 +844,7 @@ fn summarize_report(summary: &mut ReplaySummary, report: &ReplayReport) {
     }
     summary.lifecycle = report.lifecycle;
     let mut gap_fingerprint = Sha256::new();
-    let mut gaps = report.gaps.iter().collect::<Vec<_>>();
-    gaps.sort_by_key(|gap| gap_sort_key(gap));
-    for gap in gaps {
+    for gap in &report.gaps {
         match gap.kind() {
             ReplayGapKind::Framing => summary.framing_gaps += 1,
             ReplayGapKind::TruncatedPdu => summary.truncated_pdu_gaps += 1,

--- a/crates/ironrdp-capture-replay/tests/keylog.rs
+++ b/crates/ironrdp-capture-replay/tests/keylog.rs
@@ -381,3 +381,19 @@ fn reports_invalid_key_log_file() {
     std::fs::remove_file(capture_path).expect("remove synthetic capture");
     std::fs::remove_file(key_log_path).expect("remove synthetic key log");
 }
+
+#[test]
+fn summary_mode_rejects_missing_capture_input() {
+    let output = Command::new(env!("CARGO_BIN_EXE_ironrdp-capture-replay"))
+        .args(["--summary", "missing-capture.pcapng"])
+        .output()
+        .expect("run replay binary");
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).starts_with("replay export failed: failed to read capture"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty());
+}

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -25,7 +25,7 @@ cargo xtask bench replay
 Use `--capture <id>` to run one manifest entry.
 The command never fetches data and fails when a cache entry is missing or its digest does not match the manifest.
 It prints only payload-free outcome categories and verifies every successful replay's routing counters, graphics dimensions, output fingerprint, lifecycle, and exact gap metadata fingerprint.
-Run `cargo xtask bench corpus-fetch` before `cargo xtask ci` when the local corpus cache is cold.
+`cargo xtask ci` fetches and verifies the pinned corpus before replaying it.
 
 The fetch command downloads only the files listed in `crates/ironrdp-bench/corpus.toml` from immutable raw URLs at the manifest's Git commit.
 It requires the cross-platform `curl` command to be available on `PATH`.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -16,6 +16,17 @@ List the pinned capture identifiers, filenames, digests, and upstream scenario i
 cargo xtask bench corpus-list
 ```
 
+Replay every verified cached capture and enforce its qualified expectation with:
+
+```PowerShell
+cargo xtask bench replay
+```
+
+Use `--capture <id>` to run one manifest entry.
+The command never fetches data and fails when a cache entry is missing or its digest does not match the manifest.
+It prints only payload-free outcome categories and verifies every successful replay's routing counters, graphics dimensions, output fingerprint, and enumerated gaps.
+Run `cargo xtask bench corpus-fetch` before `cargo xtask ci` when the local corpus cache is cold.
+
 The fetch command downloads only the files listed in `crates/ironrdp-bench/corpus.toml` from immutable raw URLs at the manifest's Git commit.
 It requires the cross-platform `curl` command to be available on `PATH`.
 It verifies every download and warm-cache entry with the manifest SHA-256 digest before storing files under `bench-data/wireshark-rdp/<revision>/captures`.
@@ -23,5 +34,5 @@ Keep generated benchmark output under `bench-data/benchmark-output`, separate fr
 The ignored `bench-data` directory must never be committed.
 Capture-based commands must work from the verified local cache and must not perform network I/O after this explicit fetch step.
 
-To update the corpus, inspect the upstream capture inventory, revise the manifest revision, inventory, scenario intent metadata, and SHA-256 digests together, then run `cargo xtask bench corpus-fetch`.
+To update the corpus, inspect the upstream capture inventory, revise the manifest revision, inventory, scenario intent metadata, replay expectations, and SHA-256 digests together, then run `cargo xtask bench corpus-fetch` followed by `cargo xtask bench replay`.
 Do not commit captures, TLS key material, decrypted payloads, screenshots, or generated output.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -24,7 +24,7 @@ cargo xtask bench replay
 
 Use `--capture <id>` to run one manifest entry.
 The command never fetches data and fails when a cache entry is missing or its digest does not match the manifest.
-It prints only payload-free outcome categories and verifies every successful replay's routing counters, graphics dimensions, output fingerprint, and enumerated gaps.
+It prints only payload-free outcome categories and verifies every successful replay's routing counters, graphics dimensions, output fingerprint, lifecycle, and exact gap metadata fingerprint.
 Run `cargo xtask bench corpus-fetch` before `cargo xtask ci` when the local corpus cache is cold.
 
 The fetch command downloads only the files listed in `crates/ironrdp-bench/corpus.toml` from immutable raw URLs at the manifest's Git commit.

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -731,6 +731,7 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
         fs::remove_dir_all(directory).expect("remove test directory");
     }
 
+    #[test]
     fn rejects_missing_replay_cache_entry() {
         let capture = parse_corpus(&corpus_toml("accepted-rdp.pcapng"))
             .expect("valid manifest")
@@ -742,7 +743,6 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
 
         assert!(error.to_string().contains("open capture"));
     }
-    #[test]
     #[test]
     fn invalid_download_does_not_install_cache_entry() {
         let directory = test_directory();

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -19,7 +19,6 @@ pub struct Corpus {
     pub revision: String,
     /// Captures and strict replay expectations.
     pub captures: Vec<Capture>,
->>>>>>> a3b87d1e6 (feat: add headless corpus replay)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -41,23 +41,23 @@ pub struct Capture {
 pub struct ReplayExpectation {
     /// Declared outcome category.
     pub outcome: ReplayOutcome,
-    /// Failing replay stage for rejection and unsupported outcomes.
+    /// Failing replay stage for unsupported outcomes.
     pub stage: Option<String>,
-    /// Stable failing replay reason for rejection and unsupported outcomes.
+    /// Stable failing replay reason for unsupported outcomes.
     pub reason: Option<String>,
     /// Exact counters and output identity for completed and partial outcomes.
     pub summary: Option<ReplaySummaryExpectation>,
 }
 
 /// Stable category for a qualified capture replay.
+///
+/// Add a rejected outcome only when the replay decodes protocol rejection evidence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReplayOutcome {
     /// Replay reached a clean completed state.
     Complete,
     /// Replay produced useful output but recorded known gaps.
     Partial,
-    /// The capture records a recognized protocol rejection.
-    Rejected,
     /// The capture requires a replay capability that is not implemented.
     Unsupported,
 }
@@ -137,7 +137,7 @@ pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
         selector.unwrap_or_default()
     );
 
-    let mut outcomes = [0usize; 4];
+    let mut outcomes = [0usize; 3];
     for capture in captures {
         let capture_path = cache_dir.join(&capture.file);
         verify_file(&capture_path, &capture.sha256)
@@ -150,10 +150,9 @@ pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
     }
 
     println!(
-        "Qualified replay outcomes: complete={}, partial={}, rejected={}, unsupported={}",
+        "Qualified replay outcomes: complete={}, partial={}, unsupported={}",
         outcomes[usize::from(ReplayOutcome::Complete)],
         outcomes[usize::from(ReplayOutcome::Partial)],
-        outcomes[usize::from(ReplayOutcome::Rejected)],
         outcomes[usize::from(ReplayOutcome::Unsupported)],
     );
     Ok(())
@@ -185,7 +184,6 @@ impl ReplayOutcome {
         match self {
             Self::Complete => "complete",
             Self::Partial => "partial",
-            Self::Rejected => "rejected",
             Self::Unsupported => "unsupported",
         }
     }
@@ -196,8 +194,7 @@ impl From<ReplayOutcome> for usize {
         match value {
             ReplayOutcome::Complete => 0,
             ReplayOutcome::Partial => 1,
-            ReplayOutcome::Rejected => 2,
-            ReplayOutcome::Unsupported => 3,
+            ReplayOutcome::Unsupported => 2,
         }
     }
 }
@@ -423,12 +420,11 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
     let outcome = match string(value, "outcome", "capture.expect")? {
         "complete" => ReplayOutcome::Complete,
         "partial" => ReplayOutcome::Partial,
-        "rejected" => ReplayOutcome::Rejected,
         "unsupported" => ReplayOutcome::Unsupported,
         outcome => anyhow::bail!("unknown capture replay outcome: {outcome}"),
     };
-    let stage = value.get("stage").and_then(toml::Value::as_str).map(str::to_owned);
-    let reason = value.get("reason").and_then(toml::Value::as_str).map(str::to_owned);
+    let stage = optional_string(value, "stage", "capture.expect")?.map(str::to_owned);
+    let reason = optional_string(value, "reason", "capture.expect")?.map(str::to_owned);
     let summary = value
         .get("summary")
         .map(|value| {
@@ -471,7 +467,7 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
                 );
             }
         }
-        ReplayOutcome::Rejected | ReplayOutcome::Unsupported => {
+        ReplayOutcome::Unsupported => {
             anyhow::ensure!(
                 stage.is_some() && reason.is_some(),
                 "failed replay expectation must declare stage and reason"
@@ -485,6 +481,17 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
         reason,
         summary,
     })
+}
+
+fn optional_string<'a>(table: &'a toml::Table, key: &str, location: &str) -> anyhow::Result<Option<&'a str>> {
+    table
+        .get(key)
+        .map(|value| {
+            value
+                .as_str()
+                .with_context(|| format!("invalid {location}.{key} string"))
+        })
+        .transpose()
 }
 
 fn inspect_cache(path: &Path, capture: &Capture) -> anyhow::Result<CacheState> {
@@ -641,7 +648,7 @@ id = "accepted-rdp"
 file = "{file}"
 sha256 = "{SHA256_ABC}"
 intent = "A direct RDP session accepted by the server."
-expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }}
+expect = {{ outcome = "unsupported", stage = "negotiate", reason = "missing-rdp-state" }}
 "#
         )
     }
@@ -684,6 +691,25 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
 
         assert_eq!(corpus.captures.len(), 1);
         assert_eq!(corpus.captures[0].id, "accepted-rdp");
+    }
+
+    #[test]
+    fn rejects_unobservable_replay_outcome() {
+        let manifest =
+            corpus_toml("accepted-rdp.pcapng").replace(r#"outcome = "unsupported""#, r#"outcome = "rejected""#);
+
+        let error = parse_corpus(&manifest).expect_err("unobservable outcome must fail");
+
+        assert!(error.to_string().contains("unknown capture replay outcome: rejected"));
+    }
+
+    #[test]
+    fn rejects_wrong_typed_optional_replay_field() {
+        let manifest = corpus_toml("accepted-rdp.pcapng").replace(r#"stage = "negotiate""#, "stage = 123");
+
+        let error = parse_corpus(&manifest).expect_err("wrong-typed stage must fail");
+
+        assert!(error.to_string().contains("invalid capture.expect.stage string"));
     }
 
     #[test]
@@ -792,7 +818,7 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
     }
 
     #[test]
-    fn rejects_mismatched_replay_failure() {
+    fn rejects_mismatched_unsupported_replay() {
         let capture = Capture {
             id: "accepted-rdp".to_owned(),
             file: "accepted-rdp.pcapng".to_owned(),

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -14,45 +14,45 @@ const CACHE_ROOT: &str = "bench-data/wireshark-rdp";
 const UPSTREAM_REPOSITORY: &str = "awakecoding/wireshark-rdp";
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Corpus {
+struct Corpus {
     /// Immutable upstream revision that identifies the cached capture set.
-    pub revision: String,
+    revision: String,
     /// Captures and strict replay expectations.
-    pub captures: Vec<Capture>,
+    captures: Vec<Capture>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Capture {
+struct Capture {
     /// Stable manifest identifier.
-    pub id: String,
+    id: String,
     /// Pinned upstream file name.
-    pub file: String,
+    file: String,
     /// Expected SHA-256 digest.
-    pub sha256: String,
+    sha256: String,
     /// Recorded upstream scenario description.
-    pub intent: String,
+    intent: String,
     /// Observed replay behavior for this exact capture revision.
-    pub expect: ReplayExpectation,
+    expect: ReplayExpectation,
 }
 
 /// Strict expected result for one capture replay.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReplayExpectation {
+struct ReplayExpectation {
     /// Declared outcome category.
-    pub outcome: ReplayOutcome,
+    outcome: ReplayOutcome,
     /// Failing replay stage for unsupported outcomes.
-    pub stage: Option<String>,
+    stage: Option<String>,
     /// Stable failing replay reason for unsupported outcomes.
-    pub reason: Option<String>,
+    reason: Option<String>,
     /// Exact counters and output identity for completed and partial outcomes.
-    pub summary: Option<ReplaySummaryExpectation>,
+    summary: Option<ReplaySummaryExpectation>,
 }
 
 /// Stable category for a qualified capture replay.
 ///
 /// Add a rejected outcome only when the replay decodes protocol rejection evidence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ReplayOutcome {
+enum ReplayOutcome {
     /// Replay reached a clean completed state.
     Complete,
     /// Replay produced useful output but recorded known gaps.
@@ -63,9 +63,9 @@ pub enum ReplayOutcome {
 
 /// Expected payload-free counters and output identity for a successful replay.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReplaySummaryExpectation {
+struct ReplaySummaryExpectation {
     /// Exact values keyed by the stable summary field names.
-    pub values: std::collections::BTreeMap<String, String>,
+    values: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -109,6 +109,7 @@ pub fn corpus_fetch(sh: &Shell) -> anyhow::Result<()> {
         install_capture(&temporary_path, &cache_path)?;
         println!("Fetched and verified: {}", capture.file);
     }
+    remove_stale_corpus_revisions(&project_root().join(CACHE_ROOT), &corpus.revision)?;
 
     Ok(())
 }
@@ -136,7 +137,9 @@ pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
         selector.unwrap_or_default()
     );
 
-    let mut outcomes = [0usize; 3];
+    let mut complete = 0;
+    let mut partial = 0;
+    let mut unsupported = 0;
     for capture in captures {
         let capture_path = cache_dir.join(&capture.file);
         verify_file(&capture_path, &capture.sha256)
@@ -144,15 +147,17 @@ pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
         let observed = run_headless_replay(&capture_path)?;
         validate_replay_expectation(capture, &observed)?;
         let outcome = observed.outcome()?;
-        outcomes[usize::from(outcome)] += 1;
+        match outcome {
+            ReplayOutcome::Complete => complete += 1,
+            ReplayOutcome::Partial => partial += 1,
+            ReplayOutcome::Unsupported => unsupported += 1,
+        }
         println!("{}: {}", capture.id, outcome.name());
     }
 
     println!(
         "Qualified replay outcomes: complete={}, partial={}, unsupported={}",
-        outcomes[usize::from(ReplayOutcome::Complete)],
-        outcomes[usize::from(ReplayOutcome::Partial)],
-        outcomes[usize::from(ReplayOutcome::Unsupported)],
+        complete, partial, unsupported,
     );
     Ok(())
 }
@@ -184,16 +189,6 @@ impl ReplayOutcome {
             Self::Complete => "complete",
             Self::Partial => "partial",
             Self::Unsupported => "unsupported",
-        }
-    }
-}
-
-impl From<ReplayOutcome> for usize {
-    fn from(value: ReplayOutcome) -> Self {
-        match value {
-            ReplayOutcome::Complete => 0,
-            ReplayOutcome::Partial => 1,
-            ReplayOutcome::Unsupported => 2,
         }
     }
 }
@@ -319,7 +314,7 @@ fn is_unsupported_reason(reason: &str) -> bool {
 }
 
 /// Load and validate the pinned benchmark corpus manifest.
-pub fn load_corpus() -> anyhow::Result<Corpus> {
+fn load_corpus() -> anyhow::Result<Corpus> {
     let path = project_root().join(MANIFEST_PATH);
     let contents = fs::read_to_string(&path).with_context(|| format!("read corpus manifest: {}", path.display()))?;
     parse_corpus(&contents).with_context(|| format!("validate corpus manifest: {}", path.display()))
@@ -464,8 +459,15 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
                     summary_lifecycle(summary) == Some("active") && !summary_has_gaps(summary),
                     "complete replay expectation must end active without gaps"
                 );
+            } else {
+                let summary = summary.as_ref().expect("partial replay summary is required");
+                anyhow::ensure!(
+                    summary_lifecycle(summary) != Some("active") || summary_has_gaps(summary),
+                    "partial replay expectation must have gaps or not end active"
+                );
             }
         }
+
         ReplayOutcome::Unsupported => {
             anyhow::ensure!(
                 stage.is_some() && reason.is_some(),
@@ -480,6 +482,28 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
         reason,
         summary,
     })
+}
+
+fn remove_stale_corpus_revisions(cache_root: &Path, revision: &str) -> anyhow::Result<()> {
+    for entry in
+        fs::read_dir(cache_root).with_context(|| format!("read corpus cache root: {}", cache_root.display()))?
+    {
+        let entry = entry.with_context(|| format!("read corpus cache root: {}", cache_root.display()))?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if file_name != revision
+            && is_lower_hex(&file_name, 40)
+            && entry
+                .file_type()
+                .with_context(|| format!("inspect corpus cache entry: {}", entry.path().display()))?
+                .is_dir()
+        {
+            fs::remove_dir_all(entry.path())
+                .with_context(|| format!("remove stale corpus cache revision: {}", entry.path().display()))?;
+        }
+    }
+
+    Ok(())
 }
 
 fn optional_string<'a>(table: &'a toml::Table, key: &str, location: &str) -> anyhow::Result<Option<&'a str>> {
@@ -898,5 +922,50 @@ summary = {{ {values} }}
                 .to_string()
                 .contains("complete replay expectation must end active without gaps")
         );
+    }
+
+    #[test]
+    fn rejects_partial_expectation_without_gaps() {
+        let summary = summary("active", 0);
+        let values = SUMMARY_KEYS
+            .iter()
+            .map(|key| {
+                let value = summary.values.get(*key).expect("partial summary field");
+                format!("{key} = \"{value}\"")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = format!(
+            r#"
+outcome = "partial"
+summary = {{ {values} }}
+"#
+        );
+        let expectation = toml::from_str::<toml::Table>(&manifest).expect("valid expectation TOML");
+
+        let error = parse_replay_expectation(&expectation).expect_err("clean partial must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("partial replay expectation must have gaps or not end active")
+        );
+    }
+
+    #[test]
+    fn removes_stale_corpus_revision_directories() {
+        let directory = test_directory();
+        let current = "683505a753dfd7a2b27713b3a21e9a6951abacc4";
+        let stale = "0000000000000000000000000000000000000000";
+        fs::create_dir(directory.join(current)).expect("create current revision");
+        fs::create_dir(directory.join(stale)).expect("create stale revision");
+        fs::create_dir(directory.join("unexpected")).expect("create unrelated cache entry");
+
+        remove_stale_corpus_revisions(&directory, current).expect("prune stale revision");
+
+        assert!(directory.join(current).exists());
+        assert!(!directory.join(stale).exists());
+        assert!(directory.join("unexpected").exists());
+        fs::remove_dir_all(directory).expect("remove test directory");
     }
 }

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::Context as _;
 use sha2::{Digest as _, Sha256};
@@ -12,18 +13,60 @@ const MANIFEST_PATH: &str = "crates/ironrdp-bench/corpus.toml";
 const CACHE_ROOT: &str = "bench-data/wireshark-rdp";
 const UPSTREAM_REPOSITORY: &str = "awakecoding/wireshark-rdp";
 
-#[derive(Debug)]
-struct Corpus {
-    revision: String,
-    captures: Vec<Capture>,
+#[derive(Debug, Eq, PartialEq)]
+pub struct Corpus {
+    /// Immutable upstream revision that identifies the cached capture set.
+    pub revision: String,
+    /// Captures and strict replay expectations.
+    pub captures: Vec<Capture>,
+>>>>>>> a3b87d1e6 (feat: add headless corpus replay)
 }
 
-#[derive(Debug)]
-struct Capture {
-    id: String,
-    file: String,
-    sha256: String,
-    intent: String,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Capture {
+    /// Stable manifest identifier.
+    pub id: String,
+    /// Pinned upstream file name.
+    pub file: String,
+    /// Expected SHA-256 digest.
+    pub sha256: String,
+    /// Recorded upstream scenario description.
+    pub intent: String,
+    /// Observed replay behavior for this exact capture revision.
+    pub expect: ReplayExpectation,
+}
+
+/// Strict expected result for one capture replay.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplayExpectation {
+    /// Declared outcome category.
+    pub outcome: ReplayOutcome,
+    /// Failing replay stage for rejection and unsupported outcomes.
+    pub stage: Option<String>,
+    /// Stable failing replay reason for rejection and unsupported outcomes.
+    pub reason: Option<String>,
+    /// Exact counters and output identity for completed and partial outcomes.
+    pub summary: Option<ReplaySummaryExpectation>,
+}
+
+/// Stable category for a qualified capture replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReplayOutcome {
+    /// Replay reached a clean completed state.
+    Complete,
+    /// Replay produced useful output but recorded known gaps.
+    Partial,
+    /// The capture records a recognized protocol rejection.
+    Rejected,
+    /// The capture requires a replay capability that is not implemented.
+    Unsupported,
+}
+
+/// Expected payload-free counters and output identity for a successful replay.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplaySummaryExpectation {
+    /// Exact values keyed by the stable summary field names.
+    pub values: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -76,7 +119,200 @@ pub fn corpus_list() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn load_corpus() -> anyhow::Result<Corpus> {
+/// Replay verified cached captures and enforce their qualified expectations.
+pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
+    let corpus = load_corpus()?;
+    let cache_dir = project_root().join(CACHE_ROOT).join(&corpus.revision).join("captures");
+    let captures = match selector {
+        Some(selector) => corpus
+            .captures
+            .iter()
+            .filter(|capture| capture.id == selector)
+            .collect::<Vec<_>>(),
+        None => corpus.captures.iter().collect(),
+    };
+    anyhow::ensure!(
+        !captures.is_empty(),
+        "unknown benchmark capture selector: {}",
+        selector.unwrap_or_default()
+    );
+
+    let mut outcomes = [0usize; 4];
+    for capture in captures {
+        let capture_path = cache_dir.join(&capture.file);
+        verify_file(&capture_path, &capture.sha256)
+            .with_context(|| format!("verify cached benchmark capture: {}", capture.file))?;
+        let observed = run_headless_replay(&capture_path)?;
+        validate_replay_expectation(capture, &observed)?;
+        outcomes[usize::from(observed.outcome())] += 1;
+        println!("{}: {}", capture.id, observed.outcome().name());
+    }
+
+    println!(
+        "Qualified replay outcomes: complete={}, partial={}, rejected={}, unsupported={}",
+        outcomes[usize::from(ReplayOutcome::Complete)],
+        outcomes[usize::from(ReplayOutcome::Partial)],
+        outcomes[usize::from(ReplayOutcome::Rejected)],
+        outcomes[usize::from(ReplayOutcome::Unsupported)],
+    );
+    Ok(())
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum ObservedReplay {
+    Success(ReplaySummaryExpectation),
+    Failure { stage: String, reason: String },
+}
+
+impl ObservedReplay {
+    fn outcome(&self) -> ReplayOutcome {
+        match self {
+            Self::Success(summary) if summary_has_gaps(summary) => ReplayOutcome::Partial,
+            Self::Success(_) => ReplayOutcome::Complete,
+            Self::Failure { reason, .. } if is_unsupported_reason(reason) => ReplayOutcome::Unsupported,
+            Self::Failure { .. } => ReplayOutcome::Rejected,
+        }
+    }
+}
+
+impl ReplayOutcome {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Partial => "partial",
+            Self::Rejected => "rejected",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+impl From<ReplayOutcome> for usize {
+    fn from(value: ReplayOutcome) -> Self {
+        match value {
+            ReplayOutcome::Complete => 0,
+            ReplayOutcome::Partial => 1,
+            ReplayOutcome::Rejected => 2,
+            ReplayOutcome::Unsupported => 3,
+        }
+    }
+}
+
+fn run_headless_replay(capture: &Path) -> anyhow::Result<ObservedReplay> {
+    let output = Command::new(env!("CARGO"))
+        .current_dir(project_root())
+        .args([
+            "run",
+            "--quiet",
+            "--locked",
+            "-p",
+            "ironrdp-capture-replay",
+            "--bin",
+            "ironrdp-capture-replay",
+            "--",
+        ])
+        .arg("--summary")
+        .arg(capture)
+        .output()
+        .with_context(|| format!("run headless replay: {}", capture.display()))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "headless replay command failed for {}: {}",
+        capture.display(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    parse_headless_summary(&String::from_utf8(output.stdout).context("headless replay output is not UTF-8")?)
+}
+
+fn parse_headless_summary(output: &str) -> anyhow::Result<ObservedReplay> {
+    let line = output.lines().filter(|line| !line.is_empty()).collect::<Vec<_>>();
+    anyhow::ensure!(line.len() == 1, "headless replay must emit exactly one summary line");
+    let mut fields = std::collections::BTreeMap::new();
+    for field in line[0].split('\t') {
+        let (key, value) = field.split_once('=').context("invalid headless replay summary field")?;
+        anyhow::ensure!(
+            fields.insert(key, value).is_none(),
+            "duplicate headless replay summary field: {key}"
+        );
+    }
+    match fields.remove("status") {
+        Some("ok") => {
+            anyhow::ensure!(
+                fields.len() == SUMMARY_KEYS.len(),
+                "headless replay summary has unexpected fields"
+            );
+            let mut values = std::collections::BTreeMap::new();
+            for key in SUMMARY_KEYS {
+                let output_key = key.replace('_', "-");
+                let value = fields
+                    .remove(output_key.as_str())
+                    .context("headless replay summary is missing a field")?;
+                values.insert((*key).to_owned(), value.to_owned());
+            }
+            Ok(ObservedReplay::Success(ReplaySummaryExpectation { values }))
+        }
+        Some("error") => {
+            let stage = fields.remove("stage").context("headless replay failure has no stage")?;
+            let reason = fields
+                .remove("reason")
+                .context("headless replay failure has no reason")?;
+            anyhow::ensure!(fields.is_empty(), "headless replay failure has unexpected fields");
+            Ok(ObservedReplay::Failure {
+                stage: stage.to_owned(),
+                reason: reason.to_owned(),
+            })
+        }
+        Some(status) => anyhow::bail!("unknown headless replay status: {status}"),
+        None => anyhow::bail!("headless replay summary has no status"),
+    }
+}
+
+fn validate_replay_expectation(capture: &Capture, observed: &ObservedReplay) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        capture.expect.outcome == observed.outcome(),
+        "replay outcome mismatch for {}: expected {}, got {}",
+        capture.id,
+        capture.expect.outcome.name(),
+        observed.outcome().name()
+    );
+    match (capture.expect.summary.as_ref(), observed) {
+        (Some(expected), ObservedReplay::Success(actual)) => anyhow::ensure!(
+            expected == actual,
+            "replay summary mismatch for {}: update the qualified manifest explicitly",
+            capture.id
+        ),
+        (None, ObservedReplay::Failure { stage, reason }) => anyhow::ensure!(
+            capture.expect.stage.as_deref() == Some(stage) && capture.expect.reason.as_deref() == Some(reason),
+            "replay failure mismatch for {}: expected {}:{}, got {stage}:{reason}",
+            capture.id,
+            capture.expect.stage.as_deref().unwrap_or_default(),
+            capture.expect.reason.as_deref().unwrap_or_default(),
+        ),
+        _ => anyhow::bail!("replay expectation shape mismatch for {}", capture.id),
+    }
+    Ok(())
+}
+
+fn summary_has_gaps(summary: &ReplaySummaryExpectation) -> bool {
+    SUMMARY_KEYS[13..]
+        .iter()
+        .any(|key| summary.values.get(*key).is_some_and(|value| value != "0"))
+}
+
+fn is_unsupported_reason(reason: &str) -> bool {
+    matches!(
+        reason,
+        "unsupported-transport"
+            | "standard-security"
+            | "unsupported-tls"
+            | "missing-tunneled-tls-secret"
+            | "tls-key-update"
+            | "missing-drdynvc-channel"
+            | "dynamic-channel-attachment"
+    )
+}
+
+/// Load and validate the pinned benchmark corpus manifest.
+pub fn load_corpus() -> anyhow::Result<Corpus> {
     let path = project_root().join(MANIFEST_PATH);
     let contents = fs::read_to_string(&path).with_context(|| format!("read corpus manifest: {}", path.display()))?;
     parse_corpus(&contents).with_context(|| format!("validate corpus manifest: {}", path.display()))
@@ -111,7 +347,7 @@ fn parse_corpus(contents: &str) -> anyhow::Result<Corpus> {
 
     for capture in captures {
         let capture = capture.as_table().context("capture entry must be a TOML table")?;
-        ensure_allowed_keys(capture, &["id", "file", "sha256", "intent"], "capture")?;
+        ensure_allowed_keys(capture, &["id", "file", "sha256", "intent", "expect"], "capture")?;
 
         let id = string(capture, "id", "capture")?.to_owned();
         anyhow::ensure!(is_identifier(&id), "invalid capture identifier: {id}");
@@ -131,17 +367,103 @@ fn parse_corpus(contents: &str) -> anyhow::Result<Corpus> {
         let intent = string(capture, "intent", "capture")?.to_owned();
         anyhow::ensure!(!intent.is_empty(), "capture intent must not be empty: {file}");
 
+        let expect = parse_replay_expectation(table(capture, "expect", "capture")?)?;
         parsed_captures.push(Capture {
             id,
             file,
             sha256,
             intent,
+            expect,
         });
     }
 
     Ok(Corpus {
         revision,
         captures: parsed_captures,
+    })
+}
+
+const SUMMARY_KEYS: &[&str] = &[
+    "client_pdus",
+    "server_pdus",
+    "connection_pdus",
+    "client_observation_pdus",
+    "fast_path_pdus",
+    "io_channel_pdus",
+    "message_channel_pdus",
+    "static_channel_pdus",
+    "other_server_message_pdus",
+    "graphics_updates",
+    "final_dimensions",
+    "fingerprint",
+    "framing_gaps",
+    "truncated_pdu_gaps",
+    "static_channel_gaps",
+    "dynamic_channel_gaps",
+    "session_gaps",
+    "incomplete_activation_gaps",
+    "unsupported_gaps",
+];
+
+fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpectation> {
+    ensure_allowed_keys(value, &["outcome", "stage", "reason", "summary"], "capture.expect")?;
+    let outcome = match string(value, "outcome", "capture.expect")? {
+        "complete" => ReplayOutcome::Complete,
+        "partial" => ReplayOutcome::Partial,
+        "rejected" => ReplayOutcome::Rejected,
+        "unsupported" => ReplayOutcome::Unsupported,
+        outcome => anyhow::bail!("unknown capture replay outcome: {outcome}"),
+    };
+    let stage = value.get("stage").and_then(toml::Value::as_str).map(str::to_owned);
+    let reason = value.get("reason").and_then(toml::Value::as_str).map(str::to_owned);
+    let summary = value
+        .get("summary")
+        .map(|value| {
+            let value = value
+                .as_table()
+                .context("capture.expect.summary must be a TOML table")?;
+            ensure_allowed_keys(value, SUMMARY_KEYS, "capture.expect.summary")?;
+            anyhow::ensure!(
+                value.len() == SUMMARY_KEYS.len(),
+                "capture.expect.summary must declare every replay summary field"
+            );
+            let mut values = std::collections::BTreeMap::new();
+            for key in SUMMARY_KEYS {
+                let value = value.get(*key).context("missing replay summary field")?;
+                let value = match value {
+                    toml::Value::Integer(value) => value.to_string(),
+                    toml::Value::String(value) => value.clone(),
+                    _ => anyhow::bail!("invalid replay summary field: {key}"),
+                };
+                values.insert((*key).to_owned(), value);
+            }
+            Ok(ReplaySummaryExpectation { values })
+        })
+        .transpose()?;
+    match outcome {
+        ReplayOutcome::Complete | ReplayOutcome::Partial => {
+            anyhow::ensure!(
+                stage.is_none() && reason.is_none(),
+                "successful replay expectation cannot declare stage or reason"
+            );
+            anyhow::ensure!(
+                summary.is_some(),
+                "successful replay expectation must declare a summary"
+            );
+        }
+        ReplayOutcome::Rejected | ReplayOutcome::Unsupported => {
+            anyhow::ensure!(
+                stage.is_some() && reason.is_some(),
+                "failed replay expectation must declare stage and reason"
+            );
+            anyhow::ensure!(summary.is_none(), "failed replay expectation cannot declare a summary");
+        }
+    }
+    Ok(ReplayExpectation {
+        outcome,
+        stage,
+        reason,
+        summary,
     })
 }
 
@@ -299,6 +621,7 @@ id = "accepted-rdp"
 file = "{file}"
 sha256 = "{SHA256_ABC}"
 intent = "A direct RDP session accepted by the server."
+expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-state" }}
 "#
         )
     }
@@ -369,6 +692,18 @@ intent = "A direct RDP session accepted by the server."
         fs::remove_dir_all(directory).expect("remove test directory");
     }
 
+    fn rejects_missing_replay_cache_entry() {
+        let capture = parse_corpus(&corpus_toml("accepted-rdp.pcapng"))
+            .expect("valid manifest")
+            .captures
+            .pop()
+            .expect("one capture");
+        let error = verify_file(Path::new("missing-benchmark-capture.pcapng"), &capture.sha256)
+            .expect_err("missing replay cache entry must fail");
+
+        assert!(error.to_string().contains("open capture"));
+    }
+    #[test]
     #[test]
     fn invalid_download_does_not_install_cache_entry() {
         let directory = test_directory();
@@ -408,5 +743,36 @@ intent = "A direct RDP session accepted by the server."
             format_list(&corpus),
             format!("accepted-rdp\taccepted-rdp.pcapng\t{SHA256_ABC}\tA direct RDP session accepted by the server.\n")
         );
+    }
+
+    #[test]
+    fn rejects_headless_summary_with_missing_fields() {
+        let error = parse_headless_summary("status=ok\tclient-pdus=1\n").expect_err("incomplete summary must fail");
+
+        assert!(error.to_string().contains("unexpected fields"));
+    }
+
+    #[test]
+    fn rejects_mismatched_replay_failure() {
+        let capture = Capture {
+            id: "accepted-rdp".to_owned(),
+            file: "accepted-rdp.pcapng".to_owned(),
+            sha256: SHA256_ABC.to_owned(),
+            intent: "A direct RDP session accepted by the server.".to_owned(),
+            expect: ReplayExpectation {
+                outcome: ReplayOutcome::Rejected,
+                stage: Some("negotiate".to_owned()),
+                reason: Some("missing-rdp-state".to_owned()),
+                summary: None,
+            },
+        };
+        let observed = ObservedReplay::Failure {
+            stage: "decrypt".to_owned(),
+            reason: "missing-tls-secret".to_owned(),
+        };
+
+        let error = validate_replay_expectation(&capture, &observed).expect_err("mismatched failure must fail");
+
+        assert!(error.to_string().contains("replay failure mismatch"));
     }
 }

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -144,8 +144,9 @@ pub fn corpus_replay(selector: Option<&str>) -> anyhow::Result<()> {
             .with_context(|| format!("verify cached benchmark capture: {}", capture.file))?;
         let observed = run_headless_replay(&capture_path)?;
         validate_replay_expectation(capture, &observed)?;
-        outcomes[usize::from(observed.outcome())] += 1;
-        println!("{}: {}", capture.id, observed.outcome().name());
+        let outcome = observed.outcome()?;
+        outcomes[usize::from(outcome)] += 1;
+        println!("{}: {}", capture.id, outcome.name());
     }
 
     println!(
@@ -165,12 +166,16 @@ enum ObservedReplay {
 }
 
 impl ObservedReplay {
-    fn outcome(&self) -> ReplayOutcome {
+    fn outcome(&self) -> anyhow::Result<ReplayOutcome> {
         match self {
-            Self::Success(summary) if summary_has_gaps(summary) => ReplayOutcome::Partial,
-            Self::Success(_) => ReplayOutcome::Complete,
-            Self::Failure { reason, .. } if is_unsupported_reason(reason) => ReplayOutcome::Unsupported,
-            Self::Failure { .. } => ReplayOutcome::Rejected,
+            Self::Success(summary) if summary_has_gaps(summary) || summary_lifecycle(summary) != Some("active") => {
+                Ok(ReplayOutcome::Partial)
+            }
+            Self::Success(_) => Ok(ReplayOutcome::Complete),
+            Self::Failure { reason, .. } if is_unsupported_reason(reason) => Ok(ReplayOutcome::Unsupported),
+            Self::Failure { stage, reason } => anyhow::bail!(
+                "unqualified headless replay failure: {stage}:{reason}; add explicit support or classify it as unsupported"
+            ),
         }
     }
 }
@@ -268,11 +273,11 @@ fn parse_headless_summary(output: &str) -> anyhow::Result<ObservedReplay> {
 
 fn validate_replay_expectation(capture: &Capture, observed: &ObservedReplay) -> anyhow::Result<()> {
     anyhow::ensure!(
-        capture.expect.outcome == observed.outcome(),
+        capture.expect.outcome == observed.outcome()?,
         "replay outcome mismatch for {}: expected {}, got {}",
         capture.id,
         capture.expect.outcome.name(),
-        observed.outcome().name()
+        observed.outcome()?.name()
     );
     match (capture.expect.summary.as_ref(), observed) {
         (Some(expected), ObservedReplay::Success(actual)) => anyhow::ensure!(
@@ -293,9 +298,14 @@ fn validate_replay_expectation(capture: &Capture, observed: &ObservedReplay) -> 
 }
 
 fn summary_has_gaps(summary: &ReplaySummaryExpectation) -> bool {
-    SUMMARY_KEYS[13..]
+    SUMMARY_KEYS
         .iter()
+        .filter(|key| key.ends_with("_gaps"))
         .any(|key| summary.values.get(*key).is_some_and(|value| value != "0"))
+}
+
+fn summary_lifecycle(summary: &ReplaySummaryExpectation) -> Option<&str> {
+    summary.values.get("lifecycle").map(String::as_str)
 }
 
 fn is_unsupported_reason(reason: &str) -> bool {
@@ -305,6 +315,7 @@ fn is_unsupported_reason(reason: &str) -> bool {
             | "standard-security"
             | "unsupported-tls"
             | "missing-tunneled-tls-secret"
+            | "missing-rdp-state"
             | "tls-key-update"
             | "missing-drdynvc-channel"
             | "dynamic-channel-attachment"
@@ -396,6 +407,7 @@ const SUMMARY_KEYS: &[&str] = &[
     "graphics_updates",
     "final_dimensions",
     "fingerprint",
+    "lifecycle",
     "framing_gaps",
     "truncated_pdu_gaps",
     "static_channel_gaps",
@@ -403,6 +415,7 @@ const SUMMARY_KEYS: &[&str] = &[
     "session_gaps",
     "incomplete_activation_gaps",
     "unsupported_gaps",
+    "gap_fingerprint",
 ];
 
 fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpectation> {
@@ -450,6 +463,13 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
                 summary.is_some(),
                 "successful replay expectation must declare a summary"
             );
+            if outcome == ReplayOutcome::Complete {
+                let summary = summary.as_ref().expect("complete replay summary is required");
+                anyhow::ensure!(
+                    summary_lifecycle(summary) == Some("active") && !summary_has_gaps(summary),
+                    "complete replay expectation must end active without gaps"
+                );
+            }
         }
         ReplayOutcome::Rejected | ReplayOutcome::Unsupported => {
             anyhow::ensure!(
@@ -626,6 +646,25 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
         )
     }
 
+    fn summary(lifecycle: &str, static_channel_gaps: usize) -> ReplaySummaryExpectation {
+        let values = SUMMARY_KEYS
+            .iter()
+            .map(|key| {
+                let value = match *key {
+                    "lifecycle" => lifecycle.to_owned(),
+                    "static_channel_gaps" => static_channel_gaps.to_string(),
+                    "final_dimensions" => "-".to_owned(),
+                    "fingerprint" | "gap_fingerprint" => {
+                        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned()
+                    }
+                    _ => "0".to_owned(),
+                };
+                ((*key).to_owned(), value)
+            })
+            .collect();
+        ReplaySummaryExpectation { values }
+    }
+
     fn test_directory() -> PathBuf {
         let directory = std::env::temp_dir().join(format!(
             "ironrdp-xtask-bench-{}-{}",
@@ -760,7 +799,7 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
             sha256: SHA256_ABC.to_owned(),
             intent: "A direct RDP session accepted by the server.".to_owned(),
             expect: ReplayExpectation {
-                outcome: ReplayOutcome::Rejected,
+                outcome: ReplayOutcome::Unsupported,
                 stage: Some("negotiate".to_owned()),
                 reason: Some("missing-rdp-state".to_owned()),
                 summary: None,
@@ -768,11 +807,71 @@ expect = {{ outcome = "rejected", stage = "negotiate", reason = "missing-rdp-sta
         };
         let observed = ObservedReplay::Failure {
             stage: "decrypt".to_owned(),
-            reason: "missing-tls-secret".to_owned(),
+            reason: "standard-security".to_owned(),
         };
 
         let error = validate_replay_expectation(&capture, &observed).expect_err("mismatched failure must fail");
 
         assert!(error.to_string().contains("replay failure mismatch"));
+    }
+
+    #[test]
+    fn classifies_missing_rdp_state_as_unsupported() {
+        let observed = ObservedReplay::Failure {
+            stage: "negotiate".to_owned(),
+            reason: "missing-rdp-state".to_owned(),
+        };
+
+        assert_eq!(
+            observed.outcome().expect("known limitation"),
+            ReplayOutcome::Unsupported
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_replay_failure_classification() {
+        let observed = ObservedReplay::Failure {
+            stage: "route".to_owned(),
+            reason: "unexpected-error".to_owned(),
+        };
+
+        let error = observed.outcome().expect_err("unknown failure must not be classified");
+
+        assert!(error.to_string().contains("unqualified headless replay failure"));
+    }
+
+    #[test]
+    fn classifies_clean_never_activated_replay_as_partial() {
+        let observed = ObservedReplay::Success(summary("never-activated", 0));
+
+        assert_eq!(observed.outcome().expect("valid summary"), ReplayOutcome::Partial);
+    }
+
+    #[test]
+    fn rejects_complete_expectation_with_gaps() {
+        let summary = summary("active", 1);
+        let values = SUMMARY_KEYS
+            .iter()
+            .map(|key| {
+                let value = summary.values.get(*key).expect("complete summary field");
+                format!("{key} = \"{value}\"")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = format!(
+            r#"
+outcome = "complete"
+summary = {{ {values} }}
+"#
+        );
+        let expectation = toml::from_str::<toml::Table>(&manifest).expect("valid expectation TOML");
+
+        let error = parse_replay_expectation(&expectation).expect_err("gapped completion must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("complete replay expectation must end active without gaps")
+        );
     }
 }

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -109,8 +109,6 @@ pub fn corpus_fetch(sh: &Shell) -> anyhow::Result<()> {
         install_capture(&temporary_path, &cache_path)?;
         println!("Fetched and verified: {}", capture.file);
     }
-    remove_stale_corpus_revisions(&project_root().join(CACHE_ROOT), &corpus.revision)?;
-
     Ok(())
 }
 
@@ -482,28 +480,6 @@ fn parse_replay_expectation(value: &toml::Table) -> anyhow::Result<ReplayExpecta
         reason,
         summary,
     })
-}
-
-fn remove_stale_corpus_revisions(cache_root: &Path, revision: &str) -> anyhow::Result<()> {
-    for entry in
-        fs::read_dir(cache_root).with_context(|| format!("read corpus cache root: {}", cache_root.display()))?
-    {
-        let entry = entry.with_context(|| format!("read corpus cache root: {}", cache_root.display()))?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_string_lossy();
-        if file_name != revision
-            && is_lower_hex(&file_name, 40)
-            && entry
-                .file_type()
-                .with_context(|| format!("inspect corpus cache entry: {}", entry.path().display()))?
-                .is_dir()
-        {
-            fs::remove_dir_all(entry.path())
-                .with_context(|| format!("remove stale corpus cache revision: {}", entry.path().display()))?;
-        }
-    }
-
-    Ok(())
 }
 
 fn optional_string<'a>(table: &'a toml::Table, key: &str, location: &str) -> anyhow::Result<Option<&'a str>> {
@@ -950,22 +926,5 @@ summary = {{ {values} }}
                 .to_string()
                 .contains("partial replay expectation must have gaps or not end active")
         );
-    }
-
-    #[test]
-    fn removes_stale_corpus_revision_directories() {
-        let directory = test_directory();
-        let current = "683505a753dfd7a2b27713b3a21e9a6951abacc4";
-        let stale = "0000000000000000000000000000000000000000";
-        fs::create_dir(directory.join(current)).expect("create current revision");
-        fs::create_dir(directory.join(stale)).expect("create stale revision");
-        fs::create_dir(directory.join("unexpected")).expect("create unrelated cache entry");
-
-        remove_stale_corpus_revisions(&directory, current).expect("prune stale revision");
-
-        assert!(directory.join(current).exists());
-        assert!(!directory.join(stale).exists());
-        assert!(directory.join("unexpected").exists());
-        fs::remove_dir_all(directory).expect("remove test directory");
     }
 }

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -12,6 +12,8 @@ TASKS:
   bootstrap               Install all requirements for development
   bench corpus-fetch      Fetch and verify the pinned benchmark capture corpus
   bench corpus-list       List pinned benchmark capture corpus metadata
+  bench replay [--capture <ID>]
+                          Replay verified cached benchmark captures
   check fmt               Check formatting
   check lints             Check lints
   check locks             Check for dirty or staged lock files not yet committed
@@ -90,6 +92,9 @@ pub enum Action {
     Bootstrap,
     BenchCorpusFetch,
     BenchCorpusList,
+    BenchReplay {
+        capture: Option<String>,
+    },
     CheckFmt,
     CheckLints,
     CheckLocks,
@@ -156,6 +161,9 @@ pub fn parse_args() -> anyhow::Result<Args> {
             Some("bench") => match args.subcommand()?.as_deref() {
                 Some("corpus-fetch") => Action::BenchCorpusFetch,
                 Some("corpus-list") => Action::BenchCorpusList,
+                Some("replay") => Action::BenchReplay {
+                    capture: args.opt_value_from_str("--capture")?,
+                },
                 Some(unknown) => anyhow::bail!("unknown bench action: {unknown}"),
                 None => Action::ShowHelp,
             },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> anyhow::Result<()> {
         }
         Action::BenchCorpusFetch => bench::corpus_fetch(&sh)?,
         Action::BenchCorpusList => bench::corpus_list()?,
+        Action::BenchReplay { capture } => bench::corpus_replay(capture.as_deref())?,
         Action::CheckFmt => check::fmt(&sh)?,
         Action::CheckLints => check::lints(&sh)?,
         Action::CheckLocks => check::lock_files(&sh)?,
@@ -104,6 +105,7 @@ fn main() -> anyhow::Result<()> {
             features::run_all(&sh)?;
             check::dependencies(&sh)?;
             check::capture_files(&sh)?;
+            bench::corpus_replay(None)?;
             wasm::check(&sh)?;
             fuzz::run(&sh, None, None)?;
             web::install(&sh)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,6 +105,7 @@ fn main() -> anyhow::Result<()> {
             features::run_all(&sh)?;
             check::dependencies(&sh)?;
             check::capture_files(&sh)?;
+            bench::corpus_fetch(&sh)?;
             bench::corpus_replay(None)?;
             wasm::check(&sh)?;
             fuzz::run(&sh, None, None)?;


### PR DESCRIPTION
Replay verified benchmark captures headlessly and compare strict qualifications without storing capture payloads.

Terminal lifecycle and canonical metadata-only gap fingerprints prevent incomplete or rerouted input from passing as complete. Aggregate CI fetches and verifies the corpus before replaying it.