### PR TITLE
ci(pr-automation): show automation mode in the run name

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -101,7 +101,7 @@ function readReviewWorkflow(githubDirectory = path.join(__dirname, "..")) {
     .replace(/\r\n/g, "\n");
 }
 
-test("workflow run names show the target pull request when known and identify the source branch otherwise", () => {
+test("workflow run names show the target pull request and automation mode when known, and identify the source branch otherwise", () => {
   const workflow = readWorkflow();
 
   assert.match(workflow, /github\.event\.pull_request\.number.*format\('PR #\{0\}'/);
@@ -110,6 +110,8 @@ test("workflow run names show the target pull request when known and identify th
   assert.match(workflow, /github\.event\.workflow_run\.pull_requests\[0\]\.number.*format\('PR #\{0\}'/);
   assert.match(workflow, /github\.event\.workflow_run\.head_branch.*github\.event\.workflow_run\.head_sha/);
   assert.match(workflow, /format\('run \{0\}',\s*github\.run_id\)/);
+  assert.match(workflow, /github\.event_name == 'workflow_run' \|\| github\.event_name == 'repository_dispatch'/);
+  assert.match(workflow, /github\.event_name == 'workflow_dispatch' && inputs\.review\)\) && 'review' \|\| 'classify'/);
   assert.doesNotMatch(workflow, /format\('PR #\{0\}',\s*github\.run_id\)/);
   assert.doesNotMatch(workflow, /PR #\$\{\{.*github\.run_id.*\}\}/s);
 });

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -107,6 +107,18 @@ function runNameExpression(workflow = readWorkflow()) {
   return match[1];
 }
 
+// Translates the context lookups, equality, and format() calls the run-name expression uses into
+// JavaScript, so the workflow expression can be evaluated against synthetic event payloads.
+function evaluateRunName(expression, { github = {}, inputs = {} } = {}) {
+  const body = expression.trim().replace(/^\$\{\{/, "").replace(/\}\}$/, "")
+    .replace(/\b(?:github|inputs)(?:\.[A-Za-z0-9_-]+|\[\d+\])+/g, (path) => `read(${JSON.stringify(path)})`)
+    .replace(/==/g, "===");
+  const read = (path) => path.split(/[.[\]]+/).filter(Boolean)
+    .reduce((value, key) => (value == null ? null : value[key]), { github, inputs }) ?? null;
+  const format = (template, ...args) => template.replace(/\{(\d+)\}/g, (_, index) => args[Number(index)]);
+  return new Function("read", "format", `return (${body});`)(read, format);
+}
+
 test("workflow run names show the target pull request and automation mode when known, and identify the source branch otherwise", () => {
   const runName = runNameExpression();
 
@@ -117,10 +129,34 @@ test("workflow run names show the target pull request and automation mode when k
   assert.match(runName, /github\.event\.workflow_run\.head_branch.*github\.event\.workflow_run\.head_sha/);
   assert.match(runName, /format\('run \{0\}',\s*github\.run_id\)/);
   assert.match(runName, /format\('\{0\} \(\{1\}\)',/);
-  assert.match(runName, /github\.event_name == 'workflow_run' \|\| github\.event_name == 'repository_dispatch'/);
-  assert.match(runName, /github\.event_name == 'workflow_dispatch' && inputs\.review\)\) && 'review' \|\| 'classify'/);
   assert.doesNotMatch(runName, /format\('PR #\{0\}',\s*github\.run_id\)/);
   assert.doesNotMatch(runName, /PR #\$\{\{.*github\.run_id.*\}\}/s);
+});
+
+test("the run name mode follows the route the triggering event takes", () => {
+  const expression = runNameExpression();
+  const runName = (github, inputs) => evaluateRunName(expression, { github: { run_id: 7, ...github }, inputs });
+
+  assert.equal(runName({ event_name: "pull_request_target", event: { pull_request: { number: 12 } } }),
+    "PR #12 (classify)");
+  assert.equal(runName({
+    event_name: "workflow_run",
+    event: { workflow_run: { pull_requests: [{ number: 34 }], head_branch: "topic", head_sha: "a".repeat(40) } },
+  }), "PR #34 (review)");
+  assert.equal(runName({ event_name: "repository_dispatch", event: { client_payload: { pr_number: 56 } } }),
+    "PR #56 (review)");
+
+  // workflow_dispatch carries `review` as a typed boolean, so both values must pick their own mode.
+  assert.equal(runName({ event_name: "workflow_dispatch", event: {} }, { "pr-number": 78, review: false }),
+    "PR #78 (classify)");
+  assert.equal(runName({ event_name: "workflow_dispatch", event: {} }, { "pr-number": 78, review: true }),
+    "PR #78 (review)");
+
+  // A CI completion that names no pull request still identifies its source, and stays a review run.
+  assert.equal(runName({
+    event_name: "workflow_run",
+    event: { workflow_run: { pull_requests: [], head_branch: "topic", head_sha: "b".repeat(40) } },
+  }), `topic @ ${"b".repeat(40)} (review)`);
 });
 
 function resolveReviewScript(workflow = readWorkflow()) {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -101,19 +101,26 @@ function readReviewWorkflow(githubDirectory = path.join(__dirname, "..")) {
     .replace(/\r\n/g, "\n");
 }
 
-test("workflow run names show the target pull request and automation mode when known, and identify the source branch otherwise", () => {
-  const workflow = readWorkflow();
+function runNameExpression(workflow = readWorkflow()) {
+  const match = workflow.match(/\nrun-name: >-\n((?: {2}\S.*\n| {3,}.*\n)+)/);
+  assert.ok(match, "run-name expression is missing");
+  return match[1];
+}
 
-  assert.match(workflow, /github\.event\.pull_request\.number.*format\('PR #\{0\}'/);
-  assert.match(workflow, /inputs\.pr-number\s*&&\s*format\('PR #\{0\}'/);
-  assert.match(workflow, /github\.event\.client_payload\.pr_number\s*&&\s*format\('PR #\{0\}'/);
-  assert.match(workflow, /github\.event\.workflow_run\.pull_requests\[0\]\.number.*format\('PR #\{0\}'/);
-  assert.match(workflow, /github\.event\.workflow_run\.head_branch.*github\.event\.workflow_run\.head_sha/);
-  assert.match(workflow, /format\('run \{0\}',\s*github\.run_id\)/);
-  assert.match(workflow, /github\.event_name == 'workflow_run' \|\| github\.event_name == 'repository_dispatch'/);
-  assert.match(workflow, /github\.event_name == 'workflow_dispatch' && inputs\.review\)\) && 'review' \|\| 'classify'/);
-  assert.doesNotMatch(workflow, /format\('PR #\{0\}',\s*github\.run_id\)/);
-  assert.doesNotMatch(workflow, /PR #\$\{\{.*github\.run_id.*\}\}/s);
+test("workflow run names show the target pull request and automation mode when known, and identify the source branch otherwise", () => {
+  const runName = runNameExpression();
+
+  assert.match(runName, /github\.event\.pull_request\.number.*format\('PR #\{0\}'/);
+  assert.match(runName, /inputs\.pr-number\s*&&\s*format\('PR #\{0\}'/);
+  assert.match(runName, /github\.event\.client_payload\.pr_number\s*&&\s*format\('PR #\{0\}'/);
+  assert.match(runName, /github\.event\.workflow_run\.pull_requests\[0\]\.number.*format\('PR #\{0\}'/);
+  assert.match(runName, /github\.event\.workflow_run\.head_branch.*github\.event\.workflow_run\.head_sha/);
+  assert.match(runName, /format\('run \{0\}',\s*github\.run_id\)/);
+  assert.match(runName, /format\('\{0\} \(\{1\}\)',/);
+  assert.match(runName, /github\.event_name == 'workflow_run' \|\| github\.event_name == 'repository_dispatch'/);
+  assert.match(runName, /github\.event_name == 'workflow_dispatch' && inputs\.review\)\) && 'review' \|\| 'classify'/);
+  assert.doesNotMatch(runName, /format\('PR #\{0\}',\s*github\.run_id\)/);
+  assert.doesNotMatch(runName, /PR #\$\{\{.*github\.run_id.*\}\}/s);
 });
 
 function resolveReviewScript(workflow = readWorkflow()) {

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,13 +1,17 @@
 name: Pull request automation
 # Prefer an exact PR number when the event carries one; otherwise identify the CI head that triggered the workflow.
+# The trailing mode mirrors the route the triggering event takes, so classifier and reviewer runs are told apart at a glance.
 run-name: >-
   ${{
-    github.event.pull_request.number && format('PR #{0}', github.event.pull_request.number)
-    || inputs.pr-number && format('PR #{0}', inputs.pr-number)
-    || github.event.client_payload.pr_number && format('PR #{0}', github.event.client_payload.pr_number)
-    || github.event.workflow_run.pull_requests[0].number && format('PR #{0}', github.event.workflow_run.pull_requests[0].number)
-    || github.event.workflow_run.head_branch && format('{0} @ {1}', github.event.workflow_run.head_branch, github.event.workflow_run.head_sha)
-    || format('run {0}', github.run_id)
+    format('{0} ({1})',
+      github.event.pull_request.number && format('PR #{0}', github.event.pull_request.number)
+      || inputs.pr-number && format('PR #{0}', inputs.pr-number)
+      || github.event.client_payload.pr_number && format('PR #{0}', github.event.client_payload.pr_number)
+      || github.event.workflow_run.pull_requests[0].number && format('PR #{0}', github.event.workflow_run.pull_requests[0].number)
+      || github.event.workflow_run.head_branch && format('{0} @ {1}', github.event.workflow_run.head_branch, github.event.workflow_run.head_sha)
+      || format('run {0}', github.run_id),
+      (github.event_name == 'workflow_run' || github.event_name == 'repository_dispatch'
+        || (github.event_name == 'workflow_dispatch' && inputs.review)) && 'review' || 'classify')
   }}
 
 on:


### PR DESCRIPTION
The PR automation workflow serves two very different routes, classification and review, but its run name only carried the pull request number. In the Actions list every run looked like `PR #123`, so there was no way to tell a classifier run from a reviewer run without opening it.

The run name now appends the mode, for example `PR #123 (classify)` or `PR #123 (review)`.

The mode is derived from the triggering event rather than from `resolve-pr`'s `route` output, because `run-name` is evaluated before any job runs and cannot read job outputs. The mapping mirrors `routeFor` in `.github/pr-automation/resolve-pr.js`:

- `review` for CI `workflow_run`, `repository_dispatch`, and `workflow_dispatch` with `review: true`
- `classify` for `pull_request_target` and `workflow_dispatch` with `review: false`

One known imprecision: adding the `ai-review/allow-oversized` label arrives as a `pull_request_target` event, so it is labeled `classify`. That is accurate for the route it takes, since it restarts classification with a larger evidence cap, even though the maintainer's intent is to reach a review.

The existing run-name test in `.github/pr-automation/automation.test.js` was extended to cover the new suffix. All 122 tests in that suite pass.