### PR TITLE
feat(server): add bandwidth-measure generation counter

### DIFF
--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -56,6 +56,7 @@ pub struct BuilderDone {
     autodetect_rtt: Option<Arc<AtomicU32>>,
     autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
     autodetect_bandwidth: Option<Arc<AtomicU32>>,
+    autodetect_bandwidth_generation: Option<Arc<AtomicU32>>,
     honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
     connection_policy: ConnectionPolicy,
@@ -168,6 +169,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 autodetect_rtt: None,
                 autodetect_baseline_rtt: None,
                 autodetect_bandwidth: None,
+                autodetect_bandwidth_generation: None,
                 honor_client_desktop_size: None,
                 connection_policy: ConnectionPolicy::default(),
                 auto_reconnect_cookie: None,
@@ -201,6 +203,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 autodetect_rtt: None,
                 autodetect_baseline_rtt: None,
                 autodetect_bandwidth: None,
+                autodetect_bandwidth_generation: None,
                 honor_client_desktop_size: None,
                 connection_policy: ConnectionPolicy::default(),
                 auto_reconnect_cookie: None,
@@ -406,6 +409,18 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Inject a shared handle that increments every time a Bandwidth Measure
+    /// transaction completes, whether or not it produced a usable figure.
+    /// Pairs with [`Self::with_autodetect_bandwidth_handle`]: the bandwidth
+    /// figure alone repeats too often to tell a fresh measurement window
+    /// apart from a stale one. When not called, the server allocates its own
+    /// (still readable via
+    /// [`RdpServer::autodetect_bandwidth_generation_handle`]).
+    pub fn with_autodetect_bandwidth_generation_handle(mut self, handle: Arc<AtomicU32>) -> Self {
+        self.state.autodetect_bandwidth_generation = Some(handle);
+        self
+    }
+
     /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
@@ -480,6 +495,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.autodetect_rtt,
             self.state.autodetect_baseline_rtt,
             self.state.autodetect_bandwidth,
+            self.state.autodetect_bandwidth_generation,
         );
         server.set_credential_validator(self.state.credential_validator);
         server.set_auto_reconnect_cookie(self.state.auto_reconnect_cookie);

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -3793,8 +3793,24 @@ impl RdpServer {
                         }
                         AutoDetectOutcome::Bandwidth(Some(bandwidth_kbps)) => {
                             self.autodetect_bandwidth.store(bandwidth_kbps, Ordering::Relaxed);
+                            // Logging the raw inputs, not just the computed figure: a
+                            // damage-driven video source makes any single measurement
+                            // window's byte count wildly bimodal (near-idle vs. a real
+                            // frame landing in it), so bandwidth_kbps alone reads as
+                            // noise without time_delta_ms/byte_count alongside it to
+                            // show why.
+                            let rdp::autodetect::AutoDetectResponse::BandwidthMeasureResults {
+                                time_delta_ms,
+                                byte_count,
+                                ..
+                            } = &pdu.response
+                            else {
+                                unreachable!("computed_bandwidth_kbps() only returns Some for this variant")
+                            };
                             debug!(
                                 bandwidth_kbps,
+                                time_delta_ms,
+                                byte_count,
                                 seq = pdu.response.sequence_number(),
                                 "Bandwidth measured"
                             );

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -739,6 +739,16 @@ pub struct RdpServer {
     /// alone does not fix.
     autodetect_bandwidth: Arc<AtomicU32>,
 
+    /// Increments every time a Bandwidth Measure transaction completes
+    /// (whether or not it produced a usable figure — see
+    /// [`Self::autodetect_bandwidth`]'s doc comment on the None case).
+    /// [`Self::autodetect_bandwidth`] alone cannot tell an embedder "a new
+    /// window just closed" apart from "the value happens to repeat" — this
+    /// value repeats often (a quiet link reads the same low figure for
+    /// several consecutive windows), so diffing it is not a valid freshness
+    /// signal. Exposed via [`Self::autodetect_bandwidth_generation_handle`].
+    autodetect_bandwidth_generation: Arc<AtomicU32>,
+
     /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server validates a returning
     /// `ARC_CS_PRIVATE_PACKET`, replaces its random after every connection, and
@@ -1363,6 +1373,7 @@ impl RdpServer {
         autodetect_rtt: Option<Arc<AtomicU32>>,
         autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
         autodetect_bandwidth: Option<Arc<AtomicU32>>,
+        autodetect_bandwidth_generation: Option<Arc<AtomicU32>>,
     ) -> Self {
         let (ev_sender, ev_receiver) = ServerEvent::create_channel();
         if let Some(cliprdr) = cliprdr_factory.as_mut() {
@@ -1425,6 +1436,8 @@ impl RdpServer {
                 handle.store(u32::MAX, Ordering::Relaxed);
                 handle
             },
+            autodetect_bandwidth_generation: autodetect_bandwidth_generation
+                .unwrap_or_else(|| Arc::new(AtomicU32::new(0))),
             auto_reconnect_cookie: None,
             previous_auto_reconnect_cookie: None,
             auto_reconnect_sent: false,
@@ -1765,6 +1778,18 @@ impl RdpServer {
     /// [`RdpServerBuilder::with_autodetect_bandwidth_handle`](crate::RdpServerBuilder::with_autodetect_bandwidth_handle).
     pub fn autodetect_bandwidth_handle(&self) -> Arc<AtomicU32> {
         Arc::clone(&self.autodetect_bandwidth)
+    }
+
+    /// Returns a handle that increments every time a Bandwidth Measure
+    /// transaction completes, whether or not it produced a usable figure.
+    /// Pairs with [`Self::autodetect_bandwidth_handle`]: read this first to
+    /// detect a fresh measurement window (the bandwidth figure itself
+    /// repeats too often to be its own freshness signal), then read the
+    /// bandwidth handle for the value. Inject a shared instance at
+    /// construction with
+    /// [`RdpServerBuilder::with_autodetect_bandwidth_generation_handle`](crate::RdpServerBuilder::with_autodetect_bandwidth_generation_handle).
+    pub fn autodetect_bandwidth_generation_handle(&self) -> Arc<AtomicU32> {
+        Arc::clone(&self.autodetect_bandwidth_generation)
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -3793,6 +3818,7 @@ impl RdpServer {
                         }
                         AutoDetectOutcome::Bandwidth(Some(bandwidth_kbps)) => {
                             self.autodetect_bandwidth.store(bandwidth_kbps, Ordering::Relaxed);
+                            self.autodetect_bandwidth_generation.fetch_add(1, Ordering::Relaxed);
                             // Logging the raw inputs, not just the computed figure: a
                             // damage-driven video source makes any single measurement
                             // window's byte count wildly bimodal (near-idle vs. a real
@@ -3820,6 +3846,7 @@ impl RdpServer {
                             // reporting a stale one (see `handle_response`'s doc comment);
                             // mirror that here so the exposed handle does not disagree.
                             self.autodetect_bandwidth.store(u32::MAX, Ordering::Relaxed);
+                            self.autodetect_bandwidth_generation.fetch_add(1, Ordering::Relaxed);
                             trace!(
                                 seq = pdu.response.sequence_number(),
                                 "Bandwidth measurement completed without a usable figure"


### PR DESCRIPTION
## Summary

- `autodetect_bandwidth_handle()` (#1734) exposes the latest Bandwidth
  Measure figure, but a consumer doing its own smoothing/filtering on
  top of it (e.g. rejecting noisy low samples unless real demand
  existed) needs to know when a *new* measurement window has closed,
  not just what the figure currently reads. The figure itself is a bad
  freshness signal: a quiet link reads the same low value for several
  consecutive windows in a row, so diffing it cannot tell "fresh
  window, same result" apart from "stale, no new window yet".
- Adds `autodetect_bandwidth_generation`, mirroring
  `autodetect_bandwidth`'s exact shape: an `Arc<AtomicU32>` field,
  `autodetect_bandwidth_generation_handle()` accessor, and
  `with_autodetect_bandwidth_generation_handle()` builder method. It
  increments on every completed Bandwidth Measure transaction,
  successful or not — a completed-but-unusable window still needs to
  advance the generation so a consumer's own stale-demand bookkeeping
  gets cleared instead of carrying over into the next window.
- Along the way, upgrades the existing bandwidth-measured debug log
  from just the computed `bandwidth_kbps` to also include the
  transaction's raw `byte_count`/`time_delta_ms` inputs. Useful on its
  own for anyone diagnosing why the figure looks noisy against a
  bursty traffic source (as this crate's own damage-driven server
  usage does): the raw inputs make it immediately visible whether a
  low reading came from a genuinely idle window or a short one that
  happened to close early.

## Validation

`cargo xtask check fmt/lints/typos` all pass; `cargo test -p
ironrdp-server --features egfx,helper` green (5 passed, 1 ignored,
plus doctests).

## Notes

No public API break: both changes are purely additive to
`RdpServerBuilder` and `RdpServer`.