### PR TITLE
ci(pr-automation): hand off after a clean review

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -202,6 +202,10 @@ After the first review, a later push starts the second review when CI succeeds f
 Duplicates at confidence 0.85 or greater, legitimacy triage, and `ai-reviewed/2` block automatic review.
 Unavailable or invalid classification fails closed to maintainer review.
 
+`maintainer-required` marks a pull request whose next step belongs to a maintainer.
+A review applies it when it reports no findings and withdraws it when it reports findings.
+Once `ai-reviewed/2` is set, classification applies it on the next push, because automatic review has stopped.
+
 Bot-authored pull requests do not run automatic routes or label reconciliation.
 Force mode can override policy gates for an open pull request at its current head after a trusted, valid classification for that exact head selects its reviewers.
 Force mode never bypasses classification validity, evidence retrieval, output validation, filesystem restrictions, protocol citation validation, or stale-head checks.

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1780,6 +1780,35 @@ test("review transition is terminal-safe and preserves human triage on no findin
   }).failed, true);
 });
 
+test("a review with findings leaves the next step with the contributor", () => {
+  const gate = {
+    ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true,
+    risk: "high", protocolRelated: false, specialistReviewers: ["skeptical"],
+    secondReviewEligible: true,
+  };
+  const second = resolveReviewState({
+    expectedSha: SHA, labels: ["ai-reviewed/1", "risk/high", "maintainer-required"],
+    reviewer: review(), gate, contributor: { status: "eligible" },
+  });
+  assert.deepEqual(second.labelSets[0].desired, ["ai-reviewed/2"]);
+  assert.deepEqual(second.addLabels, []);
+  assert.deepEqual(second.removeLabels, ["maintainer-required"]);
+
+  // Automatic review is exhausted at `ai-reviewed/2`, so classification owns the later handoff.
+  const nextPush = resolveClassificationState({
+    expectedSha: OTHER_SHA,
+    labels: ["ai-reviewed/2", "risk/high"],
+    deterministic: {
+      ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S",
+      sizeLabels: ["size/S"], firstTime: false,
+    },
+    classifier: classifier({ head_sha: OTHER_SHA }),
+    semver: { head_sha: OTHER_SHA, status: "not-suspected" },
+  });
+  assert.deepEqual(nextPush.addLabels, ["maintainer-required"]);
+  assert.deepEqual(nextPush.removeLabels, []);
+});
+
 test("review blockers distinguish gate and contributor history failures", () => {
   const args = {
     expectedSha: SHA, labels: ["risk/high"], reviewer: review(),

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -341,8 +341,10 @@ function resolveReviewState({
     `${forced ? `:force:${reviewMarkerId}` : ""} -->`;
   return {
     ok: true, mode: "review", expectedSha, labelSets: [{ owned: AI_COUNTS, desired: [nextCount] }],
-    addLabels: nextCount === "ai-reviewed/2" || !hasFindings ? ["maintainer-required"] : [],
-    removeLabels: nextCount === "ai-reviewed/1" && hasFindings ? ["maintainer-required"] : [],
+    // Reported findings leave the next step with the contributor, even at `ai-reviewed/2`. Automatic
+    // review is exhausted there, so classification hands the pull request over on their next push.
+    addLabels: hasFindings ? [] : ["maintainer-required"],
+    removeLabels: hasFindings ? ["maintainer-required"] : [],
     comments: [{
       kind: "review", marker: reviewMarker, review: reviewerResult.value,
       reducedCoverage: Array.isArray(reducedCoverage) ? reducedCoverage : [],

--- a/.github/workflows/pr-automation.intent.md
+++ b/.github/workflows/pr-automation.intent.md
@@ -71,7 +71,9 @@ Run the second review after a later push reaches green exact-head CI.
 At `ai-reviewed/2`, the review pipeline stops; classification and its labels keep updating.
 
 Use `maintainer-required` only when maintainer action is the next step.
-On the normal review path, apply it only after exact-head CI succeeds and an automated review reports no findings or reaches `ai-reviewed/2`.
+On the normal review path, apply it only after exact-head CI succeeds and an automated review reports no findings.
+When a review reports findings, the next step belongs to the contributor, even at `ai-reviewed/2`.
+Once `ai-reviewed/2` is set, classification applies the label on the next push, when the outstanding findings are presumed addressed.
 Apply it earlier only when automation stops and needs maintainer intervention.
 
 `OWNER` and `MEMBER` authors are always eligible.


### PR DESCRIPTION
`maintainer-required` was applied as soon as the second automated review published, even when that review reported findings. The pull request then looked ready for a maintainer while the next step still belonged to the contributor.

The label now follows the review outcome alone: a review reporting no findings hands the pull request over, and a review reporting findings withdraws it. Automatic review stops at `ai-reviewed/2`, so classification performs the handoff on the contributor's next push, once the outstanding findings are presumed addressed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>