### PR TITLE
ci(pr-automation): link resolved PR in run summary

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -234,6 +234,7 @@ SHA-bound GitHub checks carry classification and review state between permission
 Attempt-scoped workflow artifacts carry evidence and validated results between review-pipeline jobs and across recovery attempts.
 Only the final writer mutates pull request state, and it serializes those mutations per pull request.
 Model-execution jobs have read-only or empty permissions.
+The run summary links the pull request the run resolved.
 
 Four static classifier lanes allow at most four classifier jobs to invoke Helmcode at once.
 Seven static caller-job lanes lock each reusable review pipeline from evidence through its result.

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -114,6 +114,48 @@ test("workflow run names show the target pull request when known and identify th
   assert.doesNotMatch(workflow, /PR #\$\{\{.*github\.run_id.*\}\}/s);
 });
 
+function resolvePrScript(workflow = readWorkflow()) {
+  const job = workflowJob(workflow, "resolve-pr");
+  const match = job.match(/script: \|\n((?: {12}.*\n?)+)/);
+  assert.ok(match, "resolve-pr script is missing");
+  return match[1].replace(/^ {12}/gm, "");
+}
+
+test("the run summary links the resolved pull request", async () => {
+  const workflow = readWorkflow();
+  assert.match(workflowJob(workflow, "resolve-pr"),
+    /PULL_REQUEST_URL_BASE: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/pull/);
+
+  const lines = [];
+  const core = {
+    setOutput: () => {},
+    info: () => {},
+    warning: () => {},
+    summary: {
+      addRaw: (value) => { lines.push(value); return core.summary; },
+      write: async () => {},
+    },
+  };
+  const rootRequire = createRequire(path.join(__dirname, "..", "..", "labeler.js"));
+  const run = async (result) => {
+    lines.length = 0;
+    const requireWithResolve = (name) => name === "./.github/pr-automation/resolve-pr"
+      ? { resolvePr: async () => result }
+      : rootRequire(name);
+    const process = { env: { PULL_REQUEST_URL_BASE: "https://github.example/Devolutions/IronRDP/pull" } };
+    await new AsyncFunction("core", "github", "context", "require", "process", resolvePrScript(workflow))(
+      core, {}, { payload: {} }, requireWithResolve, process,
+    );
+    return lines.join("\n");
+  };
+
+  assert.equal(
+    await run({ ok: true, route: "ci", prNumber: 7, headSha: SHA, baseSha: OTHER_SHA }),
+    "Resolved pull request [#7](https://github.example/Devolutions/IronRDP/pull/7).",
+  );
+  assert.equal(await run({ ok: false, route: "ci", reason: "pull request is draft" }), "");
+});
+
 function resolveReviewScript(workflow = readWorkflow()) {
   const job = workflowJob(workflow, "resolve-review-state");
   const match = job.match(/script: \|\n((?: {13}.*\n?)+)/);

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -127,18 +127,20 @@ test("the run summary links the resolved pull request", async () => {
     /PULL_REQUEST_URL_BASE: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/pull/);
 
   const lines = [];
+  let writes = 0;
   const core = {
     setOutput: () => {},
     info: () => {},
     warning: () => {},
     summary: {
       addRaw: (value) => { lines.push(value); return core.summary; },
-      write: async () => {},
+      write: async () => { writes += 1; },
     },
   };
   const rootRequire = createRequire(path.join(__dirname, "..", "..", "labeler.js"));
   const run = async (result) => {
     lines.length = 0;
+    writes = 0;
     const requireWithResolve = (name) => name === "./.github/pr-automation/resolve-pr"
       ? { resolvePr: async () => result }
       : rootRequire(name);
@@ -146,14 +148,15 @@ test("the run summary links the resolved pull request", async () => {
     await new AsyncFunction("core", "github", "context", "require", "process", resolvePrScript(workflow))(
       core, {}, { payload: {} }, requireWithResolve, process,
     );
-    return lines.join("\n");
+    return { summary: lines.join("\n"), writes };
   };
 
-  assert.equal(
-    await run({ ok: true, route: "ci", prNumber: 7, headSha: SHA, baseSha: OTHER_SHA }),
-    "Resolved pull request [#7](https://github.example/Devolutions/IronRDP/pull/7).",
-  );
-  assert.equal(await run({ ok: false, route: "ci", reason: "pull request is draft" }), "");
+  assert.deepEqual(await run({ ok: true, route: "ci", prNumber: 7, headSha: SHA, baseSha: OTHER_SHA }), {
+    summary: "Resolved pull request [#7](https://github.example/Devolutions/IronRDP/pull/7).",
+    writes: 1,
+  });
+  assert.deepEqual(await run({ ok: false, route: "ci", reason: "pull request is draft" }),
+    { summary: "", writes: 0 });
 });
 
 function resolveReviewScript(workflow = readWorkflow()) {

--- a/.github/workflows/pr-automation.intent.md
+++ b/.github/workflows/pr-automation.intent.md
@@ -94,3 +94,7 @@ Adding `ai-review/allow-oversized` forces reclassification and may dispatch on t
 Unrelated label events and repeated non-explicit unchanged classifications must not dispatch.
 
 Force mode bypasses policy gates but not classification prerequisites, evidence, validation, filesystem, citation, publication, or stale-head safeguards.
+
+## Run summary
+
+Link the resolved pull request from the workflow run summary, on every route.

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -79,6 +79,8 @@ jobs:
 
       - id: resolve
         uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_URL_BASE: ${{ github.server_url }}/${{ github.repository }}/pull
         with:
           script: |
             const { resolvePr } = require("./.github/pr-automation/resolve-pr");
@@ -106,6 +108,12 @@ jobs:
             core.setOutput("reviewer-pipeline-lane", result.prNumber ? (Number(result.prNumber) % 7) + 1 : "");
             core.setOutput("evidence-max-bytes", result.evidenceMaxBytes ?? "");
             core.info(JSON.stringify({ event: "pr-automation.resolve-pr", decision: result }));
+            if (result.prNumber) {
+              const prUrl = `${process.env.PULL_REQUEST_URL_BASE}/${result.prNumber}`;
+              await core.summary
+                .addRaw(`Resolved pull request [#${result.prNumber}](${prUrl}).`, true)
+                .write();
+            }
             if (!result.ok) core.warning(`PR automation did not start: ${result.reason}`);
 
   classification-gate:


### PR DESCRIPTION
The run title already names the pull request an automation run targets, but it is plain text. Getting from a workflow run back to the pull request means looking the number up by hand, which is annoying when triaging runs from the Actions tab.

The `resolve-pr` job now writes the link into the run summary as soon as it resolves a pull request, so it shows up at the top of the run summary page on every route (classification, CI completion, dispatch, and review). The URL base comes from a `PULL_REQUEST_URL_BASE` env value built from `github.server_url` and `github.repository`, matching how `SUMMARY_URL` is already assembled elsewhere in the workflow. Runs that resolve no pull request write nothing.

Also documented in `PR_AUTOMATION.md` and the workflow intent file, and covered by a test that executes the extracted job script and asserts both the rendered link and the no-PR case.