### PR TITLE
ci: add CodSpeed benchmark reporting

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,11 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
-    inputs:
-      walltime_runner:
-        description: Approved Linux runner label for wall-time measurements
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -64,8 +59,8 @@ jobs:
 
   walltime:
     name: CodSpeed walltime
-    if: github.event_name == 'workflow_dispatch' && inputs.walltime_runner != '' && vars.CODSPEED_ENABLED == 'true'
-    runs-on: ${{ inputs.walltime_runner }}
+    if: github.event_name == 'workflow_dispatch' && vars.CODSPEED_ENABLED == 'true' && vars.CODSPEED_WALLTIME_RUNNER != ''
+    runs-on: ${{ vars.CODSPEED_WALLTIME_RUNNER }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Corpus cache
         uses: actions/cache@v5
         with:
-          path: ./dependencies/wireshark-rdp
+          path: ./bench-data/wireshark-rdp
           key: ${{ runner.os }}-codspeed-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
 
       - name: Fetch corpus
@@ -74,7 +74,7 @@ jobs:
       - name: Corpus cache
         uses: actions/cache@v5
         with:
-          path: ./dependencies/wireshark-rdp
+          path: ./bench-data/wireshark-rdp
           key: ${{ runner.os }}-codspeed-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
 
       - name: Fetch corpus

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,94 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      walltime_runner:
+        description: Approved Linux runner label for wall-time measurements
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+  CARGO_PROFILE_DEV_DEBUG: 0
+
+jobs:
+  simulation:
+    name: CodSpeed simulation
+    if: vars.CODSPEED_ENABLED == 'true'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: Corpus cache
+        uses: actions/cache@v5
+        with:
+          path: ./dependencies/wireshark-rdp
+          key: ${{ runner.os }}-codspeed-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
+
+      - name: Fetch corpus
+        run: cargo xtask bench corpus-fetch
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --version 5.0.1 --locked
+
+      - name: Build benchmarks
+        run: cargo codspeed build -p ironrdp-bench --bench bench --bench capture_replay --features codspeed --locked -m simulation
+
+      - name: Measure benchmarks
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: simulation
+          run: cargo codspeed run -p ironrdp-bench --bench bench --bench capture_replay -m simulation
+
+  walltime:
+    name: CodSpeed walltime
+    if: github.event_name == 'workflow_dispatch' && inputs.walltime_runner != '' && vars.CODSPEED_ENABLED == 'true'
+    runs-on: ${{ inputs.walltime_runner }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: Corpus cache
+        uses: actions/cache@v5
+        with:
+          path: ./dependencies/wireshark-rdp
+          key: ${{ runner.os }}-codspeed-corpus-${{ hashFiles('crates/ironrdp-bench/corpus.toml') }}
+
+      - name: Fetch corpus
+        run: cargo xtask bench corpus-fetch
+
+      - name: Build replay command
+        run: cargo build --release -p ironrdp-bench --bin capture-replay-bench --locked
+
+      - name: Measure replay commands
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: walltime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,10 +808,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.3",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -992,8 +1068,8 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
- "itertools",
+ "criterion-plot 0.8.2",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -1008,12 +1084,22 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2670,6 +2756,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "codspeed-criterion-compat",
  "criterion",
  "ironrdp",
  "ironrdp-capture-replay",
@@ -3568,6 +3655,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7660d28d24a831d690228a275d544654a30f3b167a8e491cf31af5fe5058b546"
 dependencies = [
  "untrusted",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -6322,6 +6429,16 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strck"

--- a/codspeed.yml
+++ b/codspeed.yml
@@ -1,0 +1,9 @@
+benchmarks:
+  - name: partial-replay/no-nla-accepted/strict-cli
+    exec: ./target/release/capture-replay-bench --capture no-nla-accepted
+
+  - name: partial-replay/no-nla-smartcard/strict-cli
+    exec: ./target/release/capture-replay-bench --capture no-nla-smartcard
+
+  - name: connector-replay/no-nla-accepted/strict-cli
+    exec: ./target/release/capture-replay-bench --connector no-nla-accepted

--- a/crates/ironrdp-bench/Cargo.toml
+++ b/crates/ironrdp-bench/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 default = ["qoi", "qoiz"]
 qoi = ["ironrdp/qoi"]
 qoiz = ["ironrdp/qoiz"]
+codspeed = ["dep:codspeed-criterion-compat"]
 
 [dependencies]
 anyhow = "1"
@@ -21,6 +22,7 @@ tokio = { version = "1", features = ["sync", "fs", "time", "io-util", "macros", 
 toml = "1.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
+codspeed-criterion-compat = { version = "5.0.1", package = "codspeed-criterion-compat", optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ironrdp-bench/Cargo.toml
+++ b/crates/ironrdp-bench/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", features = ["sync", "fs", "time", "io-util", "macros", 
 toml = "1.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
-codspeed-criterion-compat = { version = "5.0.1", package = "codspeed-criterion-compat", optional = true }
+codspeed-criterion-compat = { version = "5.0.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ironrdp-bench/benches/bench.rs
+++ b/crates/ironrdp-bench/benches/bench.rs
@@ -4,6 +4,8 @@
 use core::hint::black_box;
 use core::num::{NonZeroU16, NonZeroUsize};
 
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat as criterion;
 use criterion::{Criterion, criterion_group, criterion_main};
 use ironrdp_graphics::color_conversion::to_64x64_ycbcr_tile;
 use ironrdp_pdu::codecs::rfx;

--- a/crates/ironrdp-bench/benches/capture_replay.rs
+++ b/crates/ironrdp-bench/benches/capture_replay.rs
@@ -2,6 +2,8 @@
 
 use core::hint::black_box;
 
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat as criterion;
 use criterion::{Criterion, criterion_group, criterion_main};
 use ironrdp_bench::connector_replay::{ConnectorReplayId, ConnectorReplayWorkload};
 use ironrdp_bench::replay::{PartialReplayId, PartialReplayWorkload};

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -131,7 +131,9 @@ Compilation and corpus fetching occur before the CodSpeed action and are exclude
 
 The `CodSpeed` workflow runs simulation for pushes and pull requests only after maintainers set the `CODSPEED_ENABLED` repository variable to `true` and enable the repository in CodSpeed.
 It authenticates through GitHub OIDC and requires no repository secret for this public repository.
-The wall-time job is manual only and runs only when its dispatcher supplies a known, approved Linux runner label.
+The wall-time job is manual only and runs only when maintainers set the repository-controlled `CODSPEED_WALLTIME_RUNNER` variable to a known, approved Linux runner label.
+Dispatchers cannot select or override the wall-time runner.
+The job is skipped unless `CODSPEED_ENABLED` is `true` and `CODSPEED_WALLTIME_RUNNER` is nonempty.
 Use a dedicated stable runner for wall time; shared hosted runners are too noisy for performance decisions.
 The public capture cache uses the existing manifest-hash cache key and is digest-verified before use.
 Do not upload captures, decrypted payloads, TLS key material, screenshots, or generated replay output; CodSpeed receives measurements and may retain symbol-bearing profiles, not raw replay payloads.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -129,7 +129,7 @@ Hyperfine remains a separate local tool and does not import results into CodSpee
 Each command starts one release binary process, verifies and loads the selected cached capture, decrypts and prepares its replay state, and executes one strict replay.
 Compilation and corpus fetching occur before the CodSpeed action and are excluded from this measurement.
 
-The `CodSpeed` workflow runs simulation for pushes and pull requests only after maintainers set the `CODSPEED_ENABLED` repository variable to `true` and enable the repository in CodSpeed.
+The `CodSpeed` workflow runs simulation for pushes, pull requests, and manual dispatches after maintainers set the `CODSPEED_ENABLED` repository variable to `true` and enable the repository in CodSpeed.
 It authenticates through GitHub OIDC and requires no repository secret for this public repository.
 The wall-time job is manual only and runs only when maintainers set the repository-controlled `CODSPEED_WALLTIME_RUNNER` variable to a known, approved Linux runner label.
 Dispatchers cannot select or override the wall-time runner.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -98,5 +98,43 @@ hyperfine --warmup 1 '.\target\release\capture-replay-bench.exe --connector no-n
 ```
 Use `cargo xtask bench replay` to regression-test the complete pinned corpus, not to produce a single-capture timing score.
 
+## CodSpeed reporting
+
+CodSpeed simulation measures the three individually named encoder workloads (`rfx_enc_tile`, `rfx_enc`, and `to_ycbcr`) plus the two passive partial replays and one connector replay.
+The simulation job fetches and verifies the corpus before benchmark setup, then each replay target prepares and strictly preflights its selected capture outside Criterion's timed iterations.
+Every timed iteration starts with fresh replay, connector, and session state.
+CPU simulation models deterministic user-space work and is useful for focused processing regressions, not wall-clock completion, hardware-specific SIMD behavior, or native H.264 performance.
+
+The `codspeed` feature selects `codspeed-criterion-compat` only for the two benchmark targets.
+Regular `cargo bench` continues to use Criterion 0.8.
+Build the CodSpeed targets locally without uploading results with:
+
+```PowerShell
+cargo xtask bench corpus-fetch
+cargo install cargo-codspeed --version 5.0.1 --locked
+cargo codspeed build -p ironrdp-bench --bench bench --bench capture_replay --features codspeed --locked -m simulation
+```
+
+Run the ordinary local Criterion workloads or one whole-process measurement with:
+
+```PowerShell
+cargo bench -p ironrdp-bench --bench capture_replay -- 'partial-replay/no-nla-smartcard/processing' --exact
+cargo build --release -p ironrdp-bench --bin capture-replay-bench --locked
+hyperfine --warmup 1 '.\target\release\capture-replay-bench.exe --connector no-nla-accepted'
+```
+
+Hyperfine remains a separate local tool and does not import results into CodSpeed.
+
+`codspeed.yml` defines the independent wall-time command identities `exec_harness::partial-replay/no-nla-accepted/strict-cli`, `exec_harness::partial-replay/no-nla-smartcard/strict-cli`, and `exec_harness::connector-replay/no-nla-accepted/strict-cli`.
+Each command starts one release binary process, verifies and loads the selected cached capture, decrypts and prepares its replay state, and executes one strict replay.
+Compilation and corpus fetching occur before the CodSpeed action and are excluded from this measurement.
+
+The `CodSpeed` workflow runs simulation for pushes and pull requests only after maintainers set the `CODSPEED_ENABLED` repository variable to `true` and enable the repository in CodSpeed.
+It authenticates through GitHub OIDC and requires no repository secret for this public repository.
+The wall-time job is manual only and runs only when its dispatcher supplies a known, approved Linux runner label.
+Use a dedicated stable runner for wall time; shared hosted runners are too noisy for performance decisions.
+The public capture cache uses the existing manifest-hash cache key and is digest-verified before use.
+Do not upload captures, decrypted payloads, TLS key material, screenshots, or generated replay output; CodSpeed receives measurements and may retain symbol-bearing profiles, not raw replay payloads.
+
 To update the corpus, inspect the upstream capture inventory, revise the manifest revision, inventory, scenario intent metadata, replay expectations, and SHA-256 digests together, then run `cargo xtask bench corpus-fetch` followed by `cargo xtask bench replay`.
 Do not commit captures, TLS key material, decrypted payloads, screenshots, or generated output.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -115,13 +115,7 @@ cargo install cargo-codspeed --version 5.0.1 --locked
 cargo codspeed build -p ironrdp-bench --bench bench --bench capture_replay --features codspeed --locked -m simulation
 ```
 
-Run the ordinary local Criterion workloads or one whole-process measurement with:
-
-```PowerShell
-cargo bench -p ironrdp-bench --bench capture_replay -- 'partial-replay/no-nla-smartcard/processing' --exact
-cargo build --release -p ironrdp-bench --bin capture-replay-bench --locked
-hyperfine --warmup 1 '.\target\release\capture-replay-bench.exe --connector no-nla-accepted'
-```
+Use the local Criterion and Hyperfine commands above; replace `no-nla-accepted` with `no-nla-smartcard` in the Criterion filter to benchmark that passive replay.
 
 Hyperfine remains a separate local tool and does not import results into CodSpeed.
 
@@ -131,9 +125,8 @@ Compilation and corpus fetching occur before the CodSpeed action and are exclude
 
 The `CodSpeed` workflow runs simulation for pushes, pull requests, and manual dispatches after maintainers set the `CODSPEED_ENABLED` repository variable to `true` and enable the repository in CodSpeed.
 It authenticates through GitHub OIDC and requires no repository secret for this public repository.
-The wall-time job is manual only and runs only when maintainers set the repository-controlled `CODSPEED_WALLTIME_RUNNER` variable to a known, approved Linux runner label.
+The wall-time job is manual only and runs only when `CODSPEED_ENABLED` is `true` and maintainers set the repository-controlled `CODSPEED_WALLTIME_RUNNER` variable to a known, approved Linux runner label.
 Dispatchers cannot select or override the wall-time runner.
-The job is skipped unless `CODSPEED_ENABLED` is `true` and `CODSPEED_WALLTIME_RUNNER` is nonempty.
 Use a dedicated stable runner for wall time; shared hosted runners are too noisy for performance decisions.
 The public capture cache uses the existing manifest-hash cache key and is digest-verified before use.
 Do not upload captures, decrypted payloads, TLS key material, screenshots, or generated replay output; CodSpeed receives measurements and may retain symbol-bearing profiles, not raw replay payloads.


### PR DESCRIPTION
Report focused codec and replay workloads separately via CodSpeed while keeping ordinary Criterion and Hyperfine paths unchanged.

Gate service upload until the repository integration and an approved wall-time runner are configured.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>